### PR TITLE
Add C4H google-verification meta tag

### DIFF
--- a/apps/compilersforhumans/src/layouts/index.tsx
+++ b/apps/compilersforhumans/src/layouts/index.tsx
@@ -36,6 +36,12 @@ const Layout: FunctionComponent<LayoutProps> = ({
         }}
         canonical={url}
         noindex={noIndex}
+        additionalMetaTags={[
+          {
+            name: 'google-site-verification',
+            content: 'NYJ_fuwXe8EEG56oW0-ty0TO5k3MWz_VA9m_vOI-7cw',
+          },
+        ]}
       />
       <div className={`flex flex-col min-h-screen ${className}`}>
         <Navigation />


### PR DESCRIPTION
Adds Google Verification meta tag to the Next SEO component for domain email creation per [Google's Directions](https://support.google.com/webmasters/answer/9008080?hl=en#zippy=%2Chtml-tag) from [this question in the Next.js repo](https://github.com/vercel/next.js/discussions/14806).

![](https://media4.giphy.com/media/llQMjpdCwjdrVGzz1d/giphy.gif)