### PR TITLE
fix(ta): set up word breakes

### DIFF
--- a/apps/testingaccessibility/src/components/portable-text/index.tsx
+++ b/apps/testingaccessibility/src/components/portable-text/index.tsx
@@ -270,7 +270,10 @@ const PortableTextComponents: PortableTextComponentsProps = {
           >
             <code>{code}</code>
           </pre>
-          <pre aria-hidden="true">
+          <pre
+            aria-hidden="true"
+            className="rounded-none sm:rounded-md lg:rounded-lg"
+          >
             <Refractor
               inline
               language={

--- a/apps/testingaccessibility/src/templates/article-template.tsx
+++ b/apps/testingaccessibility/src/templates/article-template.tsx
@@ -52,7 +52,7 @@ const ArticleTemplate: React.FC<
         <div>
           <div className="max-w-screen-md mx-auto w-full">
             <div className="md:py-16 py-10">
-              <article className="max-w-none prose-p:max-w-screen-md prose-ul:sm:pr-0 prose-ul:pr-5 prose-p:w-full lg:prose-p:px-0 prose-p:px-5 md:prose-headings:px-0 prose-headings:px-5 prose-headings:max-w-screen-sm prose-p:mx-auto prose-headings:mx-auto prose-ul:max-w-screen-sm prose-ul:mx-auto text-gray-800 prose prose-lg prose-h2:max-w-[30ch] prose-h2:font-bold prose-h2:pt-0 prose-headings:py-8 prose-p:font-sans prose-li:font-sans prose-h2:font-heading prose-h3:font-heading prose-h3:font-semibold prose-headings:text-center sm:prose-h3:pt-10 prose-h3:pt-0 sm:prose-h3:pb-14 prose-h3:pb-5 sm:prose-h3:max-w-[35ch] prose-h3:max-w-[30ch] prose-h3:mx-auto  lg:prose-xl">
+              <article className="max-w-none prose-p:max-w-screen-md prose-ul:sm:pr-0 prose-ul:pr-5 prose-p:w-full lg:prose-p:px-0 prose-p:px-5 md:prose-headings:px-0 prose-headings:px-5 prose-headings:max-w-screen-sm prose-p:mx-auto prose-headings:mx-auto prose-ul:max-w-screen-sm prose-ul:mx-auto text-gray-800 prose prose-lg prose-h2:max-w-[30ch] prose-h2:font-bold prose-h2:pt-0 prose-headings:py-8 prose-p:font-sans prose-li:font-sans prose-h2:font-heading prose-h3:font-heading prose-h3:font-semibold prose-headings:text-center sm:prose-h3:pt-10 prose-h3:pt-0 sm:prose-h3:pb-14 prose-h3:pb-5 sm:prose-h3:max-w-[35ch] prose-h3:max-w-[30ch] prose-h3:mx-auto lg:prose-xl break-words">
                 <PortableText
                   value={body}
                   components={PortableTextComponents}


### PR DESCRIPTION
Long words broke the page on mobile:
![reason](https://user-images.githubusercontent.com/1519448/184510387-3e18670f-8714-405c-9a9e-a6368667fde2.jpg)

Also removed border-radius for the code blocks in mobile:
<details>
  <summary>Before</summary>
  <img width="400" src="https://user-images.githubusercontent.com/1519448/184510431-47d1a960-1667-474e-9343-2d781f7449a7.jpg">
</details>
<details>
  <summary>After</summary>
  <img width="400" src="https://user-images.githubusercontent.com/1519448/184510433-3f143ae8-22e6-4c71-a335-235f516d8478.jpg">
</details>

![Wedding Crashers Lol GIF by La Guarimba Film Festival](https://user-images.githubusercontent.com/1519448/184510673-9a6143b2-3044-4b7c-b34b-310f8215977c.gif)

