### PR TITLE
build(ta): remove `build:dev` from TA pnpm scripts

### DIFF
--- a/apps/testingaccessibility/README.md
+++ b/apps/testingaccessibility/README.md
@@ -43,7 +43,7 @@ Copy the template `.env.local.template` file to `.env.local` and `.env.template`
 
 🔒 `env.local` contains local __private environment variables__
 
-* `ALGOLIA_API_WRITE_KEY`: Required to build the project with both `build` and `build:dev`.
+* `ALGOLIA_API_WRITE_KEY`: Required when running `pnpm build` which invokes `next build` which use `NODE_ENV=production`.
 * `CONVERTKIT_API_SECRET`: not required for local development unless actively working on ConvertKit integration. Can be found in 1password.
 * `POSTMARK_KEY`: not required to run in dev, but enables email sending from local environment. Can be found in 1password.
 * `STRIPE_SECRET_TOKEN`: Not required unless you need to make an end to end purchase. Can be found in 1password.
@@ -70,7 +70,7 @@ cp .env.template .env
 Now build the app and all dependencies with the following command:
 
 ```shell
-pnpm build:dev
+pnpm build
 ```
 
 This command will also `test` and `lint` the project. If you run into errors at this step, they should be addressed.

--- a/apps/testingaccessibility/package.json
+++ b/apps/testingaccessibility/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "build:dev": "cd ../.. && pnpm -- turbo run build test lint --filter=testingaccessibility && cd apps/testingaccessibility",
     "postbuild": "NODE_ENV=production next-sitemap",
     "clean": "pnpm -r exec -- rm -rf .turbo node_modules .next",
     "dev": "pnpm dev:validate && next dev -p 3013",


### PR DESCRIPTION
According to a recent discussion, the `build:dev` command (introduced in [this PR](https://github.com/skillrecordings/products/commit/bf0fbe34244cd6414352b6f1308e05010313ecf1#diff-284649712bae897eb9f7e577e57534aa1ec714618f8b0b4641d70de63818c8ff))
is not used. Instead, if you want to build the app, you should run `pnpm
build`.

This commits removes `build:dev` from both `package.json` and the
`README.md` to avoid confusion about how to set up and build this app.

![confusion](https://media1.giphy.com/media/1X7lCRp8iE0yrdZvwd/giphy.gif?cid=d1fd59ab7vyleh9f323zbz6823kwps5hkyj3v5lqmd20p3u2&rid=giphy.gif&ct=g)
