### PR TITLE
feat(testingaccessibility): accessible emojis from portable text

### DIFF
--- a/apps/testingaccessibility/README.md
+++ b/apps/testingaccessibility/README.md
@@ -21,15 +21,21 @@ pnpm i
 pnpm dev
 ```
 
-### Strip CLI
+### Stripe CLI
 
 You'll need the [Strip CLI](https://stripe.com/docs/stripe-cli) to capture web hooks locally.
 
 When you run the CLI it gives you your webhook signing secret that you can set in `.env.local`.
 
-The Stripe test secret token is also required! 
+The Stripe test secret token is also required!
 
 see: `.env.local.template`
+
+Listen to webhook:
+
+```bash
+stripe listen --forward-to localhost:3013/api/stripe/webhook
+```
 
 ### Postmark
 
@@ -79,6 +85,14 @@ If you make changes to the schema via Prisma you'll need to push it to the DB. W
 npx prisma db push
 ```
 
+### Prisma studio
+
+Start prisma studio:
+
+```bash
+npx prisma studio
+```
+
 ### Seed Data
 
 When you make a new branch in Planetscale it doesn't bring data over.
@@ -90,5 +104,3 @@ pscale database restore-dump testing-accessibility next-steps --dir ./seed_data/
 ```
 
 This should set up the basics that are associated with the **test mode** Stripe account
-
-

--- a/apps/testingaccessibility/src/components/portable-text/index.tsx
+++ b/apps/testingaccessibility/src/components/portable-text/index.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import type {ArbitraryTypedObject, PortableTextBlock} from '@portabletext/types'
-import {PortableText, PortableTextComponents} from '@portabletext/react'
+import {
+  PortableText,
+  PortableTextComponents,
+  PortableTextMarkComponentProps,
+} from '@portabletext/react'
 import {useSelector} from '@xstate/react'
 import {
   HLSSource,
@@ -43,7 +47,19 @@ const Video: React.FC<{url: string; title: string}> = ({url, title}) => {
   )
 }
 
+// https://github.com/portabletext/react-portabletext
+
 const PortableTextComponents: PortableTextComponents = {
+  marks: {
+    emoji: ({text, value}: EmojiProps) => {
+      const label = value.emoji.label
+      return (
+        <span role="img" aria-label={label} aria-hidden={!label}>
+          {text}
+        </span>
+      )
+    },
+  },
   types: {
     bodyVideo: ({value}: BodyVideoProps) => {
       const {url, title, caption} = value
@@ -95,6 +111,8 @@ const PortableTextComponents: PortableTextComponents = {
     },
   },
 }
+
+type EmojiProps = PortableTextMarkComponentProps<any>
 
 type CalloutProps = {
   value: {

--- a/apps/testingaccessibility/studio/schemas/objects/body.js
+++ b/apps/testingaccessibility/studio/schemas/objects/body.js
@@ -1,5 +1,6 @@
-// TODO: Exercises (don't have to have solutions), Challenges (always have solutions, sometimes multiple parts)
+import {HiOutlineEmojiHappy, HiLink} from 'react-icons/hi'
 
+// TODO: Exercises (don't have to have solutions), Challenges (always have solutions, sometimes multiple parts)
 export default {
   name: 'body',
   type: 'array',
@@ -15,7 +16,50 @@ export default {
       //   {title: 'H5', value: 'h5'},
       //   {title: 'H6', value: 'h6'},
       //   {title: 'Quote', value: 'blockquote'}
-      // ]
+      // ],
+      marks: {
+        annotations: [
+          {
+            name: 'internalLink',
+            type: 'object',
+            title: 'Internal link',
+            blockEditor: {
+              icon: HiLink,
+            },
+            fields: [
+              {
+                name: 'reference',
+                type: 'reference',
+                title: 'Reference',
+                to: [{type: 'lesson'}, {type: 'section'}, {type: 'module'}],
+              },
+            ],
+          },
+          {
+            name: 'emoji',
+            type: 'object',
+            title: 'Emoji',
+            blockEditor: {
+              icon: HiOutlineEmojiHappy,
+            },
+            fields: [
+              {
+                name: 'emoji',
+                title: 'Emoji',
+                type: 'object',
+                fields: [
+                  {
+                    name: 'label',
+                    type: 'string',
+                    title: 'Label',
+                    validation: (Rule) => Rule.required(),
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
     },
     {type: 'bodyImage'},
     {type: 'bodyVideo'},


### PR DESCRIPTION
This adds new Emoji mark so that we can provide `aria-label` for emojis. I've noticed that even though I made the label required in schema, the editor won't highlight it in case it's missing. Might be worth reporting to Sanity team. :) In case the label isn't provided, we hide the emoji for screen readers using `aria-hidden="true"`.

I also added way to link to internal documents, but haven't implemented a react component for it yet.

https://user-images.githubusercontent.com/25487857/164165058-cfefa8cd-bd32-4bda-a01e-d53b18a98e1c.mp4

<img src="https://media.giphy.com/media/1vLHnnIiwUN7a/giphy.gif" width="150" alt="gif">