### PR TITLE
fix: reducing files size in pricing function to reduce start time

### DIFF
--- a/apps/testingaccessibility/src/lib/prisma-api.ts
+++ b/apps/testingaccessibility/src/lib/prisma-api.ts
@@ -3,7 +3,6 @@ import {Context, defaultContext} from './context'
 import {v4} from 'uuid'
 import {SpanContext} from '@vercel/tracing-js'
 import {tracer} from '../utils/honeycomb-tracer'
-import prisma from '../db'
 
 type SDKOptions = {ctx?: Context; spanContext?: SpanContext}
 

--- a/apps/testingaccessibility/src/utils/format-prices-for-product.ts
+++ b/apps/testingaccessibility/src/utils/format-prices-for-product.ts
@@ -3,7 +3,6 @@ import {getBulkDiscountPercent} from './bulk-coupon'
 import {getCalculatedPriced} from './get-calculated-price'
 import {getSdk} from '../lib/prisma-api'
 import {Context, defaultContext} from '../lib/context'
-import {SpanContext} from '@vercel/tracing-js'
 
 // 10% premium for an upgrade
 // TODO: Display Coupon Errors
@@ -49,7 +48,6 @@ export type FormattedPrice = {
  */
 export async function formatPricesForProduct(
   options: FormatPricesForProductOptions,
-  childOf?: SpanContext,
 ): Promise<FormattedPrice> {
   const {ctx = defaultContext, ...noContextOptions} = options
   const {
@@ -62,7 +60,7 @@ export async function formatPricesForProduct(
   } = noContextOptions
 
   const {getProduct, getMerchantCoupon, getCoupon, getPrice, getPurchase} =
-    getSdk({ctx, spanContext: childOf})
+    getSdk({ctx})
 
   const upgradeFromPurchase = upgradeFromPurchaseId
     ? await getPurchase({


### PR DESCRIPTION
I notice that the /buy route on testing accessibility is slow to start up so this PR is to test.

![cold start](https://media.giphy.com/media/KePKsTrw11HMPK9LHF/giphy-downsized.gif)