### PR TITLE
feat(tt): ability to mark solution complete

### DIFF
--- a/apps/total-typescript/src/components/lesson-overlay.tsx
+++ b/apps/total-typescript/src/components/lesson-overlay.tsx
@@ -175,15 +175,23 @@ const DefaultOverlay: React.FC<OverlayProps> = ({handlePlay}) => {
         <button
           className="text-lg bg-cyan-600 hover:bg-cyan-500 transition rounded sm:px-5 px-3 sm:py-3 py-1 font-semibold"
           onClick={() => {
-            track('clicked continue', {
+            track('clicked complete', {
               lesson: lesson.slug,
               module: module.slug,
               location: 'lesson',
             })
-            handleContinue(router, module, nextLesson, handlePlay, path)
+            completeLesson(lesson.slug).then(() => {
+              return handleContinue(
+                router,
+                module,
+                nextLesson,
+                handlePlay,
+                path,
+              )
+            })
           }}
         >
-          Continue <span aria-hidden="true">→</span>
+          Complete <span aria-hidden="true">→</span>
         </button>
       </div>
     </OverlayWrapper>
@@ -350,6 +358,12 @@ const BlockedOverlay: React.FC = () => {
 
 export {ExerciseOverlay, DefaultOverlay, FinishedOverlay, BlockedOverlay}
 
+const completeLesson = async (lessonSlug: string) => {
+  return await fetch(`/api/progress/${lessonSlug}`, {
+    method: 'POST',
+  }).then((response) => response.json())
+}
+
 const handleContinue = async (
   router: NextRouter,
   module: SanityDocument,
@@ -357,7 +371,7 @@ const handleContinue = async (
   handlePlay: () => void,
   path: string,
 ) => {
-  await router
+  return await router
     .push({
       query: {module: module.slug, lesson: nextLesson.slug},
       pathname: `${path}/[module]/[lesson]`,

--- a/apps/total-typescript/src/pages/api/progress/[lesson].ts
+++ b/apps/total-typescript/src/pages/api/progress/[lesson].ts
@@ -18,7 +18,7 @@ const lessonProgressHandler = async (
 ) => {
   if (req.method === 'POST') {
     try {
-      const {findOrCreateUser, toggleLessonProgressForUser} = getSdk()
+      const {findOrCreateUser, completeLessonProgressForUser} = getSdk()
       const lessonSlug = req.query.lesson as string
       const subscriberCookie = req.cookies['ck_subscriber']
 
@@ -36,7 +36,7 @@ const lessonProgressHandler = async (
 
       const {user} = await findOrCreateUser(subscriber.email_address)
 
-      const progress = await toggleLessonProgressForUser({
+      const progress = await completeLessonProgressForUser({
         userId: user.id,
         lessonSlug,
       })

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -175,6 +175,42 @@ export function getSdk(
           })
         : []
     },
+    async completeLessonProgressForUser({
+      userId,
+      lessonSlug,
+    }: {
+      userId: string
+      lessonSlug: string
+    }) {
+      let lessonProgress = await ctx.prisma.lessonProgress.findFirst({
+        where: {
+          userId,
+          lessonSlug,
+        },
+      })
+
+      const now = new Date()
+
+      if (lessonProgress) {
+        lessonProgress = await ctx.prisma.lessonProgress.update({
+          where: {id: lessonProgress.id},
+          data: {
+            completedAt: now,
+            updatedAt: now,
+          },
+        })
+      } else {
+        lessonProgress = await ctx.prisma.lessonProgress.create({
+          data: {
+            userId,
+            lessonSlug,
+            completedAt: now,
+            updatedAt: now,
+          },
+        })
+      }
+      return lessonProgress
+    },
     async toggleLessonProgressForUser({
       userId,
       lessonSlug,


### PR DESCRIPTION
changes the `continue` button to `complete` on the solution page and completes the solution lesson

problem here IMO is that you should be able to mark a `section` as complete instead of lessons because in this case a section is a pair with the solution/exercise so it's better represented by the container. another consideration would be that they might want to mark it complete INSTEAD of watching the solution.

![finish](https://media.giphy.com/media/3o6Mbnll2gudglC3HG/giphy-downsized.gif)