### PR TITLE
build(tests): add e2e tests to github actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
       preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
     steps:
       - name: Wait for Vercel preview deployment to be ready
-        uses: patrickedqvist/wait-for-vercel-preview@1.2.0
+        uses: patrickedqvist/wait-for-vercel-preview@v1.2.0
         id: waitForVercelPreviewDeployment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,51 @@
+name: Integration Tests
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  test_setup:
+    name: Test setup
+    runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
+    steps:
+      - name: Wait for Vercel preview deployment to be ready
+        uses: patrickedqvist/wait-for-vercel-preview@1.2.0
+        id: waitForVercelPreviewDeployment
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 600
+
+  test_e2e:
+    needs: tests_setup
+    name: Playwright tests
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - uses: pnpm/action-setup@v2.0.1
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 7
+          run_install: false
+
+      - name: Cache pnpm modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      # - run: pnpm exec playwright install --with-deps
+      - name: Run tests
+        run: pnpm -- turbo run test:e2e --team=skillrecordings --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: ${{ needs.test_setup.outputs.preview_url }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,8 +44,10 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      # - run: pnpm exec playwright install --with-deps
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
+
       - name: Run tests
-        run: pnpm -- turbo run test:e2e --team=skillrecordings --token=${{ secrets.VERCEL_TOKEN }}
+        run: "pnpm -- turbo run test:e2e --team=skillrecordings --token=${{ secrets.VERCEL_TOKEN }}"
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ needs.test_setup.outputs.preview_url }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,8 @@
 name: Integration Tests
 on:
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
+
 jobs:
   test_setup:
     name: Test setup
@@ -18,7 +18,7 @@ jobs:
           max_timeout: 600
 
   test_e2e:
-    needs: tests_setup
+    needs: test_setup
     name: Playwright tests
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Run Linting and Tests
+    name: Run Linting and Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -36,9 +36,3 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: pnpm -- turbo run generate test lint --team=skillrecordings --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Run Integration Tests
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: pnpm -- turbo run test:e2e --team=skillrecordings --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,14 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Run Tests
+      - name: Run Unit Tests
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: pnpm -- turbo run generate test lint --team=skillrecordings --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Run Integration Tests
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: pnpm -- turbo run test:e2e --team=skillrecordings --token=${{ secrets.VERCEL_TOKEN }}

--- a/apps/testingaccessibility/playwright.config.ts
+++ b/apps/testingaccessibility/playwright.config.ts
@@ -1,0 +1,7 @@
+import {PlaywrightTestConfig} from '@playwright/test'
+const config: PlaywrightTestConfig = {
+  use: {
+    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3013',
+  },
+}
+export default config

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sort": "npx sort-package-json \"package.json\" \"packages/*/package.json\" \"apps/*/package.json\"",
     "start": "turbo run start",
     "test": "turbo run test",
+    "test:e2e": "turbo run test:e2e",
     "version:canary": "changeset version --snapshot canary"
   },
   "lint-staged": {

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,9 @@
     "test": {
       "dependsOn": ["^build", "generate"]
     },
+    "test:e2e": {
+      "dependsOn": ["^build", "generate"]
+    },
     "deploy": {
       "dependsOn": ["generate", "build", "test", "lint"]
     },


### PR DESCRIPTION
This sets up the Playwright e2e tests to run via GitHub Actions.

![verify](https://media4.giphy.com/media/54pMajJIlSuIRy8I5L/giphy.gif?cid=95df73492t70linlqwxad03u82s7a7s6pjc5ywum86auhy8c&rid=giphy.gif&ct=g)