### PR TITLE
update(player): cue bar a11y improvements

### DIFF
--- a/apps/next-product-starter/src/styles/globals.css
+++ b/apps/next-product-starter/src/styles/globals.css
@@ -10,6 +10,6 @@
 This will hide the focus indicator if the element receives focus via the mouse,
 but it will still show up on keyboard focus.
 */
-.js-focus-visible :focus:not(.focus-visible) {
+[data-js-focus-visible] :focus:not([data-focus-visible-added]) {
   outline: none;
 }

--- a/packages/player/src/components/cue-bar.tsx
+++ b/packages/player/src/components/cue-bar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import classNames from 'classnames'
-import {isEmpty} from 'lodash'
 import Tippy from '@tippyjs/react'
 import CodeBlock from './code-block'
 import {useVideo} from '../context/video-context'
@@ -10,6 +9,7 @@ import {useCue} from '../hooks/use-cue'
 import {ElementType} from 'react'
 import ReactMarkdown from 'react-markdown'
 import {useMetadataCues} from '../hooks/use-metadata-cues'
+import {convertTimeWithTitles} from '@skillrecordings/time'
 
 export const CueBar: React.FC<any> = ({
   className,
@@ -39,9 +39,6 @@ export const CueBar: React.FC<any> = ({
 }
 
 const NoteCue: React.FC<any> = ({cue, duration, className}) => {
-  // const [visible, setVisible] = React.useState(false)
-  // const [mouseOverTippy, setMouseOverTippy] = React.useState(false)
-
   const videoService = useVideo()
   const viewer = useSelector(videoService, selectViewer)
 
@@ -86,16 +83,9 @@ const NoteCue: React.FC<any> = ({cue, duration, className}) => {
       trigger="mouseenter focus"
       delay={20}
       inertia={true}
-      // visible={visible || mouseOverTippy}
       content={
-        <div
-          // onMouseMove={() => setMouseOverTippy(true)}
-          // onMouseLeave={() => setTimeout(() => setMouseOverTippy(false), 200)}
-          className="cueplayer-react-cue-popup-content"
-        >
-          {/* <div className="cueplayer-react-cue-popup-header">header here</div> */}
+        <div id={cue.startTime} className="cueplayer-react-cue-popup-content">
           <div className="cueplayer-react-cue-popup-body">
-            {/* @ts-ignore */}
             <ReactMarkdown renderers={customRenderers}>
               {note.text}
             </ReactMarkdown>
@@ -104,10 +94,13 @@ const NoteCue: React.FC<any> = ({cue, duration, className}) => {
       }
     >
       <button
+        aria-label={`jump to note at ${convertTimeWithTitles(cue.startTime, {
+          showSeconds: true,
+          longForm: true,
+        })}`}
+        aria-describedby={cue.startTime}
         type="button"
         onClick={clickOpen}
-        // onMouseEnter={() => setVisible(true)}
-        // onMouseLeave={() => setTimeout(() => setVisible(false), 200)}
         className={classNames(
           `${
             note.type === 'learner'

--- a/packages/player/src/components/cue-form.tsx
+++ b/packages/player/src/components/cue-form.tsx
@@ -57,17 +57,17 @@ export const CueForm: React.FC = () => {
           <LoadingIndicator />
         ) : (
           <img
+            alt={viewer.name}
             src={viewer.avatar_url}
             className="cueplayer-react-cue-form-image"
             width={24}
             height={24}
           />
         )}
-
-        {/* https://github.com/ianstormtaylor/slate looks awesome if we wanted wysiwyg editor */}
         <input
           disabled={isSubmittingCueNote}
           autoComplete="off"
+          aria-label="Leave your note here (required)"
           placeholder="Leave your note here..."
           className="cueplayer-react-cue-form-input"
           id="input"

--- a/packages/player/src/components/seek-bar/index.tsx
+++ b/packages/player/src/components/seek-bar/index.tsx
@@ -60,6 +60,7 @@ export const SeekBar: React.FC<any> = (props) => {
         })
         videoService.send('END_SEEKING')
       }}
+      aria-label="seek slider"
       getAriaValueText={(value) => {
         const currentValue = Number(value.toFixed(0))
 

--- a/packages/player/src/components/volume-control/volume-bar.tsx
+++ b/packages/player/src/components/volume-control/volume-bar.tsx
@@ -44,6 +44,7 @@ export const VolumeBar: React.FC<any> = ({isActive, ...props}) => {
       step={0.05}
       handleAlignment="contain"
       getAriaValueText={(value) => formattedVolume(muted ? volume : value)}
+      aria-label="volume slider"
       onChange={(newValue) => {
         checkMuted()
         videoService.send({type: 'VOLUME_CHANGE', volume: newValue})

--- a/packages/player/src/styles/scss/components/cue-form.scss
+++ b/packages/player/src/styles/scss/components/cue-form.scss
@@ -66,7 +66,7 @@
       line-height: 1;
       color: $cueplayer-react-primary-foreground-color;
       border: none;
-      font-size: 12px;
+      font-size: 1.2em;
       border-radius: 5px;
       appearance: none;
       background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAYAAADEUlfTAAAAG0lEQVR42mNgwAfKy8v/48I4FeA0AacVDFQBAP9wJkE/KhUMAAAAAElFTkSuQmCC')
@@ -75,7 +75,7 @@
   }
   .cueplayer-react-cue-form-submit-button {
     padding: 2px 10px;
-    font-size: 12px;
+    font-size: 1.2em;
     font-weight: 500;
     border-radius: 5px;
     background: $cueplayer-react-tertiary-foreground-color;

--- a/packages/player/src/styles/scss/variables.scss
+++ b/packages/player/src/styles/scss/variables.scss
@@ -12,7 +12,7 @@ $cueplayer-react-secondary-background-color: lighten(
   33%
 ) !default;
 $cueplayer-react-secondary-background-transparency: 0.5 !default;
-$cueplayer-react-tertiary-foreground-color: #6961ff;
+$cueplayer-react-tertiary-foreground-color: #5b53ff;
 
 $cueplayer-react-text-font-family: system-ui, -apple-system, BlinkMacSystemFont,
   'Segoe UI', Roboto, Ubuntu, 'Helvetica Neue', Oxygen, Cantarell, sans-serif !default;


### PR DESCRIPTION
- [x] Avatar on note field is missing alternative text
- [x] The note text doesn't get announced to screen reader users
- [x] The egghead icon note buttons don't have an accessible name. (I.e. they contain empty text)
- [x] The note field doesn't have an accessible label
- [x] If I use the tab key and tab to the playback rate, press enter to activate, then use "Shift + Tab" key to go backwards and focus on one of the notes, pressing "Enter" doesn't act as a button anymore, and activates the playback rate dropdown again instead of jumping to the note
- [x] Submit button on note form has insufficient color contrast
- [x] When I use settings to change the spacings the "Only Me" select, the placeholder text, remains static
- [x] The input has a required attribute but there is no visual indicator that the field is required 

<img src="https://media.giphy.com/media/3zgPY6cX4gREs/giphy-downsized.gif" width="300" alt="true">