### PR TITLE
feat: register css and jsx with Refractor

### DIFF
--- a/apps/testingaccessibility/src/components/portable-text/index.tsx
+++ b/apps/testingaccessibility/src/components/portable-text/index.tsx
@@ -25,11 +25,15 @@ import Refractor from 'react-refractor'
 import js from 'refractor/lang/javascript'
 import markdown from 'refractor/lang/markdown'
 import yaml from 'refractor/lang/yaml'
+import jsx from 'refractor/lang/jsx'
+import css from 'refractor/lang/css'
 import Spinner from 'components/spinner'
 
 Refractor.registerLanguage(js)
 Refractor.registerLanguage(markdown)
+Refractor.registerLanguage(jsx)
 Refractor.registerLanguage(yaml)
+Refractor.registerLanguage(css)
 
 const Video: React.FC<{url: string; title: string}> = ({url, title}) => {
   const fullscreenWrapperRef = React.useRef<HTMLDivElement>(null)


### PR DESCRIPTION
I used these languages in code blocks and it is required that they are registered with Refractor

![light refract](https://media4.giphy.com/media/W6oaT50Bz3lMUTmtgr/giphy.gif?cid=01d288b0pl4b98puxg0xamq0kj0f5owxc2weiymv7f26tatf&rid=giphy.gif&ct=g)