### PR TITLE
feat: load srt from sanity

### DIFF
--- a/apps/testingaccessibility/src/components/portable-text/index.tsx
+++ b/apps/testingaccessibility/src/components/portable-text/index.tsx
@@ -36,7 +36,11 @@ Refractor.registerLanguage(jsx)
 Refractor.registerLanguage(yaml)
 Refractor.registerLanguage(css)
 
-const Video: React.FC<{url: string; title: string}> = ({url, title}) => {
+const Video: React.FC<{
+  url: string
+  title: string
+  videoResource: {_ref: string}
+}> = ({url, title, videoResource}) => {
   const fullscreenWrapperRef = React.useRef<HTMLDivElement>(null)
   const videoService: any = useVideo()
   const isFullscreen = useSelector(videoService, selectIsFullscreen)
@@ -67,6 +71,14 @@ const Video: React.FC<{url: string; title: string}> = ({url, title}) => {
             poster={poster}
           >
             {url && <HLSSource src={url} />}
+            {videoResource && (
+              <track
+                label="English"
+                kind="subtitles"
+                srcLang="en"
+                src={`/api/srt/${videoResource._ref}`}
+              />
+            )}
           </Player>
         </div>
       </div>
@@ -214,11 +226,11 @@ const PortableTextComponents: PortableTextComponentsProps = {
   },
   types: {
     bodyVideo: ({value}: BodyVideoProps) => {
-      const {url, title, caption} = value
+      const {url, title, caption, videoResource} = value
       return (
         <figure className="video">
           <VideoProvider>
-            <Video url={url} title={title} />
+            <Video url={url} title={title} videoResource={videoResource} />
           </VideoProvider>
           <figcaption>
             <details className="group marker:text-transparent no-marker">
@@ -337,6 +349,9 @@ type BodyVideoProps = {
     url: string
     title: string
     caption: PortableTextBlock | ArbitraryTypedObject
+    videoResource: {
+      _ref: string
+    }
   }
 }
 

--- a/apps/testingaccessibility/src/pages/api/srt/[videoResourceId].ts
+++ b/apps/testingaccessibility/src/pages/api/srt/[videoResourceId].ts
@@ -1,0 +1,42 @@
+import {NextApiRequest, NextApiResponse} from 'next'
+import {withSentry} from '@sentry/nextjs'
+import {sanityClient} from 'utils/sanity-client'
+
+const srt = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method === 'GET') {
+    try {
+      const {videoResourceId} = req.query
+
+      const videoResource = await sanityClient
+        .fetch(
+          `*[_type == "videoResource" && _id == "${videoResourceId}"][0]{srt}`,
+        )
+        .catch((error) => {
+          console.error(error)
+          res.status(500).end()
+        })
+
+      if (videoResource?.srt) {
+        const webvtt = `WEBVTT \n\n${videoResource?.srt
+          .replace(/,/gi, '.')
+          .trim()}`
+        res.setHeader('Content-Type', 'text/vtt')
+        res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate')
+        res.status(200).send(webvtt)
+      } else {
+        res.status(200).end()
+      }
+    } catch (error) {}
+  } else {
+    console.error('non-get request made')
+    res.status(404).end()
+  }
+}
+
+export default withSentry(srt)
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+}

--- a/apps/testingaccessibility/studio/schemas/documents/videoResource.js
+++ b/apps/testingaccessibility/studio/schemas/documents/videoResource.js
@@ -19,9 +19,9 @@ export default {
       type: 'url',
     },
     {
-      title: 'SRT File',
-      name: 'srtFile',
-      type: 'file',
+      title: 'SRT',
+      name: 'srt',
+      type: 'text',
     },
     {
       title: 'Transcript',


### PR DESCRIPTION
https://testingaccessibility.sanity.studio/desk/videoResources;1ae99cd3-c636-4355-9095-b9f31b51ef51

I only affected this one video resource.

It's for this lesson -> http://localhost:3013/learn/semantics-and-aria/build-page-structure-through-headings-and-semantic-landmark-elements/a-note-about-the-header-landmark-solution

For the VideoResource I think using this type of "backlink" has a lot of potential https://www.sanity.io/schemas/list-referring-documents-backlinks-in-sanity-1a8ada64

![subtitles](https://media.giphy.com/media/zvpJTO5XnNENyrJbIP/giphy.gif)