### PR TITLE
build: check if pnpm 7.13.6 breaks the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "turbo": "~1.4.7",
     "typescript": "^4.8.3"
   },
-  "packageManager": "pnpm@7.13.2",
+  "packageManager": "pnpm@7.13.6",
   "manypkg": {
     "ignoredRules": [
       "INTERNAL_MISMATCH"


### PR DESCRIPTION
I just confirmed that pnpm 7.13.5 still breaks several of our builds (https://github.com/skillrecordings/products/pull/539). This is a secondary experiment to see if the now latest release (7.13.6) will also break it or not. 

![maze](https://media0.giphy.com/media/ACLCA6bvwBEvC/giphy.gif?cid=d1fd59aboph7u79yoq4w3agbwqk07ttv8q5yrwm6mduutizu&rid=giphy.gif&ct=g)