### PR TITLE
feat(tt): disable castingwords order to test Whisper transcripts

### DIFF
--- a/apps/total-typescript/src/lib/sanity.ts
+++ b/apps/total-typescript/src/lib/sanity.ts
@@ -98,7 +98,7 @@ export const writeTranscriptToVideoResource = async (
 
 const UpdateVideoResourceAssetSchema = z.object({
   sanityDocumentId: z.string(),
-  castingwordsOrder: CastingWordsOrderResponseSchema,
+  // castingwordsOrder: CastingWordsOrderResponseSchema,
   muxAsset: z.object({
     muxAssetId: z.string(),
     muxPlaybackId: z.string().optional(),
@@ -109,17 +109,17 @@ type UpdateVideoResourceAsset = z.infer<typeof UpdateVideoResourceAssetSchema>
 
 export const updateVideoResourceWithTranscriptOrderId = async ({
   sanityDocumentId,
-  castingwordsOrder,
+  // castingwordsOrder,
   muxAsset,
 }: UpdateVideoResourceAsset) => {
   return sanityWriteClient
     .patch(sanityDocumentId)
     .set({
       muxAsset,
-      castingwords: {
-        orderId: castingwordsOrder.order,
-        audioFileId: String(first(castingwordsOrder.audiofiles)),
-      },
+      // castingwords: {
+      //   orderId: castingwordsOrder.order,
+      //   audioFileId: String(first(castingwordsOrder.audiofiles)),
+      // },
     })
     .commit()
 }

--- a/apps/total-typescript/src/pages/api/webhooks/sanity/videoResource/created.ts
+++ b/apps/total-typescript/src/pages/api/webhooks/sanity/videoResource/created.ts
@@ -29,7 +29,8 @@ const sanityVideoResourceWebhook = async (
       console.info('processing Sanity webhook: Video Resource created', _id)
 
       if (!castingwords?.orderId && !castingwords?.transcript) {
-        const castingwordsOrder = await orderTranscript(originalMediaUrl)
+        // Disabling castingwords ordering while we experiment with using Whisper to order transcripts
+        // const castingwordsOrder = await orderTranscript(originalMediaUrl)
 
         const {Video} = new Mux()
 
@@ -38,9 +39,12 @@ const sanityVideoResourceWebhook = async (
           playback_policy: ['public'],
         })
 
+        console.info('new mux asset created', muxAsset.id)
+
+        // New function signature while we experiment with using Whisper to order transcripts
         await updateVideoResourceWithTranscriptOrderId({
           sanityDocumentId: _id,
-          castingwordsOrder,
+          // castingwordsOrder,
           muxAsset: {
             muxAssetId: muxAsset.id,
             muxPlaybackId: muxAsset.playback_ids?.find((playback_id) => {


### PR DESCRIPTION
For the next workshop, we are testing out a workflow where we order our transcripts using Whisper instead of Castingwords.

I've "unplugged" castingwords from the create sanity document handler so that we aren't paying for those transcripts to be done while we use Whisper.  

![shh](https://media4.giphy.com/media/U7isUDZ6VPWJW/giphy.gif?cid=01d288b0sf4ty662i0l8l8pkc4a919qole1e1z3nn0lcmjnk&rid=giphy.gif&ct=g)