### PR TITLE
fix(typescriptcourse): fix og image

### DIFF
--- a/apps/typescriptcourse/src/config.js
+++ b/apps/typescriptcourse/src/config.js
@@ -31,11 +31,6 @@ export default {
         width: 1200,
         height: 640,
       },
-      {
-        url: 'https://typescriptcourse.com/images/share/card-articles@2x.png',
-        width: 1200,
-        height: 640,
-      },
     ],
   },
 }

--- a/apps/typescriptcourse/src/pages/articles.tsx
+++ b/apps/typescriptcourse/src/pages/articles.tsx
@@ -4,10 +4,13 @@ import {GetServerSideProps} from 'next'
 import {SanityDocument} from '@sanity/client'
 import {getAllArticles} from '../lib/articles'
 import Layout from 'components/app/layout'
-import config from '../config'
 const meta = {
   title: 'TypeScript Articles',
-  ogImage: config.openGraph.images[1],
+  ogImage: {
+    url: 'https://typescriptcourse.com/images/share/card-articles@2x.png',
+    width: 1200,
+    height: 640,
+  },
 }
 
 type ArticlesProps = {


### PR DESCRIPTION
Fixes the previous [fix](https://github.com/skillrecordings/products/pull/419) :

`og-image` attribute got duplicated.

![fix-og](https://user-images.githubusercontent.com/1519448/185272652-c2adf47e-15f2-4e09-80eb-abedb8595679.jpg)

after fix:
 
![after-fix](https://user-images.githubusercontent.com/1519448/185272783-b93235da-7a31-4890-9d86-d5f9295805fd.jpg)

![No Frustrated GIF](https://user-images.githubusercontent.com/1519448/185272386-8701e27f-cb66-4519-b347-8843e13ec394.gif)

