### PR TITLE
fix(protailwind): the wrong answer was specified as the correct one

### DIFF
--- a/apps/protailwind/src/pages/answer.tsx
+++ b/apps/protailwind/src/pages/answer.tsx
@@ -47,7 +47,7 @@ export async function getStaticProps() {
         'When using multiple themes, how is the theme for a given HTML element determined?',
       type: 'multiple-choice',
       tagId: 3232321,
-      correct: 'body-data-theme',
+      correct: 'nearest-parent',
       choices: [
         {
           answer: 'body-data-theme',


### PR DESCRIPTION
Had the wrong answer specified. Now it's the right one.