### PR TITLE
fix(testingaccessibility): checkout `expires_at`

### DIFF
--- a/apps/testingaccessibility/src/pages/api/stripe/checkout.ts
+++ b/apps/testingaccessibility/src/pages/api/stripe/checkout.ts
@@ -192,7 +192,8 @@ export default withSentry(async function stripeCheckoutHandler(
             quantity: Number(quantity),
           },
         ],
-        expires_at: TWENTY_FOUR_HOURS_FROM_NOW,
+        // This resulted in error: "The `expires_at` timestamp must be at least 60 minutes from Checkout Session creation."
+        // expires_at: TWENTY_FOUR_HOURS_FROM_NOW,
         payment_method_types: ['card'],
         mode: 'payment',
         success_url: successUrl,


### PR DESCRIPTION
This fixes following error on checkout reported by a user which I was able to confirm.

```json
{"error":true,"message":"The `expires_at` timestamp must be at least 60 minutes from Checkout Session creation."}
```

from docs: 
`expires_at` The Epoch time in seconds at which the Checkout Session will expire. It can be anywhere from 1 to 24 hours after Checkout Session creation. **By default, this value is 24 hours from creation.**

--- 

We might not need to overwrite this since the default already is 24 hours from session creation?

