### PR TITLE
feat(react): Navigation component in layout now has a 'slot'

### DIFF
--- a/apps/typescriptcourse/src/components/layout.tsx
+++ b/apps/typescriptcourse/src/components/layout.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import DefaultLayout from '@skillrecordings/react/dist/layouts'
 import type {LayoutProps} from '@skillrecordings/react/dist/layouts'
 import config from '../config'
-import {first} from 'lodash'
+import {first, noop} from 'lodash'
 
 const Layout: React.FC<LayoutProps> = ({children, meta, ...props}) => {
   const defaultMeta = {
@@ -15,9 +15,9 @@ const Layout: React.FC<LayoutProps> = ({children, meta, ...props}) => {
 
   return (
     <DefaultLayout
-      showNavigation={false}
       {...props}
       meta={{...defaultMeta, ...meta}}
+      Navigation={() => null}
     >
       {children}
     </DefaultLayout>

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -2,7 +2,7 @@
   "name": "@skillrecordings/player",
   "description": "Internal, shared utilities",
   "author": "Joel Hooks",
-  "version": "0.11.01",
+  "version": "0.11.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/react/src/components/navigation.test.tsx
+++ b/packages/react/src/components/navigation.test.tsx
@@ -4,6 +4,6 @@ import Navigation from './navigation'
 
 test('renders root link', () => {
   const {getByText} = render(<Navigation />)
-  const linkElement = getByText(/Skill Recordings Product/)
+  const linkElement = getByText(/Product/)
   expect(linkElement).toBeInTheDocument()
 })

--- a/packages/react/src/components/navigation.tsx
+++ b/packages/react/src/components/navigation.tsx
@@ -3,9 +3,9 @@ import DarkModeToggle from './color-mode-toggle'
 import Link from 'next/link'
 import {useViewer} from '@skillrecordings/viewer'
 
-const Navigation: React.FC<{title?: string}> = ({
-  title = 'Skill Recordings Product',
-}) => {
+export type NavigationProps = {title?: string}
+
+const Navigation: React.FC<NavigationProps> = ({title = 'Product'}) => {
   const {isAuthenticated, logout} = useViewer()
   return (
     <nav className="w-full flex items-center justify-between print:hidden">

--- a/packages/react/src/layouts/index.tsx
+++ b/packages/react/src/layouts/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {NextSeo} from 'next-seo'
-import Navigation from '../components/navigation'
+import DefaultNavigation, {NavigationProps} from '../components/navigation'
 import Footer from '../components/footer'
 
 export type LayoutProps = {
@@ -8,6 +8,7 @@ export type LayoutProps = {
   noIndex?: boolean
   className?: string
   showNavigation?: boolean
+  Navigation?: React.FC<NavigationProps>
 }
 
 const Layout: React.FC<LayoutProps> = ({
@@ -16,6 +17,7 @@ const Layout: React.FC<LayoutProps> = ({
   meta,
   noIndex,
   showNavigation = true,
+  Navigation = DefaultNavigation,
 }) => {
   const {
     title,
@@ -25,7 +27,6 @@ const Layout: React.FC<LayoutProps> = ({
     ogImage,
   } = meta || {}
 
-  console.log(showNavigation)
   return (
     <>
       <NextSeo
@@ -42,7 +43,7 @@ const Layout: React.FC<LayoutProps> = ({
         noindex={noIndex}
       />
       <div className={`p-5 flex flex-col min-h-screen ${className}`}>
-        {showNavigation && <Navigation title={title} />}
+        <Navigation title={title} />
         <main className="flex-grow flex flex-col justify-center">
           {children}
         </main>


### PR DESCRIPTION
simple change to give Navigation a slot in the Layout component so it can be overridden (or hidden) in this case.

![meatballs](https://media.giphy.com/media/bSgaYwwIGtKSHSIr1Z/giphy.gif)