### PR TITLE
feat(player): improved volume controls a11y

### DIFF
--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/core": "^7.16.5",
     "@emotion/react": "^11.4.1",
+    "@reach/slider": "^0.16.0",
     "@reach/tabs": "^0.16.4",
     "@skillrecordings/react": "workspace:*",
     "@tippyjs/react": "^4.2.5",

--- a/packages/player/src/components/controls/volume-menu-button-control.tsx
+++ b/packages/player/src/components/controls/volume-menu-button-control.tsx
@@ -1,19 +1,17 @@
 import * as React from 'react'
 import {useSelector} from '@xstate/react'
-import {PopupButton} from '../popup/popup-button'
 import cx from 'classnames'
 import {VolumeBar} from '../volume-control/volume-bar'
 import {useVideo} from '../../context/video-context'
 import {selectMuted, selectVolume} from '../../selectors'
 
 export const VolumeMenuButtonControl: React.FC<any> = (props) => {
-  const {className, vertical = false, alwaysShowVolume} = props
-  const [active, setActive] = React.useState(false)
+  const {className, alwaysShowVolume} = props
+  const [isActive, setActive] = React.useState(alwaysShowVolume)
   const videoService = useVideo()
   const volume = useSelector(videoService, selectVolume)
   const muted = useSelector(videoService, selectMuted)
 
-  const inline = !vertical
   const level = volumeLevel()
 
   function volumeLevel() {
@@ -37,30 +35,41 @@ export const VolumeMenuButtonControl: React.FC<any> = (props) => {
   }
 
   function handleBlur() {
-    setActive(false)
+    !alwaysShowVolume && setActive(false)
   }
 
   return (
-    <PopupButton
-      className={cx(
-        className,
-        {
-          'cueplayer-react-volume-menu-button-vertical': vertical,
-          'cueplayer-react-volume-menu-button-horizontal': !vertical,
-          'cueplayer-react-vol-muted': muted,
-          'cueplayer-react-vol-0': level === 0 && !muted,
-          'cueplayer-react-vol-1': level === 1,
-          'cueplayer-react-vol-2': level === 2,
-          'cueplayer-react-vol-3': level === 3,
-          'cueplayer-react-slider-active': alwaysShowVolume || active,
-          'cueplayer-react-lock-showing': alwaysShowVolume || active,
-        },
-        'cueplayer-react-volume-menu-button',
-      )}
-      onClick={handleClick}
-      inline={inline}
-    >
-      <VolumeBar onFocus={handleFocus} onBlur={handleBlur} {...props} />
-    </PopupButton>
+    <div className="cueplayer-react-volume-control" aria-label="Volume Control">
+      <button
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onMouseEnter={handleFocus}
+        onMouseLeave={handleBlur}
+        title={muted ? 'Unmute' : 'Mute'}
+        aria-label={muted ? 'Unmute' : 'Mute'}
+        role="button"
+        onClick={handleClick}
+        className={cx(
+          className,
+          {
+            'cueplayer-react-vol-muted': muted,
+            'cueplayer-react-vol-0': level === 0 && !muted,
+            'cueplayer-react-vol-1': level === 1,
+            'cueplayer-react-vol-2': level === 2,
+            'cueplayer-react-vol-3': level === 3,
+          },
+          'cueplayer-react-volume-menu-button',
+          'cueplayer-react-control',
+          'cueplayer-react-button',
+          'cueplayer-react-menu-button',
+        )}
+      />
+      <VolumeBar
+        onMouseEnter={handleFocus}
+        onMouseLeave={handleBlur}
+        isActive={isActive}
+        {...props}
+      />
+    </div>
   )
 }

--- a/packages/player/src/components/volume-control/volume-bar.tsx
+++ b/packages/player/src/components/volume-control/volume-bar.tsx
@@ -1,32 +1,22 @@
 import * as React from 'react'
 import cx from 'classnames'
-import {Slider} from '../core/slider'
 import {useSelector} from '@xstate/react'
-import {SyntheticEvent} from 'react'
-import {VolumeLevel} from './volume-level'
 import {useVideo} from '../../context/video-context'
-import {getPointerPosition} from '../../utils'
 import {selectMuted, selectVolume} from '../../selectors'
+import {
+  SliderInput,
+  SliderTrack,
+  SliderRange,
+  SliderHandle,
+} from '@reach/slider'
 
 export const VolumeBar: React.FC<any> = (props) => {
-  const {className} = props
+  const {className, onMouseEnter, onMouseLeave, isActive} = props
   const videoService = useVideo()
   const volume = useSelector(videoService, selectVolume)
   const muted = useSelector(videoService, selectMuted)
 
-  const sliderRef = React.useRef(null)
-
-  const formattedVolume = (volume * 100).toFixed(2)
-
-  function calculateDistance(event: Event | SyntheticEvent) {
-    // forwarding refs made for a bit of a weird situation with
-    // the typing but there IS a ref here
-    const node = sliderRef?.current
-    const position = getPointerPosition(node, event)
-    return position.x
-  }
-
-  function getPercent() {
+  function getVolume() {
     if (muted) {
       return 0
     }
@@ -39,60 +29,41 @@ export const VolumeBar: React.FC<any> = (props) => {
     }
   }
 
-  function handleMouseMove(event: Event) {
-    checkMuted()
-    const distance = calculateDistance(event)
-    videoService.send({type: 'VOLUME_CHANGE', volume: distance})
-  }
-
-  function stepForward() {
-    checkMuted()
-    videoService.send({type: 'VOLUME_CHANGE', volume: volume + 0.1})
-  }
-
-  function stepBack() {
-    checkMuted()
-    videoService.send({type: 'VOLUME_CHANGE', volume: volume - 0.1})
-  }
-
-  function handleFocus(e: Event) {
-    if (props.onFocus) {
-      props.onFocus(e)
-    }
-  }
-
-  function handleBlur(e: Event) {
-    if (props.onBlur) {
-      props.onBlur(e)
-    }
-  }
-
-  function handleClick(event: Event) {
-    event.stopPropagation()
+  function formattedVolume(value: number) {
+    return (value * 100).toFixed(0) + `% ${muted ? 'volume muted' : 'volume'}`
   }
 
   return (
-    <Slider
-      ref={sliderRef}
-      label="volume level"
-      valuenow={formattedVolume}
-      valuetext={`${formattedVolume}%`}
-      onMouseMove={handleMouseMove}
-      onFocus={handleFocus}
-      onBlur={handleBlur}
-      onClick={handleClick}
-      sliderActive={handleFocus}
-      sliderInactive={handleBlur}
-      getPercent={getPercent}
-      stepForward={stepForward}
-      stepBack={stepBack}
+    <SliderInput
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      min={0}
+      max={1}
+      value={getVolume()}
+      defaultValue={getVolume()}
+      step={0.05}
+      handleAlignment="contain"
+      getAriaValueText={(value) => formattedVolume(muted ? volume : value)}
+      onChange={(newValue) => {
+        checkMuted()
+        videoService.send({type: 'VOLUME_CHANGE', volume: newValue})
+      }}
+      className={cx(className, 'cueplayer-react-volume-bar')}
       {...props}
-      className={cx(
-        className,
-        'cueplayer-react-volume-bar cueplayer-react-slider-bar',
-      )}
     >
-      <VolumeLevel {...props} />
-    </Slider>
+      {({hasFocus}) => {
+        const isVisible = hasFocus || isActive
+        return (
+          <SliderTrack
+            className={cx('cueplayer-react-volume-slider', {
+              'cueplayer-react-volume-slider-active': isVisible,
+            })}
+          >
+            <SliderRange />
+            <SliderHandle />
+          </SliderTrack>
+        )
+      }}
+    </SliderInput>
   )
 }

--- a/packages/player/src/styles/scss/components/slider.scss
+++ b/packages/player/src/styles/scss/components/slider.scss
@@ -8,8 +8,150 @@
     $cueplayer-react-secondary-background-color,
     $cueplayer-react-secondary-background-transparency
   );
+  /* 
+   &:focus {
+     @include box-shadow(0 0 1em $cueplayer-react-primary-foreground-color);
+   } 
+   */
+}
 
-  // &:focus {
-  //   @include box-shadow(0 0 1em $cueplayer-react-primary-foreground-color);
-  // }
+/* 
+Reach UI Slider
+https://reach.tech/slider
+*/
+
+:root {
+  --reach-slider: 1;
+}
+
+.cueplayer-react {
+  [data-reach-slider-input] {
+    max-width: 100%;
+  }
+
+  [data-reach-slider-input][data-orientation='horizontal'] {
+    height: 0.25rem;
+  }
+
+  [data-reach-slider-input][data-orientation='vertical'] {
+    width: 0.5rem;
+    /* the height is somewhat arbitrary but necessary for vertical sliders for
+  basic functionality */
+    height: 250px;
+    max-height: 100%;
+  }
+
+  [data-reach-slider-input][data-disabled] {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  [data-reach-slider-track] {
+    position: relative;
+    border-radius: 0.25rem;
+    @include background-color-with-alpha(
+      $cueplayer-react-primary-foreground-color,
+      0.2
+    );
+  }
+
+  [data-reach-slider-track][data-orientation='horizontal'] {
+    width: 100%;
+    height: inherit;
+  }
+
+  [data-reach-slider-track][data-orientation='vertical'] {
+    width: inherit;
+    height: 100%;
+  }
+
+  /* This pseudo element provides an invisible area that increases the touch
+target size of the track */
+  [data-reach-slider-track]::before {
+    content: '';
+    position: absolute;
+    height: 2.5rem;
+  }
+
+  [data-reach-slider-track][data-orientation='horizontal']::before {
+    width: 100%;
+    height: 1.5rem;
+    top: calc(-0.5rem - 1px);
+    left: 0;
+  }
+
+  [data-reach-slider-track][data-orientation='vertical']::before {
+    width: 1.5rem;
+    height: 100%;
+    top: 0;
+    left: calc(-0.5rem - 1px);
+  }
+
+  [data-reach-slider-handle] {
+    width: 16px;
+    height: 16px;
+    @include background-color-with-alpha(
+      $cueplayer-react-primary-foreground-color,
+      1
+    );
+    border-radius: 10px;
+    z-index: 1;
+    transform-origin: center;
+  }
+
+  [data-reach-slider-handle][aria-orientation='horizontal'] {
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  [data-reach-slider-handle][aria-orientation='horizontal']:focus {
+    transform: translateY(-50%);
+  }
+
+  [data-reach-slider-handle][aria-orientation='vertical'] {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  [data-reach-slider-range] {
+    border-radius: inherit;
+    @include background-color-with-alpha(
+      $cueplayer-react-primary-foreground-color,
+      0.5
+    );
+    left: 0;
+    bottom: 0;
+  }
+
+  [data-reach-slider-range][data-orientation='horizontal'] {
+    height: 100%;
+  }
+
+  [data-reach-slider-range][data-orientation='vertical'] {
+    width: 100%;
+  }
+
+  [data-reach-slider-marker] {
+    background: hsl(0, 0%, 50%);
+    transform-origin: center;
+  }
+
+  [data-reach-slider-marker][data-orientation='horizontal'] {
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 3px;
+    height: 0.75rem;
+  }
+
+  [data-reach-slider-marker][data-orientation='vertical'] {
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 0.75rem;
+    height: 3px;
+  }
+
+  /* 
+  [data-reach-slider-marker][data-state="at-value"],
+  [data-reach-slider-marker][data-state="under-value"] {}
+  */
 }

--- a/packages/player/src/styles/scss/components/volume.scss
+++ b/packages/player/src/styles/scss/components/volume.scss
@@ -1,4 +1,18 @@
 .cueplayer-react {
+  /*
+  Volume Container
+  */
+  .cueplayer-react-volume-control {
+    @include display-flex(center);
+  }
+
+  /*
+  Volume Button
+  */
+  .cueplayer-react-volume {
+    @include display-flex(center);
+  }
+
   .cueplayer-react-mute-control,
   .cueplayer-react-volume-menu-button {
     font-size: 0.85em;
@@ -24,147 +38,39 @@
     }
   }
 
-  .cueplayer-react-volume-control {
-    width: 5em;
-    @include flex(none);
-    @include display-flex(center);
-  }
+  /*
+  Volume Slider
+  */
 
   .cueplayer-react-volume-bar {
-    margin: 1.35em 0.45em;
+    width: 6em;
+    position: relative;
 
-    &.cueplayer-react-slider-horizontal {
-      width: 5em;
-      height: 0.3em;
-
-      .cueplayer-react-volume-level {
-        width: 100%;
-      }
+    .cueplayer-react-volume-slider {
+      opacity: 0;
+      @include transition(opacity 0.2s ease-in-out);
     }
-
-    &.cueplayer-react-slider-vertical {
-      width: 0.3em;
-      height: 5em;
-      margin: 1.35em auto;
-
-      .cueplayer-react-volume-level {
-        height: 100%;
-      }
+    .cueplayer-react-volume-slider-active {
+      @include transition(opacity 0.2s ease-in-out);
+      opacity: 1;
     }
   }
 
-  .cueplayer-react-volume-level {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-
-    background-color: $cueplayer-react-primary-foreground-color;
-
-    @extend .cueplayer-react-icon;
-    @extend .cueplayer-react-icon-circle;
-
-    // Volume handle
-    &:before {
-      position: absolute;
-      font-size: 1.1em;
-    }
+  [data-reach-slider-input][data-orientation='horizontal'] {
+    height: 0.15rem;
   }
 
-  .cueplayer-react-slider-vertical .cueplayer-react-volume-level {
-    width: 0.3em;
-
-    // Volume handle
-    &:before {
-      top: -0.5em;
-      left: -0.3em;
-    }
+  [data-reach-slider-handle] {
+    width: 10px;
+    height: 10px;
+    border-radius: 5px;
   }
 
-  .cueplayer-react-slider-horizontal .cueplayer-react-volume-level {
-    height: 0.3em;
-
-    // Volume handle
-    &:before {
-      top: -0.35em;
-      right: -0.5em;
-    }
-  }
-
-  // The volume menu button is like menu buttons (captions/subtitles) but works
-  // a little differently. It needs to be possible to tab to the volume slider
-  // without hitting space bar on the menu button. To do this we're not using
-  // display:none to hide the slider menu by default, and instead setting the
-  // width and height to zero.
-  .cueplayer-react-menu-button-popup.cueplayer-react-volume-menu-button
-    .cueplayer-react-menu {
-    display: block;
-    width: 0;
-    height: 0;
-    border-top-color: transparent;
-  }
-
-  .cueplayer-react-menu-button-popup.cueplayer-react-volume-menu-button-vertical
-    .cueplayer-react-menu {
-    left: 0.5em;
-    height: 8em;
-  }
-
-  .cueplayer-react-menu-button-popup.cueplayer-react-volume-menu-button-horizontal
-    .cueplayer-react-menu {
-    left: -2em;
-  }
-
-  .cueplayer-react-menu-button-popup.cueplayer-react-volume-menu-button
-    .cueplayer-react-menu-content {
-    height: 0;
-    width: 0;
-
-    // Avoids unnecessary scrollbars in the menu content. Primarily noticed in Chrome on Linux.
-    overflow-x: hidden;
-    overflow-y: hidden;
-  }
-
-  .cueplayer-react-volume-menu-button-vertical:hover
-    .cueplayer-react-menu-content,
-  .cueplayer-react-volume-menu-button-vertical:focus
-    .cueplayer-react-menu-content,
-  .cueplayer-react-volume-menu-button-vertical.cueplayer-react-slider-active
-    .cueplayer-react-menu-content,
-  .cueplayer-react-volume-menu-button-vertical
-    .cueplayer-react-lock-showing
-    .cueplayer-react-menu-content {
-    height: 8em;
-    width: 2.9em;
-  }
-
-  .cueplayer-react-volume-menu-button-horizontal:hover
-    .cueplayer-react-menu-content,
-  .cueplayer-react-volume-menu-button-horizontal:focus
-    .cueplayer-react-menu-content,
-  .cueplayer-react-volume-menu-button-horizontal
-    .cueplayer-react-slider-active
-    .cueplayer-react-menu-content,
-  .cueplayer-react-volume-menu-button-horizontal
-    .cueplayer-react-lock-showing
-    .cueplayer-react-menu-content {
+  /* Enlarge the interactive area of the slider */
+  .cueplayer-react-volume-bar::before {
+    width: 100%;
     height: 2.5rem;
-    display: flex;
-    align-items: center;
-  }
-
-  .cueplayer-react-volume-menu-button-horizontal {
-    width: 12em;
-    .cueplayer-react-menu .cueplayer-react-menu-content {
-      height: 2.5rem;
-      display: flex;
-      align-items: center;
-    }
-  }
-
-  .cueplayer-react-volume-menu-button.cueplayer-react-menu-button-inline
-    .cueplayer-react-menu-content {
-    // An inline volume should never have a menu background color.
-    //  This protects it from external changes to background colors.
-    background-color: transparent !important;
+    position: absolute;
+    content: '';
   }
 }

--- a/packages/player/src/styles/scss/components/volume.scss
+++ b/packages/player/src/styles/scss/components/volume.scss
@@ -45,6 +45,7 @@
   .cueplayer-react-volume-bar {
     width: 6em;
     position: relative;
+    @include display-flex(center);
 
     .cueplayer-react-volume-slider {
       opacity: 0;

--- a/packages/player/src/styles/scss/components/volume.scss
+++ b/packages/player/src/styles/scss/components/volume.scss
@@ -2,9 +2,10 @@
   /*
   Volume Container
   */
-  .cueplayer-react-volume-control {
-    @include display-flex(center);
-  }
+
+  /*
+  .cueplayer-react-volume-control {}
+  */
 
   /*
   Volume Button
@@ -15,6 +16,7 @@
 
   .cueplayer-react-mute-control,
   .cueplayer-react-volume-menu-button {
+    align-self: stretch;
     font-size: 0.85em;
     cursor: pointer;
     @include flex(none);

--- a/packages/player/src/styles/scss/miscellaneous.scss
+++ b/packages/player/src/styles/scss/miscellaneous.scss
@@ -2,6 +2,7 @@
 .cueplayer-react .cueplayer-react-control.cueplayer-react-replay-control,
 .cueplayer-react .cueplayer-react-control.cueplayer-react-forward-control,
 .cueplayer-react .cueplayer-react-control.cueplayer-react-volume-menu-button,
+.cueplayer-react .cueplayer-react-volume-control,
 .cueplayer-react .cueplayer-react-control.cueplayer-react-current-time,
 .cueplayer-react .cueplayer-react-time-divider,
 .cueplayer-react .cueplayer-react-control.cueplayer-react-duration {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2505,6 +2505,7 @@ importers:
       '@emotion/babel-plugin': ^11.3.0
       '@emotion/babel-preset-css-prop': ^11.2.0
       '@emotion/react': ^11.4.1
+      '@reach/slider': ^0.16.0
       '@reach/tabs': ^0.16.4
       '@skillrecordings/react': workspace:*
       '@skillrecordings/scripts': workspace:*
@@ -2535,6 +2536,7 @@ importers:
     dependencies:
       '@babel/core': 7.16.5
       '@emotion/react': 11.4.1_213ad9d7f16d5f2143aae0ea44e017d2
+      '@reach/slider': 0.16.0_react-dom@17.0.2+react@17.0.2
       '@reach/tabs': 0.16.4_react-dom@17.0.2+react@17.0.2
       '@skillrecordings/react': link:../react
       '@tippyjs/react': 4.2.5_react-dom@17.0.2+react@17.0.2
@@ -8011,6 +8013,21 @@ packages:
       tslib: 2.3.1
     dev: false
 
+  /@reach/slider/0.16.0_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-RdJTndvn5TMJXrt9ut5xpFTXTaIllE9H+zyFT5awmNqC+0r6/kt7fFxMPAy4UI0CTFMcQXRfj6qA/TVe/vf5Tw==}
+    peerDependencies:
+      react: ^16.9.0 || 17.x
+      react-dom: ^16.9.0 || 17.x
+    dependencies:
+      '@reach/auto-id': 0.16.0_react-dom@17.0.2+react@17.0.2
+      '@reach/utils': 0.16.0_react-dom@17.0.2+react@17.0.2
+      prop-types: 15.8.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      tiny-warning: 1.0.3
+      tslib: 2.3.1
+    dev: false
+
   /@reach/tabs/0.16.4_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-4EK+1U0OoLfg2tJ1BSZf6/tx0hF5vlXKxY7qB//bPWtlIh9Xfp/aSDIdspFf3xS8MjtKeb6IVmo5UAxDMq85ZA==}
     peerDependencies:
@@ -10567,7 +10584,7 @@ packages:
   /axios/0.24.0:
     resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
     dependencies:
-      follow-redirects: 1.14.5_debug@2.6.9
+      follow-redirects: 1.14.5
     transitivePeerDependencies:
       - debug
 
@@ -15174,6 +15191,15 @@ packages:
   /focus-visible/5.2.0:
     resolution: {integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==}
 
+  /follow-redirects/1.14.5:
+    resolution: {integrity: sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   /follow-redirects/1.14.5_debug@2.6.9:
     resolution: {integrity: sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==}
     engines: {node: '>=4.0'}
@@ -15184,6 +15210,7 @@ packages:
         optional: true
     dependencies:
       debug: 2.6.9
+    dev: false
 
   /follow-redirects/1.14.9:
     resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}


### PR DESCRIPTION
this PR fixes following issues:
- [x] Volume controls should not be nested within each other
- [x] The volume button that toggles the mute state has an accessible name of 100%, versus mute/unmute. It doesn't toggle when you change the state  
- [x] I was unable to use the arrow keys to change the volume on the volume slider. It works one time when pressing the left arrow to lower it one bit - but otherwise it doesn't trigger a volume change
- [x] When I press the tab key and focus is lost when you are trying to tab to the volume slider  

https://user-images.githubusercontent.com/25487857/159444562-b42449aa-4445-419a-af81-56d2c1fe2145.mp4

<img src="https://media.giphy.com/media/hoKiEq7gwRVdmWPCTL/giphy.gif" width="200" alt="caption your content gif">