### PR TITLE
fix(pt): tips page header padding + nav links hover state

### DIFF
--- a/apps/protailwind/src/components/navigation.tsx
+++ b/apps/protailwind/src/components/navigation.tsx
@@ -58,7 +58,7 @@ const NavLink: React.FC<NavLinkProps> = ({
       <a
         aria-current={isActive ? 'page' : undefined}
         className={cx(
-          'jusfify-center flex items-center gap-1 rounded-full px-4 py-2 transition hover:bg-gray-50',
+          'jusfify-center flex items-center gap-1 rounded-full px-4 py-2 transition hover:bg-gray-100',
           {
             'bg-gray-50': isActive,
           },

--- a/apps/protailwind/src/pages/tips/index.tsx
+++ b/apps/protailwind/src/pages/tips/index.tsx
@@ -37,7 +37,7 @@ const TipsIndex: React.FC<TipsIndex> = ({tips}) => {
       }}
       className="sm:pt-18 flex flex-col items-center pb-16 pt-16 lg:pt-20 lg:pb-24"
     >
-      <header className="relative z-10 flex flex-col items-center pb-16 text-center">
+      <header className="relative z-10 flex flex-col items-center px-5 pb-16 text-center">
         <h1 className="text-center font-heading text-4xl font-black sm:text-5xl lg:text-6xl">
           Tailwind Tips
         </h1>


### PR DESCRIPTION
This small PR adds a `px-5` class to the header of the Tips page, to make sure the text doesn't touch the edges of the viewport on small screens.

I also made the hover state for the nav links a tiny bit darker (`bg-gray-100` instead of `gray-50`).

![Excited corgi](https://thumbs.gfycat.com/LightTastyIrishwolfhound-size_restricted.gif)