### PR TITLE
fix(typescriptcourse): break long words + styles tweaks

### DIFF
--- a/apps/typescriptcourse/src/pages/articles.tsx
+++ b/apps/typescriptcourse/src/pages/articles.tsx
@@ -22,7 +22,7 @@ const Articles: React.FC<React.PropsWithChildren<ArticlesProps>> = ({
 }) => {
   return (
     <Layout meta={meta} className="relative">
-      <header className="relative px-5 overflow-hidden text-white py-28 bg-noise">
+      <header className="relative px-5 overflow-hidden text-white py-28">
         <h1 className="max-w-screen-md mx-auto text-3xl font-bold leading-none text-center font-heading sm:text-4xl lg:text-5xl">
           Written Resources for Navigating the
           <span className="text-transparent bg-gradient-to-l from-purple-100 to-blue-400 bg-clip-text decoration-clone">

--- a/apps/typescriptcourse/src/pages/articles.tsx
+++ b/apps/typescriptcourse/src/pages/articles.tsx
@@ -22,7 +22,7 @@ const Articles: React.FC<React.PropsWithChildren<ArticlesProps>> = ({
 }) => {
   return (
     <Layout meta={meta} className="relative">
-      <header className="relative px-5 overflow-hidden text-white py-28">
+      <header className="relative px-5 overflow-hidden text-white pt-20 pb-10 md:pt-24 md:pb-16 lg:py-28">
         <h1 className="max-w-screen-md mx-auto text-3xl font-bold leading-none text-center font-heading sm:text-4xl lg:text-5xl">
           Written Resources for Navigating the
           <span className="text-transparent bg-gradient-to-l from-purple-100 to-blue-400 bg-clip-text decoration-clone">

--- a/apps/typescriptcourse/src/pages/confirm.mdx
+++ b/apps/typescriptcourse/src/pages/confirm.mdx
@@ -90,7 +90,7 @@ export default ({children}) => (
       variants={container}
       initial="hidden"
       animate="show"
-      className="mx-auto py-24 text-center max-w-xl relative"
+      className="mx-auto py-24 text-center max-w-xl relative px-5 lg:px-0"
     >
       {children}
     </motion.div>

--- a/apps/typescriptcourse/src/pages/confirmed.mdx
+++ b/apps/typescriptcourse/src/pages/confirmed.mdx
@@ -48,10 +48,7 @@ export const Signature = () => (
 
 export default ({children}) => (
   <Layout footer={null}>
-    <div className="bg-noise" aria-hidden="true">
-      <div className="bg-header" />
-    </div>
-    <div className="prose dark:prose-dark prose-lg mx-auto py-24 relative text-center max-w-sm">
+    <div className="prose dark:prose-dark prose-lg mx-auto py-24 relative text-center max-w-sm px-5 lg:px-0">
       {children}
     </div>
   </Layout>

--- a/apps/typescriptcourse/src/pages/excited.mdx
+++ b/apps/typescriptcourse/src/pages/excited.mdx
@@ -23,7 +23,7 @@ import Layout from '../components/app/layout'
 
 export default ({children}) => (
   <Layout>
-    <div className="prose dark:prose-dark prose-lg mx-auto py-24">
+    <div className="prose dark:prose-dark prose-lg mx-auto py-24 px-5 lg:px-0">
       {children}
     </div>
   </Layout>

--- a/apps/typescriptcourse/src/templates/portable-text-article-template.tsx
+++ b/apps/typescriptcourse/src/templates/portable-text-article-template.tsx
@@ -281,7 +281,7 @@ const PortableTextArticleTemplate: React.FC<
       <main className="mb-36">
         <div className="w-full max-w-screen-sm mx-auto">
           <div className="px-5 pt-10 md:pt-16 lg:px-0">
-            <article className="prose md:prose-lg md:prose-code:text-sm max-w-none">
+            <article className="prose md:prose-lg md:prose-code:text-sm max-w-none break-words">
               <PortableText value={body} components={PortableTextComponents} />
               {!hasSubscribed && subscribersOnly && (
                 <div className="absolute bottom-0 left-0 z-10 w-full bg-gradient-to-t from-white to-transparent h-80" />

--- a/apps/typescriptcourse/src/templates/portable-text-article-template.tsx
+++ b/apps/typescriptcourse/src/templates/portable-text-article-template.tsx
@@ -31,7 +31,7 @@ const Header: React.FC<
   React.PropsWithChildren<{title: string; date: string}>
 > = ({title, date}) => {
   return (
-    <header className="relative flex flex-col items-center px-5 pt-16 pb-8 overflow-hidden text-white bg-noise">
+    <header className="relative flex flex-col items-center px-5 pt-16 pb-8 overflow-hidden text-white">
       <div className="relative z-10 flex flex-col items-center w-full max-w-screen-md mx-auto">
         <Link passHref href="/articles">
           <a className="relative px-4 py-2 text-sm font-normal text-white transition bg-white bg-opacity-0 rounded-full sm:text-base group hover:text-white hover:bg-opacity-10 opacity-80 hover:opacity-90 focus-visible:ring-white focus-visible:opacity-100">


### PR DESCRIPTION
<details>
  <summary>Before:</summary>
  <img width="375" src="https://user-images.githubusercontent.com/1519448/187791192-877603de-1eee-4e11-a905-b1a4508b7d95.jpg">
</details>
<details>
  <summary>After:</summary>
  <img width="375" src="https://user-images.githubusercontent.com/1519448/187791187-9c7e9d17-bc21-42aa-98ee-32735f9b9c2b.jpg">
</details>

![measuring tape measure up GIF](https://user-images.githubusercontent.com/1519448/187791622-5cbc0270-b2c4-45cb-97a0-37eece3a5b22.gif)
