### PR TITLE
commerce: enable passing price id

### DIFF
--- a/packages/commerce/src/hooks/use-commerce-machine.tsx
+++ b/packages/commerce/src/hooks/use-commerce-machine.tsx
@@ -7,33 +7,39 @@ import commerceMachine from '../machines/commerce'
 type CreateCommerceMachineProps = {
   sellable: SellableResource
   upgradeFromSellable?: SellableResource
+  stripePriceId?: string
 }
 
 const createCommerceMachine = ({
   sellable,
   upgradeFromSellable,
+  stripePriceId,
 }: CreateCommerceMachineProps) =>
   commerceMachine.withContext({
     sellable,
     upgradeFromSellable,
     bulk: false,
     quantity: 1,
+    stripePriceId,
   })
 
 type UseCommerceMachineProps = {
   sellable: SellableResource
   upgradeFromSellable?: SellableResource
+  stripePriceId?: string
 }
 
 export const useCommerceMachine: any = ({
   sellable,
   upgradeFromSellable,
+  stripePriceId,
 }: UseCommerceMachineProps) => {
   const sellableSlug = get(sellable, 'slug')
   const commerceMachine = React.useMemo(() => {
     return createCommerceMachine({
       sellable,
       upgradeFromSellable,
+      stripePriceId,
     })
   }, [sellableSlug, upgradeFromSellable])
 


### PR DESCRIPTION
this enables passing `stripePriceId` to commerce machine like so:
```
  const [state, send] = useCommerceMachine({
    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_PRICE_ID,
  })
```

<img src="https://p-zmfjnlq.b3.n0.cdn.getcloudapp.com/items/jku4XeO5/1326bb02-245b-4338-9537-e478910f8874.jpg?source=viewer&v=d82fc48dd314edbc361a85e3f358b4ea" width="300" alt="screenshot">

<img src="https://media.giphy.com/media/1BeZUvPQyw0KroGIxm/giphy-downsized.gif?cid=ecf05e47rwrd1fqxicviy5jga45sz8uq4llwp35pn4ehpa4i&rid=giphy-downsized.gif&ct=g" width="300" alt="gif">