### PR TITLE
feat(player): video poster image support

### DIFF
--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -2,7 +2,7 @@
   "name": "@skillrecordings/player",
   "description": "Internal, shared utilities",
   "author": "Joel Hooks",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/player/src/components/player.tsx
+++ b/packages/player/src/components/player.tsx
@@ -43,6 +43,7 @@ type PlayerProps = {
   controls?: React.ReactElement
   overlay?: React.ReactElement
   canAddNotes?: boolean
+  poster?: string
 }
 
 const usePlayerState = () => {
@@ -86,6 +87,7 @@ export const Player: React.FC<PlayerProps> = (props) => {
     fluid = true,
     overlay,
     canAddNotes = false,
+    poster,
   } = props
   const containerRef = React.useRef(container)
   const {
@@ -234,7 +236,7 @@ export const Player: React.FC<PlayerProps> = (props) => {
             style={getAspectRatioStyle()}
             className="cueplayer-react-video-holder"
           >
-            <Video>{children}</Video>
+            <Video poster={poster}>{children}</Video>
             <BigPlayButton />
             <Bezel />
             <LoadingSpinner />


### PR DESCRIPTION
Allows passing `poster="image_url"` to the `<Player>` element.

<img src="https://media.giphy.com/media/l3vR8OCJPIhKSDqAU/giphy.gif" alt="cartman typing">