### PR TITLE
feat(ta): fix videoplayer frame

### DIFF
--- a/apps/testingaccessibility/src/components/portable-text/index.tsx
+++ b/apps/testingaccessibility/src/components/portable-text/index.tsx
@@ -55,7 +55,7 @@ const Video: React.FC<
     .replace('stream.mux.com', 'image.mux.com')
     .replace('.m3u8', '/thumbnail.png?width=1600&height=1000&fit_mode=pad')
   return isMounted ? (
-    <div className="">
+    <div className="not-prose">
       {title && (
         <strong className="font-semibold inline-block pb-2">
           <span className="sr-only">Video:</span> {title}


### PR DESCRIPTION
It seems that the only thing to fix it was add the `not-prose` class to `video` portable-text component. 

before:
![before](https://user-images.githubusercontent.com/1519448/183754619-fee48bd7-e90a-4bb8-b22d-b8e6b9a9c6be.jpg)

after:
![after](https://user-images.githubusercontent.com/1519448/183754648-0132b52b-aa4e-450b-b1a0-b9be54049e9f.jpg)

