### PR TITLE
feat(ta): add one-to-many relation for bulk coupons

### DIFF
--- a/apps/testingaccessibility/src/data/migrate-bulk-coupon-purchases-relation.ts
+++ b/apps/testingaccessibility/src/data/migrate-bulk-coupon-purchases-relation.ts
@@ -1,0 +1,79 @@
+// Running this script:
+//
+// Run the following commands from 'apps/testingaccessibility'.
+//
+// First, open a connection to the planetscale database and branch:
+//
+// ```
+// pscale connect testing-accessbility <branch-name> --port 3309 --host "::1"
+// ```
+//
+// Execute the data migration:
+//
+// ```
+// npx ts-node --skipProject src/data/migrate-bulk-coupon-purchases-relation.ts
+// ```
+
+import {prisma} from '@skillrecordings/database'
+
+const backfillBulkCouponIdForBulkPurchases = async () => {
+  // Make sure this only runs for the expected database, because TA is the only
+  // DB that has purchases that need migrating.
+  if (
+    process.env.DATABASE_URL !==
+    'mysql://root@localhost:3309/testing-accessibility'
+  ) {
+    console.log(
+      'This is only meant to run against the testing-accessibility database.',
+    )
+    process.exit(1)
+  }
+
+  const purchaseCount = await prisma.purchase.count()
+  const purchasesThatNeedUpdating = await prisma.purchase.findMany({
+    where: {individualBulkCoupon: {isNot: null}, bulkCouponId: null},
+    select: {
+      id: true,
+      individualBulkCoupon: {
+        select: {
+          id: true,
+        },
+      },
+    },
+  })
+
+  console.log(
+    `Need to update ${purchasesThatNeedUpdating.length} of ${purchaseCount} purchases.`,
+  )
+
+  for (const purchaseToUpdate of purchasesThatNeedUpdating) {
+    if (purchaseToUpdate.individualBulkCoupon === null) continue
+
+    await prisma.purchase.update({
+      where: {
+        id: purchaseToUpdate.id,
+      },
+      data: {
+        bulkCouponId: purchaseToUpdate.individualBulkCoupon.id,
+      },
+    })
+  }
+
+  const afterPurchasesThatNeedUpdating = await prisma.purchase.findMany({
+    where: {individualBulkCoupon: {isNot: null}, bulkCouponId: null},
+    select: {
+      id: true,
+      individualBulkCoupon: {
+        select: {
+          id: true,
+        },
+      },
+    },
+  })
+
+  const numberUpdated =
+    purchasesThatNeedUpdating.length - afterPurchasesThatNeedUpdating.length
+  console.log(`Successfully updated ${numberUpdated} purchases`)
+}
+
+backfillBulkCouponIdForBulkPurchases()

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -68,11 +68,12 @@ model Coupon {
   percentageDiscount            Decimal         @db.Decimal(3, 2)
   restrictedToProductId         String?
   bulkPurchaseId                String?         @unique
-  bulkPurchase                  Purchase?       @relation("BulkCoupon", fields: [bulkPurchaseId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  bulkPurchase                  Purchase?       @relation("IndividualBulkCoupon", fields: [bulkPurchaseId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   merchantCoupon                MerchantCoupon? @relation(fields: [merchantCouponId], references: [id], onDelete: Cascade)
   product                       Product?        @relation(fields: [restrictedToProductId], references: [id], onDelete: Cascade)
   purchases                     Purchase[]      @relation("StandardPurchase")
   bulkCouponRedemptionPurchases Purchase[]      @relation("RedeemedBulkCoupon")
+  bulkCouponPurchases           Purchase[]      @relation("BulkCoupon")
 }
 
 model MerchantAccount {
@@ -197,13 +198,15 @@ model Purchase {
   state                String?
   country              String?
   couponId             String?
+  bulkCouponId         String?
   redeemedBulkCouponId String?
   productId            String
   merchantChargeId     String?
   upgradedFromId       String?         @unique
   upgradedFrom         Purchase?       @relation("UpgradedToPurchase", fields: [upgradedFromId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   upgradedTo           Purchase?       @relation("UpgradedToPurchase")
-  bulkCoupon           Coupon?         @relation("BulkCoupon")
+  bulkCoupon           Coupon?         @relation("BulkCoupon", fields: [bulkCouponId], references: [id])
+  individualBulkCoupon Coupon?         @relation("IndividualBulkCoupon")
   coupon               Coupon?         @relation("StandardPurchase", fields: [couponId], references: [id], onDelete: Cascade)
   redeemedBulkCoupon   Coupon?         @relation("RedeemedBulkCoupon", fields: [redeemedBulkCouponId], references: [id], onDelete: NoAction)
   merchantCharge       MerchantCharge? @relation(fields: [merchantChargeId], references: [id], onDelete: Cascade)

--- a/packages/skill-api/src/core/services/redeem-golden-ticket.ts
+++ b/packages/skill-api/src/core/services/redeem-golden-ticket.ts
@@ -72,7 +72,7 @@ export async function redeemGoldenTicket({
         where: {
           userId: user.id,
           productId,
-          bulkCoupon: null,
+          individualBulkCoupon: null,
           status: PurchaseStatus.Valid,
         },
         select: {


### PR DESCRIPTION
This PR represents the second and third step of the Expand and Contract
pattern for replacing the existing one-to-one relation between Bulk
Coupon and Bulk Purchase with a one-to-many relation of Bulk Coupon to
Purchases.

Before this can be merged, the schema needs to be fully deployed to the
existing production database environments. Those Deploy Requests have
already been opened at:
1. https://app.planetscale.com/skill-recordings/testing-accessibility/deploy-requests/14
2. https://app.planetscale.com/skill-recordings/total-typescript/deploy-requests/3

Visual of the one-to-many relationship we're moving toward:

![CleanShot 2022-10-17 at 10 06 45](https://user-images.githubusercontent.com/694063/196214109-e73b6c3b-8dea-4590-8e9c-9778a622f352.png)


![bulk purchase](https://media4.giphy.com/media/26uf4LsTj87JjVDbO/giphy.gif?cid=d1fd59abwmnnwmc5hgw8u8ywdhopug57y3wjw8w8rzbh8qrc&rid=giphy.gif&ct=g)
