### PR TITLE
feat(skill-api): wrap coupon redemption in transaction

### DIFF
--- a/packages/skill-api/src/core/services/redeem-golden-ticket.ts
+++ b/packages/skill-api/src/core/services/redeem-golden-ticket.ts
@@ -85,7 +85,7 @@ export async function redeemGoldenTicket({
           existingPurchase.id,
         )
 
-      const purchase = await prisma.purchase.create({
+      const createPurchase = prisma.purchase.create({
         data: {
           userId: user.id,
           couponId: coupon.id,
@@ -93,6 +93,23 @@ export async function redeemGoldenTicket({
           totalAmount: 0,
         },
       })
+
+      const updateCouponUsage = prisma.coupon.update({
+        where: {id: coupon.id},
+        data: {
+          usedCount: {
+            increment: 1,
+          },
+        },
+      })
+
+      // To ensure consistency when "redeeming a coupon", we use a DB
+      // transaction to create the purchase record and update the coupon's
+      // usage count atomically.
+      const [purchase, _coupon] = await prisma.$transaction([
+        createPurchase,
+        updateCouponUsage,
+      ])
 
       if (sendEmail && nextAuthOptions) {
         await sendServerEmail({
@@ -103,15 +120,6 @@ export async function redeemGoldenTicket({
       } else {
         console.error(`no email sent to ${user.email}`)
       }
-
-      await prisma.coupon.update({
-        where: {id: coupon.id},
-        data: {
-          usedCount: {
-            increment: 1,
-          },
-        },
-      })
 
       if (params.options.slack?.redeem && !coupon.bulkPurchaseId) {
         console.warn('not configured for slack to post coupon redemptions')


### PR DESCRIPTION
Use a transaction when redeeming a coupon to ensure that both the
purchase record is created and the coupon seat usage is updated
atomically. Otherwise, there is always a possibility that one would
succeed and the other fail which would leave them out of sync. Making
the data inconsistent.

![transac](https://media1.giphy.com/media/XA7hAO76RCB7BO46v3/giphy.gif?cid=d1fd59ab570qtb3dbbzohftd1x2xsrvcs138egatoxfns6yw&rid=giphy.gif&ct=g)
