### PR TITLE
feat(tt): video loading overlay

### DIFF
--- a/apps/total-typescript/next.config.js
+++ b/apps/total-typescript/next.config.js
@@ -11,6 +11,7 @@ const IMAGE_HOST_DOMAINS = [
   `res.cloudinary.com`,
   `d2eip9sf3oo6c2.cloudfront.net`,
   `cdn.sanity.io`,
+  `image.mux.com`,
   process.env.NEXT_PUBLIC_HOST,
 ]
 

--- a/apps/total-typescript/src/components/exercise-overlay.tsx
+++ b/apps/total-typescript/src/components/exercise-overlay.tsx
@@ -20,10 +20,11 @@ import {sanityClient} from 'utils/sanity-client'
 import {PortableText} from '@portabletext/react'
 import {useQuery} from 'react-query'
 import {trpc} from '../utils/trpc'
+import Spinner from './spinner'
 
 const OverlayWrapper: React.FC<
-  React.PropsWithChildren<{className?: string}>
-> = ({children, className}) => {
+  React.PropsWithChildren<{className?: string; dismissable?: boolean}>
+> = ({children, className, dismissable = true}) => {
   const {setDisplayOverlay, exercise, module} = useMuxPlayer()
 
   return (
@@ -31,20 +32,22 @@ const OverlayWrapper: React.FC<
       id="video-overlay"
       className="relative top-0 left-0 flex items-center justify-center w-full bg-[#070B16] aspect-video"
     >
-      <button
-        className="absolute top-2 right-2 py-2 px-3 z-50 font-medium rounded flex items-center gap-1 hover:bg-gray-800 transition text-gray-200"
-        onClick={() => {
-          track('dismissed video overlay', {
-            lesson: exercise.slug.current,
-            module: module.slug.current,
-            moduleType: module.moduleType,
-            lessonType: exercise._type,
-          })
-          setDisplayOverlay(false)
-        }}
-      >
-        Dismiss <XIcon className="w-5 h-5" aria-hidden="true" />
-      </button>
+      {dismissable && (
+        <button
+          className="absolute top-2 right-2 py-2 px-3 z-50 font-medium rounded flex items-center gap-1 hover:bg-gray-800 transition text-gray-200"
+          onClick={() => {
+            track('dismissed video overlay', {
+              lesson: exercise.slug.current,
+              module: module.slug.current,
+              moduleType: module.moduleType,
+              lessonType: exercise._type,
+            })
+            setDisplayOverlay(false)
+          }}
+        >
+          Dismiss <XIcon className="w-5 h-5" aria-hidden="true" />
+        </button>
+      )}
       <div
         className={cx(
           'z-20 absolute left-0 top-0 w-full h-full flex flex-col items-center justify-center text-center leading-relaxed text-lg',
@@ -401,7 +404,39 @@ const BlockedOverlay: React.FC = () => {
   )
 }
 
-export {ExerciseOverlay, DefaultOverlay, FinishedOverlay, BlockedOverlay}
+type LoadingOverlayProps = {}
+
+const LoadingOverlay: React.FC<LoadingOverlayProps> = () => {
+  const {
+    muxPlayerProps: {playbackId},
+  } = useMuxPlayer()
+  const thumbnail = `https://image.mux.com/${playbackId}/thumbnail.png?width=480&height=384&fit_mode=preserve`
+
+  return (
+    <OverlayWrapper dismissable={false}>
+      <div className="flex items-center justify-center">
+        {playbackId && (
+          <Image
+            src={thumbnail}
+            layout="fill"
+            alt=""
+            aria-hidden="true"
+            className="opacity-50 contrast-125 blur-sm"
+          />
+        )}
+        <Spinner className="absolute" />
+      </div>
+    </OverlayWrapper>
+  )
+}
+
+export {
+  ExerciseOverlay,
+  DefaultOverlay,
+  FinishedOverlay,
+  BlockedOverlay,
+  LoadingOverlay,
+}
 
 const handleContinue = async (
   router: NextRouter,

--- a/apps/total-typescript/src/templates/exercise-template.tsx
+++ b/apps/total-typescript/src/templates/exercise-template.tsx
@@ -21,6 +21,7 @@ import {
   DefaultOverlay,
   FinishedOverlay,
   BlockedOverlay,
+  LoadingOverlay,
 } from 'components/exercise-overlay'
 import Image from 'next/image'
 import {track} from 'utils/analytics'
@@ -140,6 +141,7 @@ const Video: React.FC<any> = React.forwardRef(
       exercise.resources.find(
         (resource: SanityDocument) => resource._type === 'muxVideo',
       )
+
     return (
       <>
         {displayOverlay && (
@@ -165,7 +167,10 @@ const Video: React.FC<any> = React.forwardRef(
           {video ? (
             <MuxPlayer ref={ref} {...(muxPlayerProps as MuxPlayerProps)} />
           ) : (
-            <BlockedOverlay />
+            <>
+              {/* <LoadingOverlay /> */}
+              <BlockedOverlay />
+            </>
           )}
         </div>
       </>


### PR DESCRIPTION
example usage:
```
import {LoadingOverlay} from 'components/exercise-overlay'

{isVideoLoading && <LoadingOverlay />}
```

<img src="https://user-images.githubusercontent.com/25487857/191224824-031d1446-e2a2-4eaf-a199-e61955022d40.png" alt="screenshot of loading overlay" width="600">

<img src="https://media.giphy.com/media/3y0oCOkdKKRi0/giphy.gif" width="200" alt="gif of homer running in circles">