### PR TITLE
fix(ta): cannot serialize undefined, pass null

### DIFF
--- a/apps/testingaccessibility/src/pages/thanks/purchase.tsx
+++ b/apps/testingaccessibility/src/pages/thanks/purchase.tsx
@@ -18,7 +18,7 @@ const thanksProps = z.object({
   email: z.string().email(),
   seatsPurchased: z.number(),
   purchaseType: purchaseTypeSchema,
-  bulkCouponId: z.string().optional(),
+  bulkCouponId: z.string().or(z.null()),
 })
 type ThanksProps = z.infer<typeof thanksProps>
 
@@ -80,7 +80,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     email,
     seatsPurchased,
     purchaseType,
-    bulkCouponId: purchase.bulkCoupon?.id,
+    bulkCouponId: purchase.bulkCoupon?.id || null,
   })
 
   return {


### PR DESCRIPTION
Post Purchase page was broken for individual purchases because Next.js cannot serialize `undefined`. Pass the value down as `null` instead.

![null](https://media0.giphy.com/media/KDnxbHF3N7EDKhZIGE/giphy.gif?cid=d1fd59abpu7gz8ngvy5ys5vgy4ph8c1mz4mlq4q6doo69tgq&rid=giphy.gif&ct=g)