### PR TITLE
chore(csa): ditch `next-compose-plugins`

### DIFF
--- a/packages/create-skill-app/templates/next/package.json
+++ b/packages/create-skill-app/templates/next/package.json
@@ -35,7 +35,6 @@
     "groq": "^2.15.0",
     "next": "^12.2.3",
     "next-auth": "^4.10.3",
-    "next-compose-plugins": "^2.2.1",
     "next-sitemap": "^3.0.5",
     "nodemailer": "^6.7.2",
     "mjml": "^4.12.0",


### PR DESCRIPTION
we want to stop using next-compose-plugins package in next config since it's not being updated

<img src="https://media.giphy.com/media/aWXSKuhUPFPdLQoEqt/giphy.gif" width="200" alt="gif">