### PR TITLE
player: auto hide controls in fullscreen

### DIFF
--- a/packages/player/src/components/controls/side-panel-toggle-control.tsx
+++ b/packages/player/src/components/controls/side-panel-toggle-control.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import {useVideo} from '../../context/video-context'
 import {useSelector} from '@xstate/react'
 import {selectWithSidePanel} from '../../selectors'
+import {savePlayerPrefs} from '../../hooks/use-player-prefs'
 
 type SidePanelToggleProps = {
   className?: string
@@ -13,8 +14,10 @@ export const SidePanelToggleControl: React.FC<SidePanelToggleProps> = ({
 }) => {
   const videoService = useVideo()
   const withSidePanel = useSelector(videoService, selectWithSidePanel)
+
   function handleClick() {
     videoService.send({type: 'TOGGLE_SIDE_PANEL'})
+    savePlayerPrefs({theater: !withSidePanel})
   }
   return (
     <button

--- a/packages/player/src/components/player.tsx
+++ b/packages/player/src/components/player.tsx
@@ -4,7 +4,7 @@ import {isEmpty} from 'lodash'
 import {useSelector} from '@xstate/react'
 import {useVideo} from '../context/video-context'
 import {useMetadataCues} from '../hooks/use-metadata-cues'
-import {useFullscreenControls} from '../hooks/use-fullscreen-controls'
+import {useAutoHideControls} from '../hooks/use-auto-hide-controls'
 import * as browser from '../utils/browser'
 
 import {Video} from './video'
@@ -92,7 +92,7 @@ export const Player: React.FC<PlayerProps> = (props) => {
   const cues = useMetadataCues()
 
   const {controlsHidden, setControlsHidden, setControlsHovered} =
-    useFullscreenControls()
+    useAutoHideControls()
 
   const handleActivity = () => {
     videoService.send('ACTIVITY')

--- a/packages/player/src/components/player.tsx
+++ b/packages/player/src/components/player.tsx
@@ -4,6 +4,7 @@ import {isEmpty} from 'lodash'
 import {useSelector} from '@xstate/react'
 import {useVideo} from '../context/video-context'
 import {useMetadataCues} from '../hooks/use-metadata-cues'
+import {useFullscreenControls} from '../hooks/use-fullscreen-controls'
 import * as browser from '../utils/browser'
 
 import {Video} from './video'
@@ -90,7 +91,13 @@ export const Player: React.FC<PlayerProps> = (props) => {
   } = usePlayerState()
   const cues = useMetadataCues()
 
-  const handleActivity = () => videoService.send('ACTIVITY')
+  const {controlsHidden, setControlsHidden, setControlsHovered} =
+    useFullscreenControls()
+
+  const handleActivity = () => {
+    videoService.send('ACTIVITY')
+    isFullscreen && setControlsHidden(false)
+  }
 
   function setWidthOrHeight(style: any, name: string, value: string | number) {
     let styleVal
@@ -176,6 +183,9 @@ export const Player: React.FC<PlayerProps> = (props) => {
       onMouseDown={handleActivity}
       onMouseMove={handleActivity}
       onKeyDown={handleActivity}
+      onPointerMove={() => {
+        setControlsHidden(false)
+      }}
       className={cx(
         {
           'cueplayer-react-controls-enabled': true,
@@ -206,22 +216,29 @@ export const Player: React.FC<PlayerProps> = (props) => {
             style={getAspectRatioStyle()}
             className="cueplayer-react-video-holder"
           >
-            <Video>
-              {children}
-              {/* <track id="notes" src={userCues} kind="metadata" label="notes" /> */}
-            </Video>
+            <Video>{children}</Video>
             <BigPlayButton />
             <Bezel />
             <LoadingSpinner />
           </div>
         </div>
       </div>
-      <div className="cueplayer-react-controls-holder">
+      <div
+        className={cx('cueplayer-react-controls-holder', {
+          hidden: controlsHidden,
+        })}
+        onMouseOver={() => {
+          setControlsHovered(true)
+        }}
+        onMouseOut={() => {
+          setControlsHovered(false)
+        }}
+      >
         <ProgressBar />
         <CueBar />
         <ControlBar />
         <Shortcut />
-        {!isEmpty(viewer) && <CueForm />}
+        {!isEmpty(viewer) && !isFullscreen && <CueForm />}
       </div>
     </div>
   )

--- a/packages/player/src/components/player.tsx
+++ b/packages/player/src/components/player.tsx
@@ -225,7 +225,7 @@ export const Player: React.FC<PlayerProps> = (props) => {
       </div>
       <div
         className={cx('cueplayer-react-controls-holder', {
-          hidden: controlsHidden,
+          'cueplayer-react-controls-holder-auto-hide': controlsHidden,
         })}
         onMouseOver={() => {
           setControlsHovered(true)

--- a/packages/player/src/components/shortcut.tsx
+++ b/packages/player/src/components/shortcut.tsx
@@ -15,8 +15,8 @@ import {
   selectCueFormElem,
   selectIsWritingCue,
   selectIsTakingNote,
+  selectIsFullscreen,
 } from '../selectors'
-import {focusNode} from '../utils'
 
 type ShortcutProps = {
   clickable?: boolean
@@ -39,6 +39,7 @@ const useShortcutState = () => {
   const cueFormElem = useSelector(videoService, selectCueFormElem)
   const isWritingCue = useSelector(videoService, selectIsWritingCue)
   const isTakingNote = useSelector(videoService, selectIsTakingNote)
+  const isFullscreen = useSelector(videoService, selectIsFullscreen)
 
   return {
     videoService,
@@ -53,6 +54,7 @@ const useShortcutState = () => {
     paused,
     cueFormElem,
     isWritingCue,
+    isFullscreen,
     disableShortcuts: isTakingNote,
   }
 }
@@ -82,6 +84,7 @@ export const Shortcut: React.FC<ShortcutProps> = ({
     paused,
     cueFormElem,
     isWritingCue,
+    isFullscreen,
     disableShortcuts,
   } = useShortcutState()
 
@@ -124,12 +127,14 @@ export const Shortcut: React.FC<ShortcutProps> = ({
           {
             keyCode: 67, // c
             handle: () => {
-              // focus the cue note input
-              cueFormElem?.input?.focus()
-              // start note taking session
-              videoService.send({type: 'TAKE_NOTE', source: 'shortcut'})
-              // pause video playback
-              videoService.send({type: 'CHANGE'})
+              if (!isFullscreen) {
+                // focus the cue note input
+                cueFormElem?.input?.focus()
+                // start note taking session
+                videoService.send({type: 'TAKE_NOTE', source: 'shortcut'})
+                // pause video playback
+                videoService.send({type: 'CHANGE'})
+              }
             },
           },
           {

--- a/packages/player/src/hooks/use-auto-hide-controls.ts
+++ b/packages/player/src/hooks/use-auto-hide-controls.ts
@@ -4,7 +4,9 @@ import {useSelector} from '@xstate/react'
 import {selectIsFullscreen} from '../selectors'
 import {useVideo} from '../context/video-context'
 
-const useFullscreenControls = () => {
+const DELAY = 1250
+
+const useAutoHideControls = () => {
   const [controlsHovered, setControlsHovered] = React.useState<boolean>(false)
   const [controlsHidden, setControlsHidden] = React.useState<boolean>(false)
 
@@ -17,7 +19,7 @@ const useFullscreenControls = () => {
     const hideControlsInFullscreen = setTimeout(() => {
       if (!browser.IS_IOS && !controlsHovered && isFullscreen)
         setControlsHidden(true)
-    }, 1250)
+    }, DELAY)
 
     return () => clearTimeout(hideControlsInFullscreen)
   }, [isFullscreen, controlsHidden, controlsHovered])
@@ -29,4 +31,4 @@ const useFullscreenControls = () => {
   }
 }
 
-export {useFullscreenControls}
+export {useAutoHideControls}

--- a/packages/player/src/hooks/use-fullscreen-controls.ts
+++ b/packages/player/src/hooks/use-fullscreen-controls.ts
@@ -1,0 +1,32 @@
+import React from 'react'
+import * as browser from '../utils/browser'
+import {useSelector} from '@xstate/react'
+import {selectIsFullscreen} from '../selectors'
+import {useVideo} from '../context/video-context'
+
+const useFullscreenControls = () => {
+  const [controlsHovered, setControlsHovered] = React.useState<boolean>(false)
+  const [controlsHidden, setControlsHidden] = React.useState<boolean>(false)
+
+  const videoService = useVideo()
+  const isFullscreen = useSelector(videoService, selectIsFullscreen)
+
+  React.useEffect(() => {
+    !isFullscreen && setControlsHidden(false)
+
+    const hideControlsInFullscreen = setTimeout(() => {
+      if (!browser.IS_IOS && !controlsHovered && isFullscreen)
+        setControlsHidden(true)
+    }, 1250)
+
+    return () => clearTimeout(hideControlsInFullscreen)
+  }, [isFullscreen, controlsHidden, controlsHovered])
+
+  return {
+    controlsHidden,
+    setControlsHovered,
+    setControlsHidden,
+  }
+}
+
+export {useFullscreenControls}

--- a/packages/player/src/styles/scss/layout.scss
+++ b/packages/player/src/styles/scss/layout.scss
@@ -67,6 +67,9 @@
     left: 0;
     width: 100%;
     height: 100%;
+    &::cue {
+      font-size: 80%;
+    }
   }
 
   &.cueplayer-react-fullscreen {
@@ -74,7 +77,6 @@
     height: 100% !important;
     // Undo any aspect ratio padding for fluid layouts
     padding-top: 0 !important;
-
     &.cueplayer-react-user-inactive {
       cursor: none;
     }
@@ -86,12 +88,12 @@
     justify-content: center;
     align-items: center;
     &.fullscreen {
-      height: calc(100vh - 88px);
+      height: 100vh;
       display: flex;
       justify-content: center;
       .cueplayer-react-video-holder {
         height: 100% !important;
-        width: calc((100vh - 88px) * 1.77777) !important;
+        width: calc(100vh * 1.77777) !important;
         padding: 0 !important;
       }
     }
@@ -100,8 +102,9 @@
     .fullscreen-wrapper.fullscreen
     .cueplayer-react-video-holder {
     height: 100% !important;
-    width: calc((100vh - 88px) * 1.77777) !important;
+    width: calc(100vh * 1.77777) !important;
     padding: 0 !important;
+    opacity: 100%;
   }
   .cueplayer-react-video-holder {
     width: 100%;
@@ -121,6 +124,38 @@
       max-width: 100%;
     }
   }
+}
+
+// Controls holder
+.cueplayer-react-controls-holder {
+  width: 100%;
+  margin: 0 auto;
+  max-width: calc(75vh * 1.77777);
+  opacity: 100%;
+}
+
+// Controls holder in fullscreen
+.cueplayer-react-fullscreen .cueplayer-react-controls-holder {
+  max-width: 100vw;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  opacity: 1;
+}
+.cueplayer-react-fullscreen
+  .cueplayer-react-controls-holder
+  .cueplayer-react-cue-bar {
+  @include background-color-with-alpha(black, 0.8);
+}
+.cueplayer-react-fullscreen
+  .cueplayer-react-controls-holder
+  .cueplayer-react-control-bar {
+  @include background-color-with-alpha(black, 0.8);
+}
+
+// Hide controls in fullscreen
+.cueplayer-react-fullscreen .cueplayer-react-controls-holder.hidden {
+  opacity: 0;
 }
 
 body.cueplayer-react-full-window {

--- a/packages/player/src/styles/scss/layout.scss
+++ b/packages/player/src/styles/scss/layout.scss
@@ -154,7 +154,10 @@
 }
 
 // Hide controls in fullscreen
-.cueplayer-react-fullscreen .cueplayer-react-controls-holder.hidden {
+.cueplayer-react-fullscreen
+  .cueplayer-react-controls-holder.cueplayer-react-controls-holder-auto-hide {
+  // Remain visible for screen reader and keyboard users
+  visibility: visible;
   opacity: 0;
 }
 

--- a/packages/player/src/styles/scss/miscellaneous.scss
+++ b/packages/player/src/styles/scss/miscellaneous.scss
@@ -12,16 +12,6 @@
   }
 }
 
-.cueplayer-react-controls-holder {
-  width: 100%;
-  margin: 0 auto;
-  max-width: calc(75vh * 1.77777);
-}
-
-.cueplayer-react-fullscreen .cueplayer-react-controls-holder {
-  max-width: calc((100vh - 88px) * 1.77777);
-}
-
 .cueplayer-react-sr-only {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
hides controls in fullscreen when user is inactive for 1250ms.

![screenshot](https://user-images.githubusercontent.com/25487857/151546676-9222f83e-7ee7-4957-8fcf-8ff66aab4339.gif)

<img src="https://media.giphy.com/media/26tOVxw5cTv22Z2rS/giphy.gif" width="200" alt="gif">


