### PR TITLE
feat(tt): updates exercise query for video resource

### DIFF
--- a/apps/total-typescript/src/components/exercise-navigator.tsx
+++ b/apps/total-typescript/src/components/exercise-navigator.tsx
@@ -5,6 +5,7 @@ import {useRouter} from 'next/router'
 import capitalize from 'lodash/capitalize'
 import Link from 'next/link'
 import cx from 'classnames'
+import {Exercise} from '../lib/exercises'
 
 const ExerciseNavigator: React.FC<{
   module: SanityDocument
@@ -28,18 +29,18 @@ const ExerciseNavigator: React.FC<{
     >
       <nav aria-label="exercise navigator">
         <ul className="text-lg flex flex-col divide-y divide-gray-800/0">
-          {module.exercises.map((exercise: any, sectionIdx: number) => {
+          {module.exercises.map((exercise: Exercise, sectionIdx: number) => {
             const isActive =
               router.asPath ===
-              `/tutorials/${module.slug.current}/${exercise.slug.current}`
+              `/tutorials/${module.slug.current}/${exercise.slug}`
             const scrollToElement =
               router.asPath ===
-                `/tutorials/${module.slug.current}/${exercise.slug.current}/solution` ||
+                `/tutorials/${module.slug.current}/${exercise.slug}/solution` ||
               router.asPath ===
-                `/tutorials/${module.slug.current}/${exercise.slug.current}`
+                `/tutorials/${module.slug.current}/${exercise.slug}`
 
             return (
-              <li key={exercise.slug.current} className="pt-2">
+              <li key={exercise.slug} className="pt-2">
                 {scrollToElement && (
                   <div ref={activeElRef} aria-hidden="true" />
                 )}
@@ -48,7 +49,7 @@ const ExerciseNavigator: React.FC<{
                     pathname: `${path}/[module]/[exercise]`,
                     query: {
                       module: module.slug.current,
-                      exercise: exercise.slug.current,
+                      exercise: exercise.slug,
                     },
                   }}
                   passHref
@@ -58,7 +59,7 @@ const ExerciseNavigator: React.FC<{
                     onClick={() => {
                       track('clicked exercise in navigator', {
                         module: module.slug.current,
-                        lesson: exercise.slug.current,
+                        lesson: exercise.slug,
                         moduleType: module.moduleType,
                         lessonType: exercise._type,
                       })
@@ -74,13 +75,13 @@ const ExerciseNavigator: React.FC<{
                   </a>
                 </Link>
                 <ul className="text-gray-300">
-                  <li key={exercise.slug.current + `exercise`}>
+                  <li key={exercise.slug + `exercise`}>
                     <Link
                       href={{
                         pathname: `${path}/[module]/[exercise]`,
                         query: {
                           module: module.slug.current,
-                          exercise: exercise.slug.current,
+                          exercise: exercise.slug,
                         },
                       }}
                       passHref
@@ -97,62 +98,22 @@ const ExerciseNavigator: React.FC<{
                         onClick={() => {
                           track(`clicked exercise in navigator`, {
                             module: module.slug.current,
-                            lesson: exercise.slug.current,
+                            lesson: exercise.slug,
                             location: router.query.lesson,
                             moduleType: module.moduleType,
                             lessonType: exercise._type,
                           })
                         }}
                       >
-                        Exercise
+                        Problem
                       </a>
                     </Link>
                   </li>
-                  {exercise.resources
-                    .filter(
-                      (resource: SanityDocument) =>
-                        resource._type === 'solution',
-                    )
-                    .map((solution: any, i: number) => {
-                      const isActive =
-                        router.asPath ===
-                        `/tutorials/${module.slug.current}/${exercise.slug.current}/solution`
-                      return (
-                        <li key={solution._key}>
-                          <Link
-                            href={{
-                              pathname: `${path}/[module]/[exercise]/solution`,
-                              query: {
-                                module: module.slug.current,
-                                exercise: exercise.slug.current,
-                              },
-                            }}
-                            passHref
-                          >
-                            <a
-                              className={cx(
-                                'flex items-center py-2 px-8 border-l-4 text-base font-medium hover:bg-slate-400/20 hover:text-white transition',
-                                {
-                                  'border-cyan-400 bg-gray-800/80 text-white':
-                                    isActive,
-                                  'border-transparent ': !isActive,
-                                },
-                              )}
-                              onClick={() => {
-                                track(`clicked solution in navigator`, {
-                                  module: module.slug.current,
-                                  lesson: exercise.slug.current,
-                                  moduleType: module.moduleType,
-                                  lessonType: exercise._type,
-                                })
-                              }}
-                            >
-                              {capitalize(solution._type)}
-                            </a>
-                          </Link>
-                        </li>
-                      )
-                    })}
+                  <SolutionLink
+                    module={module}
+                    exercise={exercise}
+                    path={path}
+                  />
                 </ul>
               </li>
             )
@@ -160,6 +121,56 @@ const ExerciseNavigator: React.FC<{
         </ul>
       </nav>
     </div>
+  )
+}
+
+const SolutionLink = ({
+  module,
+  exercise,
+  path,
+}: {
+  module: SanityDocument
+  exercise: Exercise
+  path: string
+}) => {
+  const router = useRouter()
+  const solution = exercise.solution
+  const isActive =
+    router.asPath ===
+    `/tutorials/${module.slug.current}/${exercise.slug}/solution`
+  return (
+    <li key={solution?._key}>
+      <Link
+        href={{
+          pathname: `${path}/[module]/[exercise]/solution`,
+          query: {
+            module: module.slug.current,
+            exercise: exercise.slug,
+          },
+        }}
+        passHref
+      >
+        <a
+          className={cx(
+            'flex items-center py-2 px-8 border-l-4 text-base font-medium hover:bg-slate-400/20 hover:text-white transition',
+            {
+              'border-cyan-400 bg-gray-800/80 text-white': isActive,
+              'border-transparent ': !isActive,
+            },
+          )}
+          onClick={() => {
+            track(`clicked solution in navigator`, {
+              module: module.slug.current,
+              lesson: exercise.slug,
+              moduleType: module.moduleType,
+              lessonType: exercise._type,
+            })
+          }}
+        >
+          {capitalize(solution?._type)}
+        </a>
+      </Link>
+    </li>
   )
 }
 export default ExerciseNavigator

--- a/apps/total-typescript/src/components/exercise-overlay.tsx
+++ b/apps/total-typescript/src/components/exercise-overlay.tsx
@@ -38,7 +38,7 @@ export const OverlayWrapper: React.FC<
           className="absolute top-2 right-2 py-2 px-3 z-50 font-medium rounded flex items-center gap-1 hover:bg-gray-800 transition text-gray-200"
           onClick={() => {
             track('dismissed video overlay', {
-              lesson: lesson.slug.current,
+              lesson: lesson.slug,
               module: module.slug.current,
               moduleType: module.moduleType,
               lessonType: lesson._type,
@@ -68,9 +68,7 @@ type OverlayProps = {
 const ExerciseOverlay: React.FC<OverlayProps> = ({handlePlay}) => {
   const {nextExercise, lesson, module, path} = useMuxPlayer()
   const {github} = module
-  const stackblitz = lesson.resources.find(
-    (resource: SanityDocument) => resource._type === 'stackblitz',
-  )
+  const stackblitz = lesson.stackblitz
   const router = useRouter()
 
   const Actions = () => {
@@ -80,7 +78,7 @@ const ExerciseOverlay: React.FC<OverlayProps> = ({handlePlay}) => {
           className="bg-gray-800 sm:px-5 px-3 sm:py-2 py-1 text-lg font-semibold rounded hover:bg-gray-700 transition"
           onClick={() => {
             track('clicked replay', {
-              lesson: lesson.slug.current,
+              lesson: lesson.slug,
               module: module.slug.current,
               location: 'exercise',
               moduleType: module.moduleType,
@@ -96,7 +94,7 @@ const ExerciseOverlay: React.FC<OverlayProps> = ({handlePlay}) => {
             className="text-lg bg-cyan-600 hover:bg-cyan-500 transition sm:px-5 px-3 sm:py-2 py-1 font-semibold rounded"
             onClick={() => {
               track('clicked continue to solution', {
-                lesson: lesson.slug.current,
+                lesson: lesson.slug,
                 module: module?.slug.current,
                 location: 'exercise',
                 moduleType: module.moduleType,
@@ -132,12 +130,12 @@ const ExerciseOverlay: React.FC<OverlayProps> = ({handlePlay}) => {
           <p className="">
             Try solving this exercise inside{' '}
             <a
-              href={`https://github.com/total-typescript/${github.repo}/blob/main/${stackblitz.openFile}`}
+              href={`https://github.com/total-typescript/${github.repo}/blob/main/${stackblitz}`}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center gap-1 font-mono text-sm py-0.5 px-1 bg-gray-800 rounded-sm"
             >
-              <IconGithub /> {stackblitz.openFile}
+              <IconGithub /> {stackblitz}
             </a>{' '}
             file.
           </p>
@@ -149,12 +147,12 @@ const ExerciseOverlay: React.FC<OverlayProps> = ({handlePlay}) => {
         <p className="">
           Try solving this exercise inside{' '}
           <a
-            href={`https://github.com/total-typescript/${github.repo}/blob/main/${stackblitz.openFile}`}
+            href={`https://github.com/total-typescript/${github.repo}/blob/main/${stackblitz}`}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center justify-center gap-1 font-mono text-sm py-0.5 px-1 bg-gray-800 rounded-sm"
           >
-            <IconGithub /> {stackblitz.openFile}
+            <IconGithub /> {stackblitz}
           </a>{' '}
           file.
         </p>
@@ -195,7 +193,7 @@ const DefaultOverlay: React.FC<OverlayProps> = ({handlePlay}) => {
           className="bg-gray-800 hover:bg-gray-700 transition sm:px-5 px-3 sm:py-3 py-1 text-lg font-semibold rounded"
           onClick={() => {
             track('clicked replay', {
-              lesson: lesson.slug.current,
+              lesson: lesson.slug,
               module: module.slug.current,
               location: 'exercise',
               moduleType: module.moduleType,
@@ -210,14 +208,14 @@ const DefaultOverlay: React.FC<OverlayProps> = ({handlePlay}) => {
           className="text-lg bg-cyan-600 hover:bg-cyan-500 transition rounded sm:px-5 px-3 sm:py-3 py-1 font-semibold"
           onClick={() => {
             track('clicked complete', {
-              lesson: lesson.slug.current,
+              lesson: lesson.slug,
               module: module.slug.current,
               location: 'exercise',
               moduleType: module.moduleType,
               lessonType: lesson._type,
             })
             addProgressMutation.mutate(
-              {lessonSlug: lesson.slug.current},
+              {lessonSlug: lesson.slug},
               {
                 onSettled: (data, error, variables, context) => {
                   handleContinue(router, module, nextExercise, handlePlay, path)
@@ -246,7 +244,7 @@ const FinishedOverlay: React.FC<OverlayProps> = ({handlePlay}) => {
   React.useEffect(() => {
     // since this is the last lesson and we show the "module complete" overlay
     // we run this when the effect renders marking the lesson complete
-    addProgressMutation.mutate({lessonSlug: lesson.slug.current})
+    addProgressMutation.mutate({lessonSlug: lesson.slug})
   }, [])
 
   return (
@@ -328,7 +326,7 @@ const BlockedOverlay: React.FC = () => {
       })
       email && setUserId(email)
       track('subscribed to email list', {
-        lesson: lesson.slug.current,
+        lesson: lesson.slug,
         module: module.slug.current,
         location: 'exercise',
         moduleType: module.moduleType,

--- a/apps/total-typescript/src/hooks/use-mux-player.tsx
+++ b/apps/total-typescript/src/hooks/use-mux-player.tsx
@@ -108,7 +108,7 @@ export const VideoProvider: React.FC<
       defaultHiddenCaptions: true, // TODO: investigate storing subtitles preferences
       // autoPlay,
       streamType: 'on-demand',
-      playbackId: video?.muxPlaybackId,
+      playbackId: video.muxPlaybackId,
       metadata: {
         video_title: `${title} (${lesson._type})`,
       },

--- a/apps/total-typescript/src/hooks/use-mux-player.tsx
+++ b/apps/total-typescript/src/hooks/use-mux-player.tsx
@@ -8,7 +8,6 @@ import {MuxPlayerProps} from '@mux/mux-player-react/*'
 import {track} from '../utils/analytics'
 import {type Exercise, ExerciseSchema} from 'lib/exercises'
 import {type Tip, TipSchema} from 'lib/tips'
-import {useQuery} from 'react-query'
 
 type VideoResource = Exercise | Tip
 
@@ -45,10 +44,7 @@ export const VideoProvider: React.FC<
     usePlayerPrefs()
   const [autoPlay, setAutoPlay] = React.useState(getPlayerPrefs().autoplay)
   const [displayOverlay, setDisplayOverlay] = React.useState(false)
-
-  const {data: video} = useQuery(['video', lesson.slug], async () => {
-    return {muxPlaybackId: lesson.muxPlaybackId}
-  })
+  const video = {muxPlaybackId: lesson.muxPlaybackId}
 
   // console.log({video, lesson}, lesson.resources)
   const title = get(lesson, 'title') || get(lesson, 'label')

--- a/apps/total-typescript/src/hooks/use-mux-player.tsx
+++ b/apps/total-typescript/src/hooks/use-mux-player.tsx
@@ -6,9 +6,9 @@ import {SanityDocument} from '@sanity/client'
 import {useRouter} from 'next/router'
 import {MuxPlayerProps} from '@mux/mux-player-react/*'
 import {track} from '../utils/analytics'
-import {Subscriber} from 'lib/convertkit'
 import {type Exercise, ExerciseSchema} from 'lib/exercises'
 import {type Tip, TipSchema} from 'lib/tips'
+import {useQuery} from 'react-query'
 
 type VideoResource = Exercise | Tip
 
@@ -24,6 +24,7 @@ type VideoContextType = {
   lesson: VideoResource
   module: SanityDocument
   path: string
+  video?: {muxPlaybackId: string | null | undefined}
 }
 
 export const VideoContext = React.createContext({} as VideoContextType)
@@ -44,10 +45,12 @@ export const VideoProvider: React.FC<
     usePlayerPrefs()
   const [autoPlay, setAutoPlay] = React.useState(getPlayerPrefs().autoplay)
   const [displayOverlay, setDisplayOverlay] = React.useState(false)
-  const video = lesson?.resources.find(
-    (resource: SanityDocument) =>
-      resource._type === 'muxVideo' || resource._type === 'videoResource',
-  )
+
+  const {data: video} = useQuery(['video', lesson.slug], async () => {
+    return {muxPlaybackId: lesson.muxPlaybackId}
+  })
+
+  // console.log({video, lesson}, lesson.resources)
   const title = get(lesson, 'title') || get(lesson, 'label')
 
   const handlePlay = () => {
@@ -78,6 +81,7 @@ export const VideoProvider: React.FC<
       muxPlayerRef.current.autoplay = autoplay
     }
   }, [playbackRate, autoPlay, video])
+
   const context = {
     muxPlayerProps: {
       id: 'mux-player',
@@ -85,7 +89,7 @@ export const VideoProvider: React.FC<
         setDisplayOverlay(false)
         track('started lesson video', {
           module: module.slug.current,
-          lesson: lesson.slug.current,
+          lesson: lesson.slug,
           moduleType: module.moduleType,
           lessonType: lesson._type,
         })
@@ -95,7 +99,7 @@ export const VideoProvider: React.FC<
         handleNext(getPlayerPrefs().autoplay)
         track('completed lesson video', {
           module: module.slug.current,
-          lesson: lesson.slug.current,
+          lesson: lesson.slug,
           moduleType: module.moduleType,
           lessonType: lesson._type,
         })
@@ -108,7 +112,7 @@ export const VideoProvider: React.FC<
       defaultHiddenCaptions: true, // TODO: investigate storing subtitles preferences
       // autoPlay,
       streamType: 'on-demand',
-      playbackId: video.muxPlaybackId || video.muxAsset.muxPlaybackId,
+      playbackId: video?.muxPlaybackId,
       metadata: {
         video_title: `${title} (${lesson._type})`,
       },
@@ -125,6 +129,7 @@ export const VideoProvider: React.FC<
         ? TipSchema.parse(lesson)
         : ExerciseSchema.parse(lesson),
     module,
+    video,
     path,
   }
   return (

--- a/apps/total-typescript/src/lib/exercises.ts
+++ b/apps/total-typescript/src/lib/exercises.ts
@@ -8,19 +8,67 @@ export const ExerciseSchema = z.object({
   _type: z.string(),
   _updatedAt: z.string().optional(),
   title: z.string(),
-  slug: z.object({
-    current: z.string(),
-  }),
+  slug: z.string(),
   description: z.nullable(z.string()).optional(),
   body: z.any().array(),
-  resources: z.any().array(),
+  stackblitz: z.string().optional(),
+  muxPlaybackId: z.nullable(z.string()).optional(),
+  transcript: z.nullable(z.any().array()),
+  solution: z
+    .object({
+      _key: z.string(),
+      _type: z.string(),
+      _updatedAt: z.string().optional(),
+      title: z.string(),
+      slug: z.string(),
+      description: z.nullable(z.string()).optional(),
+      body: z.any().array(),
+      stackblitz: z.nullable(z.string()).optional(),
+      muxPlaybackId: z.nullable(z.string()).optional(),
+      transcript: z.nullable(z.any().array()),
+    })
+    .optional(),
 })
 
 export type Exercise = z.infer<typeof ExerciseSchema>
 
+export const getExerciseMuxPlaybackId = async (exerciseSlug: string) => {
+  const exerciseVideo = await sanityClient.fetch(
+    `
+  *[_type == "exercise" && slug.current == $slug][0]
+    .resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId`,
+    {slug: `${exerciseSlug}`},
+  )
+
+  return z.string().nullish().parse(exerciseVideo)
+}
+
 export const getExercise = async (slug: string): Promise<Exercise> => {
   const exercise = await sanityClient.fetch(
-    groq`*[_type == "exercise" && slug.current == $slug][0]`,
+    groq`*[_type == "exercise" && slug.current == $slug][0]{
+      _id,
+      _type,
+      _updatedAt,
+      title,
+      description,
+      body,
+      "slug": slug.current,
+      "stackblitz": resources[@._type == 'stackblitz'][0].openFile,
+      "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
+      "transcript": resources[@->._type == 'videoResource'][0]-> castingwords.transcript,
+      "solution": resources[@._type == 'solution'][0]{
+        _key,
+        _type,
+        "_updatedAt": ^._updatedAt,
+        title,
+        description,
+        body,
+        "stackblitz": resources[@._type == 'stackblitz'][0].openFile,
+        "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
+        "slug": slug.current,
+        "transcript": resources[@->._type == 'videoResource'][0]-> castingwords.transcript,
+      }
+    }`,
     {slug: `${slug}`},
   )
 
@@ -28,7 +76,28 @@ export const getExercise = async (slug: string): Promise<Exercise> => {
 }
 
 export const getAllExercises = async (): Promise<Exercise[]> => {
-  const exercises = await sanityClient.fetch(groq`*[_type == "exercise"]`)
+  const exercises = await sanityClient.fetch(groq`*[_type == "exercise"]{
+      _id,
+      _type,
+      _updatedAt,
+      title,
+      description,
+      body,
+      "slug": slug.current,
+      "stackblitz": resources[@._type == 'stackblitz'][0].openFile,
+      "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
+      "solution": resources[@._type == 'solution'][0]{
+        _key,
+        _type,
+        _updatedAt,
+        title,
+        description,
+        body,
+        "stackblitz": resources[@._type == 'stackblitz'][0].openFile,
+        "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
+       "slug": slug.current
+       }
+    }`)
 
   return z.array(ExerciseSchema).parse(exercises)
 }

--- a/apps/total-typescript/src/lib/tips.ts
+++ b/apps/total-typescript/src/lib/tips.ts
@@ -3,17 +3,17 @@ import groq from 'groq'
 import z from 'zod'
 
 export const TipSchema = z.object({
-  _id: z.string().optional(),
-  _key: z.string().optional(),
+  _id: z.string(),
   _type: z.string(),
   _updatedAt: z.string().optional(),
   title: z.string(),
-  slug: z.object({
-    current: z.string(),
-  }),
+  slug: z.string(),
   description: z.nullable(z.string()).optional(),
   body: z.any().array(),
-  resources: z.any().array(),
+  stackblitz: z.nullable(z.string()).optional(),
+  muxPlaybackId: z.nullable(z.string()).optional(),
+  transcript: z.nullable(z.any().array()),
+  tweetId: z.string(),
 })
 
 export const TipsSchema = z.array(TipSchema)
@@ -23,11 +23,16 @@ export type Tip = z.infer<typeof TipSchema>
 export const getAllTips = async (): Promise<Tip[]> => {
   const tips =
     await sanityClient.fetch(groq`*[_type == "tip"] | order(_createdAt asc) {
-    ...,
-    'resources': resources[]{
-        _type == 'reference' => @->,
-        _type != 'reference' => @,
-    }
+        _id,
+        _type,
+        _updatedAt,
+        title,
+        description,
+        body,
+        "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
+        "slug": slug.current,
+        "transcript": resources[@->._type == 'videoResource'][0]-> castingwords.transcript,
+        "tweetId":  resources[@._type == 'tweet'][0].tweetId
   }`)
 
   return TipsSchema.parse(tips)
@@ -36,14 +41,21 @@ export const getAllTips = async (): Promise<Tip[]> => {
 export const getTip = async (slug: string): Promise<Tip> => {
   const tip = await sanityClient.fetch(
     groq`*[_type == "tip" && slug.current == $slug][0] {
-      ...,
-      'resources': resources[]{
-        _type == 'reference' => @->,
-        _type != 'reference' => @,
-    }
+        _id,
+        _type,
+        _updatedAt,
+        title,
+        description,
+        body,
+        "muxPlaybackId": resources[@->._type == 'videoResource'][0]-> muxAsset.muxPlaybackId,
+        "slug": slug.current,
+        "transcript": resources[@->._type == 'videoResource'][0]-> castingwords.transcript,
+        "tweetId":  resources[@._type == 'tweet'][0].tweetId
     }`,
     {slug: `${slug}`},
   )
+
+  console.log(tip)
 
   return TipSchema.parse(tip)
 }

--- a/apps/total-typescript/src/lib/tips.ts
+++ b/apps/total-typescript/src/lib/tips.ts
@@ -55,7 +55,5 @@ export const getTip = async (slug: string): Promise<Tip> => {
     {slug: `${slug}`},
   )
 
-  console.log(tip)
-
   return TipSchema.parse(tip)
 }

--- a/apps/total-typescript/src/lib/tutorials.ts
+++ b/apps/total-typescript/src/lib/tutorials.ts
@@ -10,7 +10,22 @@ const tutorialsQuery = groq`*[_type == "module" && moduleType == 'tutorial' && s
   _updatedAt,
   _createdAt,
   description,
-  "exercises": resources[@->._type == 'exercise']->,
+  "exercises": resources[@->._type == 'exercise']->{
+    _id,
+    _type,
+    _updatedAt,
+    title,
+    description,
+    "slug": slug.current,
+    "solution": resources[@._type == 'solution'][0]{
+      _key,
+      _type,
+      "_updatedAt": ^._updatedAt,
+      title,
+      description,
+      "slug": slug.current,
+    }
+    }
 }`
 
 export const getAllTutorials = async () =>
@@ -31,7 +46,22 @@ export const getModule = async (slug: string) =>
         ogImage,
         description,
         _updatedAt,
-        "exercises": resources[@->._type == 'exercise']->,
+        "exercises": resources[@->._type == 'exercise']->{
+          _id,
+          _type,
+          _updatedAt,
+          title,
+          description,
+          "slug": slug.current,
+          "solution": resources[@._type == 'solution'][0]{
+            _key,
+            _type,
+            "_updatedAt": ^._updatedAt,
+            title,
+            description,
+            "slug": slug.current,
+          }
+        },
         "image": image.asset->url
     }`,
     {slug: `${slug}`},

--- a/apps/total-typescript/src/pages/tips/[tip].tsx
+++ b/apps/total-typescript/src/pages/tips/[tip].tsx
@@ -19,7 +19,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
 export const getStaticPaths: GetStaticPaths = async () => {
   const tips = await getAllTips()
   const paths = tips.map((tip) => ({
-    params: {tip: tip.slug.current},
+    params: {tip: tip.slug},
   }))
   return {paths, fallback: 'blocking'}
 }

--- a/apps/total-typescript/src/pages/tips/index.tsx
+++ b/apps/total-typescript/src/pages/tips/index.tsx
@@ -47,7 +47,7 @@ const TipsIndex: React.FC<TipsIndex> = ({tips}) => {
       </header>
       <main className="rounded-lg relative z-10 w-full max-w-screen-md mx-auto flex flex-col divide-y divide-gray-800 sm:px-5 px-3 bg-black/30">
         {tips.map((tip) => {
-          return <TipTeaser tip={tip} key={tip.slug.current} />
+          return <TipTeaser tip={tip} key={tip.slug} />
         })}
       </main>
 
@@ -67,10 +67,8 @@ export default TipsIndex
 
 export const TipTeaser: React.FC<{tip: Tip}> = ({tip}) => {
   const {title} = tip
-  const video = tip?.resources.find(
-    (resource: SanityDocument) => resource._type === 'videoResource',
-  )
-  const thumbnail = `https://image.mux.com/${video.muxAsset.muxPlaybackId}/thumbnail.png?width=240&height=135&fit_mode=preserve`
+  const muxPlaybackId = tip?.muxPlaybackId
+  const thumbnail = `https://image.mux.com/${muxPlaybackId}/thumbnail.png?width=240&height=135&fit_mode=preserve`
   const router = useRouter()
 
   return (
@@ -82,7 +80,7 @@ export const TipTeaser: React.FC<{tip: Tip}> = ({tip}) => {
               .push({
                 pathname: '/tips/[tip]',
                 query: {
-                  tip: tip.slug.current,
+                  tip: tip.slug,
                 },
               })
               .then(() => {
@@ -125,7 +123,7 @@ export const TipTeaser: React.FC<{tip: Tip}> = ({tip}) => {
           href={{
             pathname: '/tips/[tip]',
             query: {
-              tip: tip.slug.current,
+              tip: tip.slug,
             },
           }}
         >

--- a/apps/total-typescript/src/pages/tutorials/[module]/[exercise]/index.tsx
+++ b/apps/total-typescript/src/pages/tutorials/[module]/[exercise]/index.tsx
@@ -26,7 +26,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
         return {
           params: {
             module: tutorial.slug.current,
-            exercise: exercise.slug.current,
+            exercise: exercise.slug,
           },
         }
       })

--- a/apps/total-typescript/src/pages/tutorials/[module]/[exercise]/solution.tsx
+++ b/apps/total-typescript/src/pages/tutorials/[module]/[exercise]/solution.tsx
@@ -26,7 +26,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
         return {
           params: {
             module: tutorial.slug.current,
-            exercise: exercise.slug.current,
+            exercise: exercise.slug,
           },
         }
       })

--- a/apps/total-typescript/src/templates/tip-template.tsx
+++ b/apps/total-typescript/src/templates/tip-template.tsx
@@ -30,18 +30,14 @@ const TipTemplate: React.FC<TipPageProps> = ({tip, tips}) => {
     },
     moduleType: 'tip',
     exercises: tips,
-    resources: tips.filter((tip) => tip.slug.current !== tip.slug.current),
+    resources: tips.filter((tip) => tip.slug !== tip.slug),
   }
-  const video = tip?.resources.find(
-    (resource: SanityDocument) => resource._type === 'videoResource',
-  )
-  const tweet = tip?.resources.find(
-    (resource: SanityDocument) => resource._type === 'tweet',
-  )
+  const muxPlaybackId = tip?.muxPlaybackId
+  const tweet = tip?.tweetId
 
   const ogImage = getOgImage({
     title: tip.title,
-    image: `https://image.mux.com/${video.muxAsset.muxPlaybackId}/thumbnail.png?width=480&height=270&fit_mode=preserve`,
+    image: `https://image.mux.com/${muxPlaybackId}/thumbnail.png?width=480&height=270&fit_mode=preserve`,
   })
 
   return (
@@ -77,9 +73,12 @@ const TipTemplate: React.FC<TipPageProps> = ({tip, tips}) => {
               </div>
             </article>
             <div className="flex md:flex-row flex-col max-w-screen-xl mx-auto w-full sm:pt-10 pt-4 gap-10">
-              {video.castingwords.transcript && (
+              {tip.transcript && (
                 <div className="max-w-2xl w-full">
-                  <Transcript video={video} muxPlayerRef={muxPlayerRef} />
+                  <Transcript
+                    transcript={tip.transcript}
+                    muxPlayerRef={muxPlayerRef}
+                  />
                 </div>
               )}
               <RelatedTips currentTip={tip} tips={tips} />
@@ -116,17 +115,17 @@ const Video: React.FC<any> = React.forwardRef(({tips}, ref: any) => {
   )
 })
 
-const Transcript: React.FC<{video: any; muxPlayerRef: any}> = ({
-  video,
+const Transcript: React.FC<{transcript: any[]; muxPlayerRef: any}> = ({
+  transcript,
   muxPlayerRef,
 }) => {
-  const {handlePlay} = useMuxPlayer()
+  const {handlePlay, video} = useMuxPlayer()
   return (
     <section aria-label="transcript">
       <h2 className="text-2xl font-semibold">Transcript</h2>
       <div className="prose sm:prose-lg max-w-none prose-p:text-gray-300 pt-4">
         <PortableText
-          value={video.castingwords.transcript}
+          value={transcript}
           components={
             {
               marks: {
@@ -164,9 +163,9 @@ const RelatedTips: React.FC<{tips: Tip[]; currentTip: Tip}> = ({
       <h2 className="text-2xl font-semibold">More Tips</h2>
       <div className="pt-4 flex flex-col divide-y divide-gray-800">
         {tips
-          .filter((tip) => tip.slug.current !== currentTip.slug.current)
+          .filter((tip) => tip.slug !== currentTip.slug)
           .map((tip) => {
-            return <TipTeaser key={tip.slug.current} tip={tip} />
+            return <TipTeaser key={tip.slug} tip={tip} />
           })}
       </div>
     </section>
@@ -198,7 +197,7 @@ const TipOverlay: React.FC<{tips: Tip[]}> = ({tips}) => {
           className={buttonStyles}
           onClick={() => {
             track('dismissed video overlay', {
-              lesson: lesson.slug.current,
+              lesson: lesson.slug,
               module: module.slug.current,
               moduleType: module.moduleType,
               lessonType: lesson._type,
@@ -213,11 +212,9 @@ const TipOverlay: React.FC<{tips: Tip[]}> = ({tips}) => {
         {/* <ShareTip lesson={tip} /> */}
         <div className="grid lg:grid-cols-3 sm:grid-cols-2 grid-cols-1 gap-2 h-full ">
           {take(shuffle(tips), 9).map((tip) => {
-            const video = tip?.resources.find(
-              (resource: SanityDocument) => resource._type === 'videoResource',
-            )
+            const muxPlaybackId = tip?.muxPlaybackId
 
-            const thumbnail = `https://image.mux.com/${video.muxAsset.muxPlaybackId}/thumbnail.png?width=288&height=162&fit_mode=preserve`
+            const thumbnail = `https://image.mux.com/${muxPlaybackId}/thumbnail.png?width=288&height=162&fit_mode=preserve`
 
             return (
               <button
@@ -225,7 +222,7 @@ const TipOverlay: React.FC<{tips: Tip[]}> = ({tips}) => {
                   router
                     .push({
                       pathname: '/tips/[tip]',
-                      query: {tip: tip.slug.current},
+                      query: {tip: tip.slug},
                     })
                     .then(() => {
                       handlePlay()
@@ -262,10 +259,10 @@ const TipOverlay: React.FC<{tips: Tip[]}> = ({tips}) => {
   )
 }
 
-const ReplyOnTwitter: React.FC<{tweet: {tweetId: string}}> = ({tweet}) => {
+const ReplyOnTwitter: React.FC<{tweet: string}> = ({tweet}) => {
   return (
     <a
-      href={`https://twitter.com/i/status/${tweet.tweetId}`}
+      href={`https://twitter.com/i/status/${tweet}`}
       target="_blank"
       rel="noopener noreferrer"
       className="mb-5 mt-2 text-gray-200 px-4 py-3 font-medium rounded bg-gray-800 gap-2 inline-flex items-center justify-center hover:brightness-150 transition brightness-110"

--- a/apps/total-typescript/src/templates/tutorial-template.tsx
+++ b/apps/total-typescript/src/templates/tutorial-template.tsx
@@ -10,6 +10,7 @@ import {IconGithub} from 'components/icons'
 import {isBrowser} from 'utils/is-browser'
 import {track} from '../utils/analytics'
 import {useConvertkit} from 'hooks/use-convertkit'
+import {Exercise} from 'lib/exercises'
 
 const TutorialTemplate: React.FC<{
   tutorial: SanityDocument
@@ -92,7 +93,7 @@ const Header: React.FC<{tutorial: SanityDocument}> = ({tutorial}) => {
                     pathname: '/tutorials/[module]/[exercise]',
                     query: {
                       module: slug.current,
-                      exercise: exercises[0].slug.current,
+                      exercise: exercises[0].slug,
                     },
                   }}
                 >
@@ -161,15 +162,15 @@ const TutorialExerciseNavigator: React.FC<{tutorial: SanityDocument}> = ({
       </h2>
       {exercises && (
         <ul>
-          {exercises.map((exercise: SanityDocument, i: number) => {
+          {exercises.map((exercise: Exercise, i: number) => {
             return (
-              <li key={exercise.slug.current}>
+              <li key={exercise.slug}>
                 <Link
                   href={{
                     pathname: '/tutorials/[module]/[exercise]',
                     query: {
                       module: slug.current,
-                      exercise: exercise.slug.current,
+                      exercise: exercise.slug,
                     },
                   }}
                   passHref
@@ -179,7 +180,7 @@ const TutorialExerciseNavigator: React.FC<{tutorial: SanityDocument}> = ({
                     onClick={() => {
                       track('clicked tutorial exercise', {
                         module: slug.current,
-                        lesson: exercise.slug.current,
+                        lesson: exercise.slug,
                         moduleType: _type,
                         lessonType: exercise._type,
                       })

--- a/apps/total-typescript/src/utils/get-next-exercise.ts
+++ b/apps/total-typescript/src/utils/get-next-exercise.ts
@@ -8,17 +8,12 @@ export const getNextExercise = (
   currentLesson: Exercise,
 ) => {
   if (currentLesson._type === 'exercise') {
-    return currentLesson.resources.find(
-      (resource: SanityDocument) => resource._type === 'solution',
-    )
+    return currentLesson.solution
   }
 
   const exerciseForSolution = module.exercises.find(
     (resource: SanityDocument) => {
-      const solution = resource.resources.find(
-        (resource: SanityDocument) => resource._key === currentLesson._key,
-      )
-      return solution?._key === currentLesson._key
+      return resource.solution?._key === currentLesson._key
     },
   )
 

--- a/apps/total-typescript/studio/schemas/documents/exercise.js
+++ b/apps/total-typescript/studio/schemas/documents/exercise.js
@@ -12,6 +12,7 @@ export default {
       name: 'label',
       title: 'Label',
       type: 'string',
+      hidden: true,
     },
     {
       name: 'title',
@@ -32,7 +33,16 @@ export default {
       name: 'resources',
       title: 'Resources',
       type: 'array',
-      of: [{type: 'solution'}, {type: 'muxVideo'}, {type: 'stackblitz'}],
+      of: [
+        {
+          title: 'Video Resource',
+          type: 'reference',
+          to: [{type: 'videoResource'}],
+        },
+        {type: 'solution'},
+        {type: 'muxVideo'},
+        {type: 'stackblitz'},
+      ],
     },
     {
       name: 'body',

--- a/apps/total-typescript/studio/schemas/documents/videoResource.js
+++ b/apps/total-typescript/studio/schemas/documents/videoResource.js
@@ -15,7 +15,6 @@ export default {
     {
       name: 'originalMediaUrl',
       title: 'AWS S3 Url',
-      validation: (Rule) => Rule.required(),
       description: 'A URL to the source video in an S3 Bucket',
       type: 'url',
     },

--- a/apps/total-typescript/studio/schemas/objects/castingwordsTranscript.js
+++ b/apps/total-typescript/studio/schemas/objects/castingwordsTranscript.js
@@ -9,7 +9,6 @@ export default {
       title: 'Order ID',
       description: 'Used to keep track of the order status on Castingwords',
       type: 'string',
-      validation: (Rule) => Rule.required(),
     },
     {
       name: 'audioFileId',
@@ -17,7 +16,6 @@ export default {
       description:
         'This is used to keep track of the specific transcript in a Castingwords order.',
       type: 'string',
-      validation: (Rule) => Rule.required(),
     },
     {
       name: 'transcript',

--- a/apps/total-typescript/studio/schemas/objects/resources/solution.js
+++ b/apps/total-typescript/studio/schemas/objects/resources/solution.js
@@ -30,7 +30,15 @@ export default {
       name: 'resources',
       title: 'Resources',
       type: 'array',
-      of: [{type: 'muxVideo'}, {type: 'stackblitz'}],
+      of: [
+        {
+          title: 'Video Resource',
+          type: 'reference',
+          to: [{type: 'videoResource'}],
+        },
+        {type: 'muxVideo'},
+        {type: 'stackblitz'},
+      ],
     },
     {
       name: 'body',


### PR DESCRIPTION
fairly sweeping change with some minor updates to sanity, but the structure of the exercise query has changed to normalize properties like `stackblitz` and `muxPlaybackId` as properties of the exercise versus a sub-object.

the issue was that solution video resources were a reference and harder to get at, so this flattens everything to make it simpler.

![sweeping](https://media.giphy.com/media/3o7TKqTOqevMiJAwU0/giphy.gif)