### PR TITLE
fixing the author for badass articles

### DIFF
--- a/apps/badass/src/templates/article-template.tsx
+++ b/apps/badass/src/templates/article-template.tsx
@@ -244,7 +244,7 @@ const Share: React.FC<React.PropsWithChildren<{title: string}>> = ({title}) => {
   const url = process.env.NEXT_PUBLIC_URL + router.asPath
   const className =
     'p-3 hover:bg-white hover:bg-opacity-10 transition rounded-full focus-visible:ring-white'
-  const message = `${title} by @marcysutton`
+  const message = `${title} by @jhooks`
 
   return (
     <div className="flex">


### PR DESCRIPTION
I realized that when someone shares an article from badass.dev the author was marcy, this small PR changes the author for @joelhooks 

<img width="572" alt="Screen Shot 2022-09-20 at 11 47 52 AM" src="https://user-images.githubusercontent.com/43156646/191317340-d13d2fa7-5e8e-45dd-9cfe-fe024908ee6a.png">
