### PR TITLE
feat: add videoResource to testing accessibility sanity schema

### DIFF
--- a/apps/testingaccessibility/studio/deskStructure.js
+++ b/apps/testingaccessibility/studio/deskStructure.js
@@ -6,6 +6,7 @@ import sections from './src/structure/sections'
 import lessons from './src/structure/lessons'
 import modules from './src/structure/modules'
 import products from './src/structure/products'
+import videoResources from './src/structure/videoResources'
 
 const hiddenDocTypes = (listItem) =>
   ![
@@ -15,6 +16,7 @@ const hiddenDocTypes = (listItem) =>
     'module',
     'section',
     'lesson',
+    'videoResource',
     'tag',
     'article',
   ].includes(listItem.getId())
@@ -29,6 +31,7 @@ export default () =>
       modules,
       sections,
       lessons,
+      videoResources,
       S.divider(),
       workshops,
       articles,

--- a/apps/testingaccessibility/studio/schemas/documents/videoResource.js
+++ b/apps/testingaccessibility/studio/schemas/documents/videoResource.js
@@ -1,0 +1,32 @@
+export default {
+  title: 'Video Resource',
+  name: 'videoResource',
+  type: 'document',
+  fields: [
+    {
+      title: 'Title',
+      name: 'title',
+      type: 'string',
+    },
+    {
+      title: 'Description',
+      name: 'description',
+      type: 'body',
+    },
+    {
+      title: 'MUX Media URL',
+      name: 'muxMediaUrl',
+      type: 'url',
+    },
+    {
+      title: 'SRT File',
+      name: 'srtFile',
+      type: 'file',
+    },
+    {
+      title: 'Transcript',
+      name: 'transcript',
+      type: 'mediaCaption',
+    },
+  ],
+}

--- a/apps/testingaccessibility/studio/schemas/documents/videoResource.js
+++ b/apps/testingaccessibility/studio/schemas/documents/videoResource.js
@@ -14,8 +14,8 @@ export default {
       type: 'body',
     },
     {
-      title: 'MUX Media URL',
-      name: 'muxMediaUrl',
+      title: 'Media URL',
+      name: 'mediaUrl',
       type: 'url',
     },
     {

--- a/apps/testingaccessibility/studio/schemas/objects/bodyVideo.js
+++ b/apps/testingaccessibility/studio/schemas/objects/bodyVideo.js
@@ -29,11 +29,23 @@ export default {
       type: 'mediaCaption',
       validation: (Rule) => Rule.required(),
     },
+    {
+      name: 'videoResource',
+      title: 'Video Resource',
+      type: 'reference',
+      to: [{type: 'videoResource'}],
+    },
   ],
   preview: {
-    select: {url: 'url', title: 'title', transcript: 'caption'},
+    select: {
+      url: 'url',
+      title: 'title',
+      transcript: 'caption',
+      // An example for how to access values from references
+      // videoTitle: 'videoResource.title'
+    },
     component: ({value}) => {
-      const {url, transcript, title} = value
+      const {url, transcript, title, videoTitle} = value
       const poster =
         url &&
         url

--- a/apps/testingaccessibility/studio/schemas/schema.js
+++ b/apps/testingaccessibility/studio/schemas/schema.js
@@ -24,6 +24,7 @@ import feature from './objects/feature'
 import externalImage from './objects/externalImage'
 import callout from './objects/callout'
 import divider from './objects/divider'
+import videoResource from './documents/videoResource'
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default createSchema({
@@ -43,6 +44,7 @@ export default createSchema({
     section,
     lesson,
     tag,
+    videoResource,
     // objects
     body,
     bodyVideo,

--- a/apps/testingaccessibility/studio/src/structure/videoResources.js
+++ b/apps/testingaccessibility/studio/src/structure/videoResources.js
@@ -1,0 +1,9 @@
+import S from '@sanity/desk-tool/structure-builder'
+import {HiOutlineVideoCamera} from 'react-icons/hi'
+
+const videoResources = S.listItem()
+  .title('Video Resources')
+  .icon(HiOutlineVideoCamera)
+  .child(S.documentTypeList('videoResource').title('All Video Resources'))
+
+export default videoResources


### PR DESCRIPTION
This completes the schema side of things for migrating videos from inline objects to their own documents.

Next step is to write a script migrating existing data over to these documents, and also making sure to replace the inline objects with refs pointed to the correct documents. 

![script](https://media0.giphy.com/media/26tn33aiTi1jkl6H6/giphy.gif?cid=01d288b03lnag4f1ah0pxs9blhkjh12dwsx2gws2czc6p9d2&rid=giphy.gif&ct=g)