### PR TITLE
feat(player): improve closed captions menu a11y

### DIFF
--- a/packages/player/src/components/controls/closed-captions-menu-button-control.tsx
+++ b/packages/player/src/components/controls/closed-captions-menu-button-control.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react'
 import cx from 'classnames'
-import find from 'lodash/find'
-import indexOf from 'lodash/indexOf'
 import isEmpty from 'lodash/isEmpty'
-import {MenuButton} from '../menu/menu-button'
+import first from 'lodash/first'
+import last from 'lodash/last'
+import {
+  ListboxItem,
+  ListboxButton,
+  ListboxGroup,
+} from '../listbox/listbox-button'
 import {useSubtitlesTrackList} from '../../hooks/use-subtitles-track-list'
 
 type ClosedCaptionsMenuButtonProps = {
@@ -18,27 +22,36 @@ export const ClosedCaptionsMenuButtonControl: React.FC<ClosedCaptionsMenuButtonP
     const {subtitles, activateSubtitlesTrack, clearSubtitlesTracks} =
       useSubtitlesTrackList()
 
-    const items = [
-      ...subtitles.map((track) => ({
-        label: `${track.label}`,
-        value: track.language,
-      })),
+    const items: ListboxItem[] = [
+      ...subtitles.map((track: TextTrack) => {
+        return {
+          mode: track.mode,
+          value: track.language,
+          label: track.label,
+        }
+      }),
       {
         label: 'Off',
-        value: {},
+        value: 'off',
       },
     ]
 
-    const activeTrack =
-      subtitles && subtitles.filter((track) => track.mode === 'showing')
-
-    const activeItemIndex = indexOf(
-      items,
-      find(items, (track) => track.value === activeTrack[0]?.language),
+    const activeTrack: any = first(
+      items.filter(
+        (track: TextTrack | ListboxItem) => track.mode === 'showing',
+      ),
     )
 
-    const lastItemIndex = items.length - 1
-    const selectedIndex = isEmpty(activeTrack) ? lastItemIndex : activeItemIndex
+    const activeItem: ListboxItem = isEmpty(activeTrack)
+      ? last(items)
+      : activeTrack
+
+    const groups: ListboxGroup[] = [
+      {
+        label: 'Closed Captions',
+        items,
+      },
+    ]
 
     const handleSelectItem = React.useCallback(
       (index: number) => {
@@ -49,13 +62,18 @@ export const ClosedCaptionsMenuButtonControl: React.FC<ClosedCaptionsMenuButtonP
     )
 
     return !isEmpty(subtitles) ? (
-      <MenuButton
-        className={cx('cueplayer-react-closed-caption', props.className)}
-        onSelectItem={handleSelectItem}
-        items={items}
-        selected={selectedIndex}
-      >
-        <span className="cueplayer-react-control-text">Subtitles</span>
-      </MenuButton>
+      <div className="cueplayer-react-closed-caption">
+        <ListboxButton
+          className={cx(props.className)}
+          selectedItem={activeItem}
+          onSelectItem={handleSelectItem}
+          items={groups}
+          title={'Closed captions'}
+        >
+          <span className="cueplayer-react-control-text">
+            {activeItem.label} subtitles
+          </span>
+        </ListboxButton>
+      </div>
     ) : null
   }

--- a/packages/player/src/components/listbox/listbox-button.tsx
+++ b/packages/player/src/components/listbox/listbox-button.tsx
@@ -70,7 +70,7 @@ export const ListboxButton: React.FC<ListboxProps> = ({
                     <ListboxGroupLabel>{group.label}</ListboxGroupLabel>
                     {group.items.map((item: any) => (
                       <ListboxOption
-                        aria-label={item.label + ' speed'}
+                        aria-label={item.label}
                         value={item.value}
                         key={item.value}
                       >

--- a/packages/player/src/styles/scss/components/closed-caption.scss
+++ b/packages/player/src/styles/scss/components/closed-caption.scss
@@ -1,13 +1,18 @@
-.cueplayer-react {
-  .cueplayer-react-closed-caption {
-    cursor: pointer;
-    @include flex(none);
+.cueplayer-react .cueplayer-react-closed-caption {
+  [data-reach-listbox-popover] {
+    font-size: 1.3em;
+  }
+  @include display-flex(center);
+  .cueplayer-react-menu-button {
+    @include display-flex(center);
+    min-height: 2.5rem;
+    @include display-flex(center);
     @extend .cueplayer-react-icon;
     @extend .cueplayer-react-icon-closed-caption;
   }
+}
 
-  video::-webkit-media-text-track-container {
-    -webkit-transform: translateY(-30px);
-    transform: translateY(-30px);
-  }
+video::-webkit-media-text-track-container {
+  -webkit-transform: translateY(-30px);
+  transform: translateY(-30px);
 }


### PR DESCRIPTION
this PR fixes following issues:
- [x] When I use the keyboard to click on the close captioning button, I am unable to use arrow keys on the keyboard to navigate through to turn on captions
- [x] When I press the escape key to close the playback rate menu, it does close the menu, but then focus is lost

<img width="150" alt="screenshot" src="https://user-images.githubusercontent.com/25487857/159935837-eba043da-ccf9-4d61-9640-2a4016fb8440.png">

<img src="https://media.giphy.com/media/dUC839HKhRbxac4pQH/giphy.gif" width="150" alt="gif">
