### PR TITLE
feat(ta): use entire team invite component on post-purchase page

### DIFF
--- a/apps/testingaccessibility/src/components/team/index.tsx
+++ b/apps/testingaccessibility/src/components/team/index.tsx
@@ -9,14 +9,14 @@ type InviteTeamProps = {
     product: {id: string; name: string}
   }
   existingPurchaseForSelf: boolean
-  session: any
+  userEmail?: string | null
   setPersonalPurchase: (props: any) => void
 }
 
 const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
   purchase,
   existingPurchaseForSelf,
-  session,
+  userEmail,
   setPersonalPurchase,
 }) => {
   const redemptionsLeft =
@@ -29,7 +29,6 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
   const [canRedeem, setCanRedeem] = React.useState(
     Boolean(redemptionsLeft && !existingPurchaseForSelf),
   )
-  const userEmail = session?.user?.email
   const bulkCouponId = purchase?.bulkCoupon?.id
 
   return (

--- a/apps/testingaccessibility/src/components/team/index.tsx
+++ b/apps/testingaccessibility/src/components/team/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import SelfRedeemButton from './self-redeem-button'
 import CopyInviteLink from './copy-invite-link'
-import Link from 'next/link'
 
 type InviteTeamProps = {
   purchase: {
@@ -65,11 +64,10 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
       )}
       {!redemptionsLeft && (
         <div className="flex items-center justify-between mt-5 pt-5 border-t border-gray-100">
-          <Link href="/#buy">
-            <a className="font-semibold bg-green-500 transition text-white px-4 py-2 hover:bg-green-600 rounded-md flex-shrink-0">
-              Buy more seats
-            </a>
-          </Link>
+          <p className="py-3">
+            You are out of seats. To invite more people to your team, buy more
+            seats.
+          </p>
         </div>
       )}
     </>

--- a/apps/testingaccessibility/src/components/team/index.tsx
+++ b/apps/testingaccessibility/src/components/team/index.tsx
@@ -9,17 +9,14 @@ type InviteTeamProps = {
     bulkCoupon: {id: string; maxUses: number; usedCount: number} | null
     product: {id: string; name: string}
   }
-  existingPurchase: {
-    id: string
-    product: {id: string; name: string}
-  }
+  existingPurchaseForSelf: boolean
   session: any
   setPersonalPurchase: (props: any) => void
 }
 
 const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
   purchase,
-  existingPurchase,
+  existingPurchaseForSelf,
   session,
   setPersonalPurchase,
 }) => {
@@ -31,7 +28,7 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
     purchase?.bulkCoupon.maxUses - purchase.bulkCoupon.usedCount
 
   const [canRedeem, setCanRedeem] = React.useState(
-    Boolean(redemptionsLeft && !existingPurchase),
+    Boolean(redemptionsLeft && !existingPurchaseForSelf),
   )
   const userEmail = session?.user?.email
   const bulkCouponId = purchase?.bulkCoupon?.id

--- a/apps/testingaccessibility/src/components/team/index.tsx
+++ b/apps/testingaccessibility/src/components/team/index.tsx
@@ -10,15 +10,19 @@ type InviteTeamProps = {
   }
   existingPurchaseForSelf: boolean
   userEmail?: string | null
-  setPersonalPurchase: (props: any) => void
 }
 
 const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
   purchase,
   existingPurchaseForSelf,
   userEmail,
-  setPersonalPurchase,
 }) => {
+  const [newSelfRedemption, setNewSelfRedemption] = React.useState<
+    object | undefined
+  >()
+
+  const hasPurchasedForSelf = existingPurchaseForSelf || newSelfRedemption
+
   const redemptionsLeft =
     purchase.bulkCoupon &&
     purchase.bulkCoupon.maxUses > purchase.bulkCoupon.usedCount
@@ -27,7 +31,7 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
     purchase?.bulkCoupon.maxUses - purchase.bulkCoupon.usedCount
 
   const [canRedeem, setCanRedeem] = React.useState(
-    Boolean(redemptionsLeft && !existingPurchaseForSelf),
+    Boolean(redemptionsLeft && !hasPurchasedForSelf),
   )
   const bulkCouponId = purchase?.bulkCoupon?.id
 
@@ -54,7 +58,7 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
                 userEmail={userEmail}
                 onSuccess={(redeemedPurchase) => {
                   setCanRedeem(false)
-                  setPersonalPurchase(redeemedPurchase)
+                  setNewSelfRedemption(redeemedPurchase)
                 }}
               />
             </div>

--- a/apps/testingaccessibility/src/pages/team/index.tsx
+++ b/apps/testingaccessibility/src/pages/team/index.tsx
@@ -32,8 +32,11 @@ export const getServerSideProps: GetServerSideProps = async ({req}) => {
     if (token && isString(purchaseId) && isString(token?.sub)) {
       // the `existingIndividualPurchase` is a non-bulk purchase, so did this
       // person already purchase individual access to the product?
-      const {purchase, existingIndividualPurchase, availableUpgrades} =
-        await getPurchaseDetails(purchaseId, token.sub)
+      const {
+        purchase,
+        existingPurchase: existingIndividualPurchase,
+        availableUpgrades,
+      } = await getPurchaseDetails(purchaseId, token.sub)
       return purchase
         ? {
             props: {

--- a/apps/testingaccessibility/src/pages/team/index.tsx
+++ b/apps/testingaccessibility/src/pages/team/index.tsx
@@ -7,7 +7,6 @@ import {getPurchasedProduct} from 'lib/get-purchased-product'
 import InviteTeam from 'components/team'
 import BuyMoreSeats from 'components/team/buy-more-seats'
 import {UserGroupIcon, TicketIcon} from '@heroicons/react/outline'
-import Link from 'next/link'
 import {useSession} from 'next-auth/react'
 import {getCurrentAbility} from '@skillrecordings/ability'
 import {getToken} from 'next-auth/jwt'
@@ -72,7 +71,6 @@ type TeamPageProps = {
 const TeamPage: React.FC<React.PropsWithChildren<TeamPageProps>> = ({
   purchase,
   existingPurchase,
-  availableUpgrades,
   userId,
 }) => {
   const {data: session} = useSession()

--- a/apps/testingaccessibility/src/pages/team/index.tsx
+++ b/apps/testingaccessibility/src/pages/team/index.tsx
@@ -95,7 +95,7 @@ const TeamPage: React.FC<React.PropsWithChildren<TeamPageProps>> = ({
           <InviteTeam
             session={session}
             purchase={purchase}
-            existingPurchase={existingPurchase}
+            existingPurchaseForSelf={!!existingPurchase}
             setPersonalPurchase={setPersonalPurchase}
           />
         </Card>

--- a/apps/testingaccessibility/src/pages/team/index.tsx
+++ b/apps/testingaccessibility/src/pages/team/index.tsx
@@ -91,7 +91,7 @@ const TeamPage: React.FC<React.PropsWithChildren<TeamPageProps>> = ({
           }
         >
           <InviteTeam
-            session={session}
+            userEmail={session?.user?.email}
             purchase={purchase}
             existingPurchaseForSelf={!!personalPurchase}
             setPersonalPurchase={setPersonalPurchase}

--- a/apps/testingaccessibility/src/pages/team/index.tsx
+++ b/apps/testingaccessibility/src/pages/team/index.tsx
@@ -95,7 +95,7 @@ const TeamPage: React.FC<React.PropsWithChildren<TeamPageProps>> = ({
           <InviteTeam
             session={session}
             purchase={purchase}
-            existingPurchaseForSelf={!!existingPurchase}
+            existingPurchaseForSelf={!!personalPurchase}
             setPersonalPurchase={setPersonalPurchase}
           />
         </Card>

--- a/packages/commerce-server/src/prisma-next-serializer.ts
+++ b/packages/commerce-server/src/prisma-next-serializer.ts
@@ -8,6 +8,8 @@ export function convertToSerializeForNextResponse(result: any) {
       result[resultKey] = result[resultKey].toISOString()
     } else if (result[resultKey]?.constructor?.name === 'Decimal') {
       result[resultKey] = result[resultKey].toNumber()
+    } else if (result[resultKey] instanceof Object) {
+      result[resultKey] = convertToSerializeForNextResponse(result[resultKey])
     }
   }
 

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -100,6 +100,8 @@ export function getSdk(
             })
           : []
 
+      // TODO: unclear if this is meant to represent an individual seat
+      // purchase, a redemption purchase, or both?
       const existingPurchase = await ctx.prisma.purchase.findFirst({
         where: {
           userId,
@@ -122,7 +124,7 @@ export function getSdk(
       })
       return {
         purchase,
-        existingIndividualPurchase: existingPurchase,
+        existingPurchase,
         availableUpgrades,
       }
     },

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -8,6 +8,32 @@ export function getSdk(
   {ctx = defaultContext}: SDKOptions = {ctx: defaultContext},
 ) {
   return {
+    async getBulkCouponRedemptionPurchase(
+      bulkCouponId: string | null,
+      userId: string | null,
+    ) {
+      if (!bulkCouponId && !userId) return null
+
+      const purchase = await ctx.prisma.purchase.findFirst({
+        where: {
+          userId,
+          redeemedBulkCouponId: bulkCouponId,
+          status: 'Valid',
+        },
+        select: {
+          id: true,
+          redeemedBulkCoupon: {
+            select: {
+              id: true,
+              maxUses: true,
+              usedCount: true,
+            },
+          },
+        },
+      })
+
+      return purchase
+    },
     async getPurchaseDetails(purchaseId: string, userId: string) {
       const allPurchases = await ctx.prisma.purchase.findMany({
         where: {
@@ -96,7 +122,7 @@ export function getSdk(
       })
       return {
         purchase,
-        existingPurchase,
+        existingIndividualPurchase: existingPurchase,
         availableUpgrades,
       }
     },


### PR DESCRIPTION
@vojtaholik requested that the entire `TeamInvite` component be used on the post-purchase page for consistency with the Team Invite page. This PR achieves that by doing a little extra data fetching.

This pairs will with allowing team owners to purchase more seats because the first page they see after their purchase has a copiable link to share with their team. 

Here is what that page will look like:

<img width="1133" alt="CleanShot 2022-11-01 at 15 27 29@2x" src="https://user-images.githubusercontent.com/694063/199334748-52d304db-180f-4482-becf-6412c1a0f8d6.png">

![the bear](https://media1.giphy.com/media/xSFG9LiuRRCejUxkFx/giphy.gif?cid=d1fd59abieju4iau3hu82egbno65z5edsgdlin6lg54qxl6u&rid=giphy.gif&ct=g)