### PR TITLE
Hide article dates on TA

### DIFF
--- a/apps/testingaccessibility/src/pages/articles.tsx
+++ b/apps/testingaccessibility/src/pages/articles.tsx
@@ -47,7 +47,7 @@ const Articles: React.FC<ArticlesProps> = ({articles}) => {
                             dateTime={date}
                             className="block pt-3 text-sm font-medium opacity-80 pb-5"
                           >
-                            {format(new Date(date), 'dd MMMM, y')}
+                            {format(new Date(date), 'MMMM dd, y')}
                           </time>
                           {description && (
                             <Markdown className="prose pt-3 pb-6">

--- a/apps/testingaccessibility/src/pages/articles.tsx
+++ b/apps/testingaccessibility/src/pages/articles.tsx
@@ -43,12 +43,12 @@ const Articles: React.FC<ArticlesProps> = ({articles}) => {
                               </h2>
                             </a>
                           </Link>
-                          <time
+                          {/* <time
                             dateTime={date}
                             className="block pt-3 text-sm font-medium opacity-80 pb-5"
                           >
                             {format(new Date(date), 'MMMM dd, y')}
-                          </time>
+                          </time> */}
                           {description && (
                             <Markdown className="prose pt-3 pb-6">
                               {description}

--- a/apps/testingaccessibility/src/templates/article-template.tsx
+++ b/apps/testingaccessibility/src/templates/article-template.tsx
@@ -93,13 +93,13 @@ const Header: React.FC<{title: string; date: string}> = ({title, date}) => {
         <div className="lg:px-0 px-5 w-full flex md:flex-row flex-col md:space-y-0 space-y-3 items-center justify-between max-w-screen-sm">
           <Author />
           <div className="flex space-x-5 items-center">
-            <time dateTime={date} className="text-sm flex items-center">
+            {/* <time dateTime={date} className="text-sm flex items-center">
               <CalendarIcon aria-hidden="true" className="w-4 opacity-80" />{' '}
               <span className="sr-only">published on </span>
               <span className="pl-1">
-                {format(new Date(date), 'dd MMMM, y')}
+                {format(new Date(date), 'MMMM dd, y')}
               </span>
-            </time>
+            </time> */}
             <Share title={title} />
           </div>
         </div>


### PR DESCRIPTION
* Changes article page & template date formatting from `22 June, 2022` to `June 22, 2022`
* Hide publish dates from articles index and pages

Before:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/2262858/180490763-0e376c71-0d92-4f41-baca-6069c365a32e.png">

After:
<img width="532" alt="image" src="https://user-images.githubusercontent.com/2262858/180490694-1ee10d25-2d25-4467-b5d5-75c49180f495.png">


![skeleton arm pulling calendar pages](https://media.giphy.com/media/ipMj7kerASRXO/giphy.gif)

