### PR TITLE
feat(ta): discontinue writes to Purchase.couponId

### DIFF
--- a/packages/skill-api/src/core/services/redeem-golden-ticket.ts
+++ b/packages/skill-api/src/core/services/redeem-golden-ticket.ts
@@ -91,8 +91,7 @@ export async function redeemGoldenTicket({
       const createPurchase = prisma.purchase.create({
         data: {
           userId: user.id,
-          couponId: coupon.id, // TODO: old redeeming-coupon identifier
-          redeemedBulkCouponId: coupon.id, // TODO: new redeeming-coupon identifer
+          redeemedBulkCouponId: coupon.id,
           productId,
           totalAmount: 0,
         },


### PR DESCRIPTION
As part of transitioning from the `couponId` column to the
`redeemedBulkCouponId` column, the app should now no longer write to the
`couponId` column.

https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern#step-6-discontinue-writing-to-the-original-structure

![discontinue](https://media2.giphy.com/media/XxvmzTFUCHggmwxmrS/giphy.gif?cid=d1fd59abow8twnun65p8c2tw07o67b4lpe1xk5tki4k1mymq&rid=giphy.gif&ct=g)
