### PR TITLE
fix(testingaccessibility): break long word

### DIFF
--- a/apps/testingaccessibility/src/templates/article-template.tsx
+++ b/apps/testingaccessibility/src/templates/article-template.tsx
@@ -52,7 +52,7 @@ const ArticleTemplate: React.FC<
         <div>
           <div className="max-w-screen-md mx-auto w-full">
             <div className="md:py-16 py-10">
-              <article className="max-w-none prose-p:max-w-screen-md prose-ul:sm:pr-0 prose-ul:pr-5 prose-p:w-full lg:prose-p:px-0 prose-p:px-5 md:prose-headings:px-0 prose-headings:px-5 prose-headings:max-w-screen-sm prose-p:mx-auto prose-ul:max-w-screen-sm prose-ul:mx-auto text-gray-800 prose prose-lg prose-h2:max-w-[30ch] prose-h2:font-bold prose-h2:pt-0 prose-p:font-sans prose-li:font-sans prose-h2:font-heading prose-h3:font-heading prose-h3:font-semibold lg:prose-xl">
+              <article className="max-w-none prose-p:max-w-screen-md prose-ul:sm:pr-0 prose-ul:pr-5 prose-p:w-full lg:prose-p:px-0 prose-p:px-5 md:prose-headings:px-0 prose-headings:px-5 prose-headings:max-w-screen-sm prose-p:mx-auto prose-ul:max-w-screen-sm prose-ul:mx-auto text-gray-800 prose prose-lg prose-h2:max-w-[30ch] prose-h2:font-bold prose-h2:pt-0 prose-p:font-sans prose-li:font-sans prose-h2:font-heading prose-h3:font-heading prose-h3:font-semibold lg:prose-xl break-words">
                 <PortableText
                   value={body}
                   components={PortableTextComponents}


### PR DESCRIPTION
fixes this:
![image](https://user-images.githubusercontent.com/1519448/187310594-0414f9b9-d3a8-4bf7-8d65-8acec62ee1b3.png)

after fix:
![Image 2022-08-29 at 15 35 40](https://user-images.githubusercontent.com/1519448/187310794-abe5dabc-985b-403a-a108-a359d4706eea.jpg)


![giphy](https://user-images.githubusercontent.com/1519448/187310665-2644e035-2521-4b30-9db2-b1b1a9a49803.gif)
