### PR TITLE
Adds a transcript markdown field to the podcastEpisode document in badass sanity studio

### DIFF
--- a/apps/badass/studio/schemas/documents/podcastEpisode.js
+++ b/apps/badass/studio/schemas/documents/podcastEpisode.js
@@ -122,6 +122,13 @@ export default {
       title: 'Cover art',
       type: 'image',
     },
+    {
+      name: 'transcript',
+      title: 'Transcript',
+      description:
+        'A markdown transcript of the episode recording.',
+      type: 'markdown',
+    },
   ],
   orderings: [
     {


### PR DESCRIPTION
![podcast](https://media0.giphy.com/media/7KafclAf3ioGa6kA6v/giphy.gif?cid=01d288b0g30msaheu2adpr3rzw4q4sgkztpkvv3gjs8gcixy&rid=giphy.gif&ct=g)