### PR TITLE
feat(db): spike out data migration script setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lint-staged": "^11.2.6",
     "plop": "^2.7.6",
     "prettier": "^2.6.2",
+    "ts-node": "^10.9.1",
     "tsdx": "^0.14.1",
     "turbo": "^1.3.1",
     "typescript": "^4.8.3"

--- a/packages/database/migrate_data/20221010203922_copy_existing_coupon_id_to_redeemed_for_purchase.ts
+++ b/packages/database/migrate_data/20221010203922_copy_existing_coupon_id_to_redeemed_for_purchase.ts
@@ -1,0 +1,37 @@
+// const {prisma} = require('../src/client')
+import {prisma} from '../src/client'
+
+const copyOverCouponIdToRedeemedCouponId = async () => {
+  const purchaseCount = await prisma.purchase.count()
+  const purchasesThatNeedUpdating = await prisma.purchase.findMany({
+    where: {redeemedCouponId: null, couponId: {not: null}},
+  })
+
+  console.log(
+    `Need to update ${purchasesThatNeedUpdating.length} of ${purchaseCount} purchases.`,
+  )
+
+  purchasesThatNeedUpdating.forEach(async (purchase) => {
+    await prisma.purchase.update({
+      where: {
+        id: purchase.id,
+      },
+      data: {
+        redeemedCouponId: purchase.couponId,
+      },
+    })
+  })
+
+  const afterPurchasesThatNeedUpdating = await prisma.purchase.findMany({
+    where: {redeemedCouponId: null, couponId: {not: null}},
+  })
+
+  const numberUpdated =
+    purchasesThatNeedUpdating.length - afterPurchasesThatNeedUpdating.length
+  console.log(`Successfully updated ${numberUpdated} purchases`)
+}
+
+// copyOverCouponIdToRedeemedCouponId()
+console.log({database_url: process.env.DATABASE_URL})
+
+export {}

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -33,6 +33,7 @@
     "jest-mock-extended": "^2.0.7",
     "prisma": "^4.4.0",
     "rimraf": "^3.0.2",
+    "ts-node": "^10.9.1",
     "tsup": "^5.11.13",
     "tsx": "^3.7.1",
     "typescript": "^4.8.3"


### PR DESCRIPTION
This is a WIP/spike on how to write a data migration script for a
scenario where the schema has been changed and now data needs to be
migrated to that updated schema.

It should lean on Prisma types and should be runnable across the various
apps using the schema for their databases.

It uses `ts-node` to execute the typescript data migration file. Open to
suggestions if there is something else I should be using for this
particular piece of this. It's what I found.

**Possibly my brain is fried from a long day, but I'm struggling to
understand where the node environment is being derived from when I
execute this script. No matter what directory I execute this from,
`ts-node` has the impression that `DATABASE_URL` is set to the URL
defined in TA's `.env` file. What am I missing? How do I make the
environment variables specific to the project this script is being run
in?**

I'm executing it with `npx ts-node
../../packages/database/migrate-data/<name-of-file>.ts`.

![spi](https://media1.giphy.com/media/zQc8STzaOlJ3q/giphy.gif?cid=d1fd59abcfxr7xv393lhlpn1ti3r80rmmlr89tpg0t167ty4&rid=giphy.gif&ct=g)
