### PR TITLE
fix(ta): correctly determine section progress

### DIFF
--- a/apps/testingaccessibility/src/pages/learn/index.tsx
+++ b/apps/testingaccessibility/src/pages/learn/index.tsx
@@ -140,16 +140,10 @@ const Learn: React.FC<
               </a>
             </Link>
           </header>
-          {/* <h1 className="font-nav text-center text-2xl leading-none font-bold text-white py-10">
-            {title}
-          </h1> */}
           <div className="grid grid-cols-1 gap-16 w-full">
             {modules.map((module: SanityDocument, i: number) => {
               const {title, slug, image, sections} = module
-              const {completedSections, isCompleted} = getModuleProgressForUser(
-                progress,
-                sections,
-              )
+              const {isCompleted} = getModuleProgressForUser(progress, sections)
               return (
                 <ol key={slug} className="text-white">
                   <li className="flex md:flex-row flex-col md:items-start items-center justify-center">
@@ -184,13 +178,10 @@ const Learn: React.FC<
                       <ol className="pt-5 list-none">
                         {sections?.map((section: SanityDocument, i: number) => {
                           const {title} = section
-                          const {isCompleted: isSectionCompleted} =
-                            getSectionProgressForUser(progress, section.lessons)
-
-                          const isCompleted =
-                            isSectionCompleted ??
-                            find(progress, {lessonSlug: section.slug})
-                              ?.completedAt
+                          const {isCompleted} = getSectionProgressForUser(
+                            progress,
+                            section,
+                          )
 
                           return (
                             <li
@@ -235,6 +226,7 @@ const Learn: React.FC<
                             </li>
                           )
                         })}
+
                         {CERTIFICATE_ENABLED && sections?.length > 0 ? (
                           <li
                             key={`certificate-${title}`}

--- a/apps/testingaccessibility/src/templates/module-template.tsx
+++ b/apps/testingaccessibility/src/templates/module-template.tsx
@@ -176,7 +176,7 @@ const Sections: React.FC<React.PropsWithChildren<SectionsProps>> = ({
         const {image} = section
         const {isCompleted: isSectionCompleted} = getSectionProgressForUser(
           progress,
-          section.lessons,
+          section,
         )
 
         const isCompleted =

--- a/apps/testingaccessibility/src/utils/progress.test.ts
+++ b/apps/testingaccessibility/src/utils/progress.test.ts
@@ -5,7 +5,7 @@ import {
 } from './progress'
 import filter from 'lodash/filter'
 import flatMap from 'lodash/flatMap'
-import isNull from 'lodash/isNull'
+import take from 'lodash/take'
 
 const mockLessonProgress = [
   {
@@ -27,18 +27,15 @@ const mockLessonProgress = [
 ]
 
 test('gets section progress for user', async () => {
-  const lessons = flatMap(
-    filter(mockModuleSections, (section: any) => !isNull(section.lessons)),
-    (section) => section.lessons,
-  )
+  const section = mockSection[1]
   const progress = getSectionProgressForUser(
     mockLessonProgress as any,
-    lessons as any,
+    section as any,
   )
 
   expect(progress).toEqual({
-    completedLessons: mockLessonProgress.filter((lesson) => lesson.completedAt),
-    percentCompleted: 15,
+    completedLessons: take(mockLessonProgress, 2),
+    percentCompleted: 50,
     isCompleted: false,
   })
 })
@@ -163,3 +160,4 @@ const mockModules = [
 ]
 
 const mockModuleSections = mockModules.flatMap((module) => module.sections)
+const mockSection = mockModules[0].sections.map((section) => section)

--- a/apps/testingaccessibility/src/utils/progress.ts
+++ b/apps/testingaccessibility/src/utils/progress.ts
@@ -43,7 +43,7 @@ export const getSectionProgressForUser = (
     return {}
   }
 
-  const sectionLessonsSlugs: string[] = section.lessons
+  const sectionLessonsSlugs = section.lessons
     ? section.lessons.map(({slug}: {slug: string}) => slug)
     : [section.slug]
 

--- a/apps/testingaccessibility/src/utils/progress.ts
+++ b/apps/testingaccessibility/src/utils/progress.ts
@@ -37,20 +37,22 @@ export const getLessonProgressForUser = async () =>
 
 export const getSectionProgressForUser = (
   progress: LessonProgress[],
-  sectionLessons: SanityDocument[],
+  section: SanityDocument,
 ) => {
-  if (!progress || !sectionLessons) {
+  if (!progress || !section) {
     return {}
   }
-  // TODO: Since sometimes we can complete a section (index) itself,
-  // make this operate with sections and not just its lessons
-  const sectionLessonsSlugs: string[] = sectionLessons.map(({slug}) => slug)
+
+  const sectionLessonsSlugs: string[] = section.lessons
+    ? section.lessons.map(({slug}: {slug: string}) => slug)
+    : [section.slug]
+
   const completedLessonsInSection = progress.filter(
     ({lessonSlug, completedAt}) =>
       sectionLessonsSlugs.includes(lessonSlug) && completedAt,
   )
 
-  const numberOfLessons = sectionLessons.length
+  const numberOfLessons = sectionLessonsSlugs?.length
   const numberOfCompletedLessons = completedLessonsInSection.length
   const isCompleted =
     numberOfCompletedLessons > 0 && numberOfCompletedLessons === numberOfLessons
@@ -78,8 +80,9 @@ export const getModuleProgressForUser = (
   moduleSections.forEach((section) => {
     const {isCompleted: isSectionCompleted} = getSectionProgressForUser(
       progress,
-      section.lessons,
+      section,
     )
+
     if (isSectionCompleted) {
       return completedSectionsInModule.push(section.slug)
     }


### PR DESCRIPTION
we've had a couple reports from learners that weren't able to get a certificate even though they've clearly completed all sections in a module. this was due to some of the sections not having any lessons which caused progress measuring utility to skip them. this is fixed by including section without lessons in an array which then gets compared to user progress.   

<img width="480" alt="screenshot" src="https://user-images.githubusercontent.com/25487857/189614606-8863cf35-9070-4ca6-a2a3-9671b79f2753.png">

<img src="https://media.giphy.com/media/WRXljwnLWZfpUXiXtZ/giphy.gif" width="150" alt="gif">