### PR TITLE
feat(ta): allow Individual to upgrade to Team

### DIFF
--- a/apps/testingaccessibility/src/pages/team/buy-more-seats.tsx
+++ b/apps/testingaccessibility/src/pages/team/buy-more-seats.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import Layout from 'components/app/layout'
+import {convertToSerializeForNextResponse} from '@skillrecordings/commerce-server'
+import {GetServerSideProps} from 'next'
+import BuyMoreSeats from 'components/team/buy-more-seats'
+import {TicketIcon} from '@heroicons/react/outline'
+import {getCurrentAbility} from '@skillrecordings/ability'
+import {getToken} from 'next-auth/jwt'
+import {getSdk} from '@skillrecordings/database'
+import Card from 'components/team/card'
+
+export const getServerSideProps: GetServerSideProps = async ({req}) => {
+  const token = await getToken({req})
+  const ability = getCurrentAbility(token as any)
+  const {getPurchasesForUser} = getSdk()
+
+  const purchases = await getPurchasesForUser(token?.sub)
+
+  // try to find a bulk purchase first
+  const bulkPurchases = purchases.filter(
+    (purchase) => purchase.bulkCoupon !== null,
+  )
+
+  // try to find individual-access purchase
+  const individualPurchase = purchases.find(
+    (purchase) =>
+      purchase.bulkCoupon === null && purchase.redeemedBulkCouponId === null,
+  )
+
+  const existingPurchase = bulkPurchases[0] || individualPurchase
+
+  if (token?.sub && existingPurchase) {
+    return {
+      props: {
+        purchase: convertToSerializeForNextResponse(existingPurchase),
+        userId: token.sub,
+      },
+    }
+  } else {
+    return {
+      redirect: {
+        destination: `/`,
+        permanent: false,
+      },
+    }
+  }
+}
+
+type BuyMoreSeatsPageProps = {
+  purchase: {
+    merchantChargeId: string | null
+    bulkCoupon: {id: string; maxUses: number; usedCount: number} | null
+    product: {id: string; name: string}
+  }
+  userId: string
+}
+
+const BuyMoreSeatsPage: React.FC<
+  React.PropsWithChildren<BuyMoreSeatsPageProps>
+> = ({purchase, userId}) => {
+  return (
+    <Layout
+      meta={{title: 'Invite your team to Testing Accessibility'}}
+      className="bg-green-700 bg-noise"
+    >
+      <main className="flex flex-col flex-grow items-center justify-center py-16 mx-auto w-full p-5 max-w-xl gap-3">
+        <Card
+          title={{content: 'Get more seats', as: 'h2'}}
+          icon={
+            <TicketIcon className="w-5 text-green-500" aria-hidden="true" />
+          }
+        >
+          <BuyMoreSeats productId={purchase.product.id} userId={userId} />
+        </Card>
+      </main>
+    </Layout>
+  )
+}
+
+export default BuyMoreSeatsPage

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -279,6 +279,7 @@ export function getSdk(
                   usedCount: true,
                 },
               },
+              redeemedBulkCouponId: true,
               product: {
                 select: {
                   id: true,


### PR DESCRIPTION
This feature was less involved than I originally anticipated. I thought it would require schema changes. It doesn't. And because of how we are already processing new and existing bulk purchases, this page can handle seat buying for both individuals and existing teams.

Roam Notes: https://roamresearch.com/#/app/egghead/page/bIpYsr441

---

This adds a page that a logged in user with a purchase can visit. It has
a 'Buy More Seats' component that takes the user to a Stripe Checkout
Session. Once they complete the purchase, a new Bulk Coupon will be
created for the user with that many seats. It doesn't impact their
existing individual purchase, which we maintain for record keeping and
to determine this user's access.

There is no top-level UI for accessing this page. Support can link a person directly to the `/team/buy-more-seats` page if they are wanting to upgrade from Individual to Team.

Here is the page:

<img width="950" alt="CleanShot 2022-11-03 at 12 56 09@2x" src="https://user-images.githubusercontent.com/694063/199798503-a7785117-4137-4c2e-b78a-9389b28a5e67.png">


Notice, after they complete the Stripe checkout session, they are dropped onto this post-purchase page.

<img width="1135" alt="CleanShot 2022-11-03 at 12 40 53@2x" src="https://user-images.githubusercontent.com/694063/199798124-4f08c61d-406e-4aef-9e37-3cd58a7ae9bf.png">


![individual](https://media1.giphy.com/media/jqrhjCDetWsx3AtwR3/giphy.gif?cid=d1fd59abr8jvwyj77mb7kqegoc322zyzp0b5ywgmy2bote8u&rid=giphy.gif&ct=g)
