### PR TITLE
feat(player): ability to disable global shortcuts

### DIFF
--- a/apps/testingaccessibility/src/components/portable-text/index.tsx
+++ b/apps/testingaccessibility/src/components/portable-text/index.tsx
@@ -36,6 +36,7 @@ const Video: React.FC<{url: string; title: string}> = ({url, title}) => {
       })}
     >
       <Player
+        enableGlobalShortcuts={false}
         aria-label={title}
         container={fullscreenWrapperRef.current || undefined}
         aspectRatio="8:5"

--- a/apps/testingaccessibility/src/templates/lesson-template.tsx
+++ b/apps/testingaccessibility/src/templates/lesson-template.tsx
@@ -1,17 +1,16 @@
 import React from 'react'
-import {VideoProvider} from '@skillrecordings/player'
+import {useProgress} from 'context/progress-context'
 import {PortableText} from '@portabletext/react'
 import {SanityDocument} from '@sanity/client'
+import {Switch} from '@headlessui/react'
 import {useRouter} from 'next/router'
 import PortableTextComponents from 'components/portable-text'
 import Layout from 'components/app/layout'
-import Link from 'next/link'
-import cx from 'classnames'
-import find from 'lodash/find'
 import indexOf from 'lodash/indexOf'
 import isEmpty from 'lodash/isEmpty'
-import {useProgress} from 'context/progress-context'
-import {Switch} from '@headlessui/react'
+import find from 'lodash/find'
+import Link from 'next/link'
+import cx from 'classnames'
 
 type LessonTemplateProps = {
   module: SanityDocument

--- a/packages/player/src/components/controls/fullscreen-toggle-control.tsx
+++ b/packages/player/src/components/controls/fullscreen-toggle-control.tsx
@@ -35,7 +35,9 @@ export const FullscreenToggleControl: React.FC<FullscrenToggleProps> =
         tabIndex={0}
         onClick={handleClick}
       >
-        <span className="cueplayer-react-control-text">Non-Fullscreen</span>
+        <span className="cueplayer-react-control-text">
+          {isFullscreen ? 'Exit full screen (f)' : 'Full screen (f)'}
+        </span>
       </button>
     )
   })

--- a/packages/player/src/components/player.tsx
+++ b/packages/player/src/components/player.tsx
@@ -30,6 +30,7 @@ import {
 } from '../selectors'
 
 type PlayerProps = {
+  children?: any
   container?: HTMLElement
   className?: string
   fluid?: boolean
@@ -44,6 +45,7 @@ type PlayerProps = {
   overlay?: React.ReactElement
   canAddNotes?: boolean
   poster?: string
+  enableGlobalShortcuts?: boolean
 }
 
 const usePlayerState = () => {
@@ -88,6 +90,7 @@ export const Player: React.FC<PlayerProps> = (props) => {
     overlay,
     canAddNotes = false,
     poster,
+    enableGlobalShortcuts = true,
   } = props
   const containerRef = React.useRef(container)
   const {
@@ -198,7 +201,10 @@ export const Player: React.FC<PlayerProps> = (props) => {
             return {}
           },
         }
-        videoService.send({type: 'SET_ROOT_ELEM', rootElemRef: domNodeRef})
+        videoService.send({
+          type: 'SET_ROOT_ELEM',
+          rootElemRef: domNodeRef,
+        })
       }}
       onMouseDown={handleActivity}
       onMouseMove={handleActivity}
@@ -257,7 +263,10 @@ export const Player: React.FC<PlayerProps> = (props) => {
         <ProgressBar />
         <CueBar />
         <ControlBar>{controls}</ControlBar>
-        <Shortcut canAddNotes={canAddNotes} />
+        <Shortcut
+          enableGlobalShortcuts={enableGlobalShortcuts}
+          canAddNotes={canAddNotes}
+        />
         {canAddNotes && <CueForm />}
       </div>
       {overlay}

--- a/packages/player/src/components/shortcut.tsx
+++ b/packages/player/src/components/shortcut.tsx
@@ -14,6 +14,7 @@ import {
   selectVolume,
   selectCueFormElem,
   selectShortcutsEnabled,
+  selectVideo,
 } from '../selectors'
 
 type ShortcutProps = {
@@ -21,6 +22,7 @@ type ShortcutProps = {
   dblclickable?: boolean
   shortcuts?: any[]
   canAddNotes: boolean
+  enableGlobalShortcuts?: boolean
 }
 
 const useShortcutState = () => {
@@ -33,6 +35,7 @@ const useShortcutState = () => {
   const playbackRate = useSelector(videoService, selectPlaybackRate)
   const rootElem = useSelector(videoService, selectRootElem)
   const readyState = useSelector(videoService, selectReadyState)
+  const video = useSelector(videoService, selectVideo)
   const volume = useSelector(videoService, selectVolume)
   const cueFormElem = useSelector(videoService, selectCueFormElem)
   const shortcutsEnabled = useSelector(videoService, selectShortcutsEnabled)
@@ -50,6 +53,7 @@ const useShortcutState = () => {
     volume,
     cueFormElem,
     shortcutsEnabled,
+    video,
   }
 }
 
@@ -58,12 +62,15 @@ const useShortcutState = () => {
  * @param clickable
  * @param dblclickable
  * @param props
+ * @param canAddNotes
+ * @param enableGlobalShortcuts
  * @constructor
  */
 export const Shortcut: React.FC<ShortcutProps> = ({
   clickable = true,
   dblclickable = true,
   canAddNotes = false,
+  enableGlobalShortcuts,
   ...props
 }) => {
   const {
@@ -445,15 +452,35 @@ export const Shortcut: React.FC<ShortcutProps> = ({
 
   React.useEffect(() => {
     shortCutsRef.current = mergeShortcuts()
-    document.addEventListener('keydown', handleKeyPress)
-    document.addEventListener('click', handleClick)
-    document.addEventListener('dblclick', handleDoubleClick)
-    return () => {
-      document.removeEventListener('keydown', handleKeyPress)
-      document.removeEventListener('click', handleClick)
-      document.removeEventListener('dblclick', handleDoubleClick)
+    if (!enableGlobalShortcuts && rootElem) {
+      rootElem.addEventListener('keydown', handleKeyPress)
+      rootElem.addEventListener('click', handleClick)
+      rootElem.addEventListener('dblclick', handleDoubleClick)
+
+      return () => {
+        rootElem.removeEventListener('keydown', handleKeyPress)
+        rootElem.removeEventListener('click', handleClick)
+        rootElem.removeEventListener('dblclick', handleDoubleClick)
+      }
+    } else {
+      document.addEventListener('keydown', handleKeyPress)
+      document.addEventListener('click', handleClick)
+      document.addEventListener('dblclick', handleDoubleClick)
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyPress)
+        document.removeEventListener('click', handleClick)
+        document.removeEventListener('dblclick', handleDoubleClick)
+      }
     }
-  }, [handleClick, handleDoubleClick, handleKeyPress, mergeShortcuts])
+  }, [
+    handleClick,
+    handleDoubleClick,
+    handleKeyPress,
+    mergeShortcuts,
+    rootElem,
+    enableGlobalShortcuts,
+  ])
 
   return null
 }

--- a/packages/player/src/selectors/index.ts
+++ b/packages/player/src/selectors/index.ts
@@ -22,8 +22,10 @@ export const selectFormattedTime = (state: StateFrom<typeof videoMachine>) =>
 export const selectResource = (state: StateFrom<typeof videoMachine>) =>
   state.context.resource ?? {}
 
-export const selectRootElem = (state: StateFrom<typeof videoMachine>) =>
-  state.context.rootElemRef?.current ?? null
+export const selectRootElem = (state: StateFrom<typeof videoMachine>) => {
+  // @ts-ignore
+  return state.context.rootElemRef?.node.current ?? null
+}
 
 export const selectCueFormElem = (state: StateFrom<typeof videoMachine>) =>
   state.context.cueFormElemRef?.current ?? null

--- a/packages/player/src/styles/scss/components/control-bar.scss
+++ b/packages/player/src/styles/scss/components/control-bar.scss
@@ -8,7 +8,7 @@
   position: relative;
   background: $cueplayer-react-primary-background-color;
   .cueplayer-react-control {
-    height: auto;
+    height: 2.5rem;
   }
 }
 


### PR DESCRIPTION
using `<Player enableGlobalShortcuts={false} ...` will switch shortcut events listener from `document` to player's `rootEl`. useful when there are multiple players on a single page. without this, using shortcuts would affect every player instance on page at the same time.

<img src="https://media.giphy.com/media/XjlNyeZp5lDri/giphy-downsized.gif" width="200">