### PR TITLE
build: move turbo env var deps to the env key

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,12 +7,11 @@
       "outputs": ["dist/**", ".next/**"]
     },
     "@skillrecordings/config#build": {
-      "dependsOn": [
-        "^build",
-        "generate",
-        "$CONVERTKIT_API_SECRET",
-        "$NEXT_PUBLIC_CONVERTKIT_TOKEN",
-        "$NEXT_PUBLIC_CONVERTKIT_SIGNUP_FORM"
+      "dependsOn": ["^build", "generate"],
+      "env": [
+        "CONVERTKIT_API_SECRET",
+        "NEXT_PUBLIC_CONVERTKIT_TOKEN",
+        "NEXT_PUBLIC_CONVERTKIT_SIGNUP_FORM"
       ],
       "outputs": ["dist/**"]
     },


### PR DESCRIPTION
The `$ENV_VAR` syntax in the `dependsOn` array has been deprecated and
you can instead declare those values in the `env` array.

The `env` key is available in turbo v1.4.7
(https://github.com/vercel/turborepo/releases/tag/v1.4.7).

turbo docs: https://turborepo.org/docs/reference/configuration#env
