### PR TITLE
fix(ta): prevent default export of server-only code

### DIFF
--- a/apps/testingaccessibility/src/pages/api/sanity/webhooks/add-all-records-to-algolia.ts
+++ b/apps/testingaccessibility/src/pages/api/sanity/webhooks/add-all-records-to-algolia.ts
@@ -1,6 +1,6 @@
 import {NextApiRequest, NextApiResponse} from 'next'
 import {sanityClient} from 'utils/sanity-client'
-import {sanityAlgolia} from 'utils/algolia'
+import {sanityAlgolia} from 'utils/algolia/sanity-algolia-client'
 import {withSentry} from '@sentry/nextjs'
 import {isValidRequest} from '@sanity/webhook'
 

--- a/apps/testingaccessibility/src/pages/api/sanity/webhooks/add-records-to-algolia.ts
+++ b/apps/testingaccessibility/src/pages/api/sanity/webhooks/add-records-to-algolia.ts
@@ -1,6 +1,6 @@
 import {NextApiRequest, NextApiResponse} from 'next'
 import {sanityClient} from 'utils/sanity-client'
-import {sanityAlgolia} from 'utils/algolia'
+import {sanityAlgolia} from 'utils/algolia/sanity-algolia-client'
 import {withSentry} from '@sentry/nextjs'
 import {isValidRequest} from '@sanity/webhook'
 

--- a/apps/testingaccessibility/src/utils/algolia/index.ts
+++ b/apps/testingaccessibility/src/utils/algolia/index.ts
@@ -1,2 +1,1 @@
-export * from './sanity-algolia-client'
 export * from './client'

--- a/apps/testingaccessibility/src/utils/algolia/sanity-algolia-client.ts
+++ b/apps/testingaccessibility/src/utils/algolia/sanity-algolia-client.ts
@@ -21,9 +21,7 @@ const algoliaWriteKeySchema = z
   })
 
 const getAlgoliaApiWriteKeyFromEnvironment = () => {
-  // TODO: make sure this doesn't break production /learn page
-  // return algoliaWriteKeySchema.parse(process.env.ALGOLIA_API_WRITE_KEY)
-  return process.env.ALGOLIA_API_WRITE_KEY
+  return algoliaWriteKeySchema.parse(process.env.ALGOLIA_API_WRITE_KEY)
 }
 
 const algoliaAppId = process.env.NEXT_PUBLIC_ALGOLIA_APPLICATION_ID


### PR DESCRIPTION
The server-side-only algolia client configured with the secret API write
key should only be imported into API code. Because it was being `*`
exported from the `utils/algolia/index.ts` file, it was being bundled
into the frontend code.

This was originally causing silent errors because the algolia client was
being configured with a blank value (that write key is only visible
servers-side). The schema parsing -- meant only to validate the key
server-side -- that I recently added was being triggered on the frontend
which caused that aforementioned error to fully surface.

This commit removes the re-export of the server-side algolia client.
Instead, the API code can import it directly from
`utils/algolia/sanity-algolia-client.ts`. Having to explicitly import it
form this location should help avoid this code getting accidentally
included in the frontend bundle going forward.

![search](https://media2.giphy.com/media/l0MYHq0IFikDrVQOc/giphy.gif?cid=d1fd59ab5cjrruac7cm1jk8m0zqpr3ca75je4cw947tx6mgx&rid=giphy.gif&ct=g)
