### PR TITLE
feat(database): add redeemedCouponId to purchases

### DIFF
--- a/apps/testingaccessibility/README.md
+++ b/apps/testingaccessibility/README.md
@@ -212,13 +212,27 @@ npx prisma studio
 
 When you make a new branch in Planetscale it doesn't bring data over.
 
-In the `seed_data` folder is a database dump.
+#### Minimal Seed Data
+
+You can seed your branch with the basics that are associated with the **test mode** Stripe account. Those seeds are located in `seed_data`.
 
 ```bash
-pscale database restore-dump testing-accessibility next-steps --dir ./seed_data/pscale_data_dump
+pscale database restore-dump testing-accessibility next-steps --dir ./seed_data
 ```
 
-This should set up the basics that are associated with the **test mode** Stripe account
+#### Production-like Seed Data
+
+You can locally dump a copy of the `main` branch using `pscale database dump`:
+
+```bash
+pscale database dump testing-accessibility main --output ./seed_data/pscale_data_dump
+```
+
+Now the `seed_data/pscale_data_dump` folder holds a database dump you can restore to your branch:
+
+```bash
+pscale database restore-dump testing-accessibility next-steps --dir ./seed_data/pscale_data_dump --overwrite-tables
+```
 
 ## Edit content
 

--- a/apps/testingaccessibility/src/data/migrate-redeemed-bulk-coupon.ts
+++ b/apps/testingaccessibility/src/data/migrate-redeemed-bulk-coupon.ts
@@ -1,0 +1,45 @@
+import {prisma} from '../../../../packages/database/src/client'
+
+const copyOverCouponIdToRedeemedCouponId = async () => {
+  // Make sure this only runs for the expected database, because TA is the only
+  // DB that has purchases that need migrating.
+  if (
+    process.env.DATABASE_URL !==
+    'mysql://root@localhost:3309/testing-accessibility'
+  ) {
+    console.log(
+      'This is only meant to run against the testing-accessibility database.',
+    )
+    process.exit(1)
+  }
+
+  const purchaseCount = await prisma.purchase.count()
+  const purchasesThatNeedUpdating = await prisma.purchase.findMany({
+    where: {redeemedBulkCouponId: null, couponId: {not: null}},
+  })
+
+  console.log(
+    `Need to update ${purchasesThatNeedUpdating.length} of ${purchaseCount} purchases.`,
+  )
+
+  for (const purchaseToUpdate of purchasesThatNeedUpdating) {
+    await prisma.purchase.update({
+      where: {
+        id: purchaseToUpdate.id,
+      },
+      data: {
+        redeemedBulkCouponId: purchaseToUpdate.couponId,
+      },
+    })
+  }
+
+  const afterPurchasesThatNeedUpdating = await prisma.purchase.findMany({
+    where: {redeemedBulkCouponId: null, couponId: {not: null}},
+  })
+
+  const numberUpdated =
+    purchasesThatNeedUpdating.length - afterPurchasesThatNeedUpdating.length
+  console.log(`Successfully updated ${numberUpdated} purchases`)
+}
+
+copyOverCouponIdToRedeemedCouponId()

--- a/apps/testingaccessibility/src/data/migrate-redeemed-bulk-coupon.ts
+++ b/apps/testingaccessibility/src/data/migrate-redeemed-bulk-coupon.ts
@@ -1,3 +1,19 @@
+// Running this script:
+//
+// Run the following commands from 'apps/testingaccessibility'.
+//
+// First, open a connection to the planetscale database and branch:
+//
+// ```
+// pscale connect testing-accessbility <branch-name> --port 3309 --host "::1"
+// ```
+//
+// Execute the data migration:
+//
+// ```
+// npx ts-node --skipProject src/data/migrate-redeemed-bulk-coupon.ts
+// ```
+
 import {prisma} from '../../../../packages/database/src/client'
 
 const copyOverCouponIdToRedeemedCouponId = async () => {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -56,22 +56,23 @@ model Account {
 }
 
 model Coupon {
-  id                    String          @id @default(uuid())
-  code                  String?         @unique
-  createdAt             DateTime        @default(now())
-  expires               DateTime?
-  maxUses               Int             @default(-1)
-  default               Boolean         @default(false)
-  merchantCouponId      String?
-  status                Int             @default(0)
-  usedCount             Int             @default(0)
-  percentageDiscount    Decimal         @db.Decimal(3, 2)
-  restrictedToProductId String?
-  bulkPurchaseId        String?         @unique
-  bulkPurchase          Purchase?       @relation("BulkCoupon", fields: [bulkPurchaseId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  merchantCoupon        MerchantCoupon? @relation(fields: [merchantCouponId], references: [id], onDelete: Cascade)
-  product               Product?        @relation(fields: [restrictedToProductId], references: [id], onDelete: Cascade)
-  purchases             Purchase[]      @relation("StandardPurchase")
+  id                            String          @id @default(uuid())
+  code                          String?         @unique
+  createdAt                     DateTime        @default(now())
+  expires                       DateTime?
+  maxUses                       Int             @default(-1)
+  default                       Boolean         @default(false)
+  merchantCouponId              String?
+  status                        Int             @default(0)
+  usedCount                     Int             @default(0)
+  percentageDiscount            Decimal         @db.Decimal(3, 2)
+  restrictedToProductId         String?
+  bulkPurchaseId                String?         @unique
+  bulkPurchase                  Purchase?       @relation("BulkCoupon", fields: [bulkPurchaseId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  merchantCoupon                MerchantCoupon? @relation(fields: [merchantCouponId], references: [id], onDelete: Cascade)
+  product                       Product?        @relation(fields: [restrictedToProductId], references: [id], onDelete: Cascade)
+  purchases                     Purchase[]      @relation("StandardPurchase")
+  bulkCouponRedemptionPurchases Purchase[]      @relation("RedeemedBulkCoupon")
 }
 
 model MerchantAccount {
@@ -187,26 +188,28 @@ model UpgradableProducts {
 }
 
 model Purchase {
-  id               String          @id @default(uuid())
-  userId           String?
-  createdAt        DateTime        @default(now())
-  totalAmount      Decimal
-  ip_address       String?
-  city             String?
-  state            String?
-  country          String?
-  couponId         String?
-  productId        String
-  merchantChargeId String?
-  upgradedFromId   String?         @unique
-  upgradedFrom     Purchase?       @relation("UpgradedToPurchase", fields: [upgradedFromId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  upgradedTo       Purchase?       @relation("UpgradedToPurchase")
-  bulkCoupon       Coupon?         @relation("BulkCoupon")
-  coupon           Coupon?         @relation("StandardPurchase", fields: [couponId], references: [id], onDelete: Cascade)
-  merchantCharge   MerchantCharge? @relation(fields: [merchantChargeId], references: [id], onDelete: Cascade)
-  product          Product         @relation(fields: [productId], references: [id], onDelete: Cascade)
-  user             User?           @relation(fields: [userId], references: [id], onDelete: Cascade)
-  status           String          @default("Valid")
+  id                   String          @id @default(uuid())
+  userId               String?
+  createdAt            DateTime        @default(now())
+  totalAmount          Decimal
+  ip_address           String?
+  city                 String?
+  state                String?
+  country              String?
+  couponId             String?
+  redeemedBulkCouponId String?
+  productId            String
+  merchantChargeId     String?
+  upgradedFromId       String?         @unique
+  upgradedFrom         Purchase?       @relation("UpgradedToPurchase", fields: [upgradedFromId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  upgradedTo           Purchase?       @relation("UpgradedToPurchase")
+  bulkCoupon           Coupon?         @relation("BulkCoupon")
+  coupon               Coupon?         @relation("StandardPurchase", fields: [couponId], references: [id], onDelete: Cascade)
+  redeemedBulkCoupon   Coupon?         @relation("RedeemedBulkCoupon", fields: [redeemedBulkCouponId], references: [id], onDelete: NoAction)
+  merchantCharge       MerchantCharge? @relation(fields: [merchantChargeId], references: [id], onDelete: Cascade)
+  product              Product         @relation(fields: [productId], references: [id], onDelete: Cascade)
+  user                 User?           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  status               String          @default("Valid")
 }
 
 model Session {

--- a/packages/skill-api/src/core/services/redeem-golden-ticket.ts
+++ b/packages/skill-api/src/core/services/redeem-golden-ticket.ts
@@ -65,6 +65,9 @@ export async function redeemGoldenTicket({
         (coupon.restrictedToProductId as string) ||
         process.env.NEXT_PUBLIC_DEFAULT_PRODUCT_ID
 
+      // To prevent double-purchasing, check if this user already has a
+      // Purchase record for this product that is valid and wasn't a bulk
+      // coupon purchase.
       const existingPurchase = await prisma.purchase.findFirst({
         where: {
           userId: user.id,
@@ -88,7 +91,8 @@ export async function redeemGoldenTicket({
       const purchase = await prisma.purchase.create({
         data: {
           userId: user.id,
-          couponId: coupon.id,
+          couponId: coupon.id, // TODO: old redeeming-coupon identifier
+          redeemedCouponId: coupon.id, // TODO: new redeeming-coupon identifer
           productId,
           totalAmount: 0,
         },


### PR DESCRIPTION
Add a specific column for tracking the bulk coupon that was redeemed in
order to create this $0 purchase. This will allow us to repurpose the
`couponId` column toward representing a one-to-many relationship between
a bulk coupon and the purchases that add seats to it.

This is the **first** step of [the expand-and-contract pattern](https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern). I'll do each of the following steps in sequence:
- Open a pscale Deploy Request and get this schema change into production
- Open PR to have coupon redemptions write to this new column alongside the original column
- Add and run script to do a _data migration_ any existing coupon redemptions purchase (write `purchase.couponId` value to `purchase.redeemedCouponId` column).
- Open PR: Anywhere the apps are reading from `purchase.couponId` needs to be cut over to `purchase.redeemedCouponId`
- Open PR to remove writes to the `purchase.couponId` column
- No need to do the last expand-and-contract step of removing the old part of the schema because we will then repurpose the `purchase.couponId` toward representing one-to-many bulk coupon purchases (i.e. adding more seats to an existing bulk coupon).

---

More details copied over from [Roam](https://roamresearch.com/#/app/egghead/page/Uub3Ki4rM):

- I originally thought the `couponId` column wasn't being used. In my initial poking around of the app, I only saw the bulk coupon being set. After redeeming a purchase, I realized that `purchases.couponId` is being used after all.
    - Whenever one of the seats for a bulk coupon is redeemed, a `purchase` record is created which points to the originating coupon at `purchase.couponId`.
- To transition to a schema that supports multiple bulks purchases and to be able to trace Coupon Redemption purchases back to the originating coupon, I'm going to need to make a series of changes.
    - A `purchase` record needs to be able to tell us one of two things:
        - The Bulk Coupon it added seats to.
        - The Bulk Coupon it was redeemed from.
        - (or if it was a single-seat purchase, neither of these values should be set)
    - We are going to need two separate Coupon ID foreign keys to do this.
        - If we used the existing `couponId` column to represent both of these things, the data could get mixed up and hard to query from.

The series of changes needed:

1. Add `redeemedCouponId` column to `purchases` (with the Expand-and-Contract pattern) to represent the bulk coupon that was redeemed for the $0 purchase.
    - This would be created anytime a team invite is redeemed for a bulk coupon.
2. Use the now empty `couponId` column (or rename it to `bulkCouponId` or `teamCouponId`) to represent the one-to-many relationship between (Bulk) Coupon and Purchases.
    - i.e. the first and any subsequent purchases of seats for a team license should point to the coupon to which they added capacity.
        - For instance, if you purchase 5 seats, then you get a coupon with capacity of 5. A new purchase for $X points to that coupon. If you buy 4 more seats, then 4 is added to that coupon's original capacity __and__ a new purchase record is created for $Y pointing to that same coupon.
    - This will follow the steps outlined in: We need to use the [[Expand-and-Contract database migration strategy](https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern)](https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern) for this.

![redeem](https://media3.giphy.com/media/PJLHNaEpmeqUU/giphy.gif?cid=d1fd59ab3icetdpmuct930890qnwde8u3zex6sq7gfcyl4zr&rid=giphy.gif&ct=g)
