### PR TITLE
update(tt): fix styles on newsletter CTA

### DIFF
--- a/apps/total-typescript/src/styles/newsletter.css
+++ b/apps/total-typescript/src/styles/newsletter.css
@@ -1,4 +1,4 @@
-#primary-newsletter-cta {
+#newsletter {
   [data-sr-convertkit-subscribe-form] {
     @apply flex flex-col gap-4;
     [data-sr-input] {


### PR DESCRIPTION
TotalTypeScript – CTA styles are currently broken in production, due to a mismatch between the ID on the HTML and the one in the CSS:

<img width="835" alt="image" src="https://user-images.githubusercontent.com/485747/194952902-9900898a-17f5-4fbd-8682-0cd37ac1dee8.png">

This PR changes the  ID in the CSS file to make the styles apply correctly.