### PR TITLE
feat: creating a stripe sdk for simplified mocking

### DIFF
--- a/packages/commerce-server/src/record-new-purchase.ts
+++ b/packages/commerce-server/src/record-new-purchase.ts
@@ -1,13 +1,13 @@
 import {Stripe} from 'stripe'
 import {first} from 'lodash'
 import {type Purchase, prisma, getSdk} from '@skillrecordings/database'
-import {stripe} from './stripe'
 import {z} from 'zod'
 import {
   EXISTING_BULK_COUPON,
   NEW_BULK_COUPON,
   NEW_INDIVIDUAL_PURCHASE,
 } from '@skillrecordings/types'
+import {getStripeSdk} from '@skillrecordings/stripe-sdk/src'
 
 export class PurchaseError extends Error {
   checkoutSessionId: string
@@ -29,16 +29,9 @@ export class PurchaseError extends Error {
 }
 
 export async function stripeData(checkoutSessionId: string) {
-  const checkoutSession = await stripe.checkout.sessions.retrieve(
-    checkoutSessionId,
-    {
-      expand: [
-        'customer',
-        'line_items.data.price.product',
-        'payment_intent.charges',
-      ],
-    },
-  )
+  const {getCheckoutSession} = getStripeSdk()
+
+  const checkoutSession = await getCheckoutSession(checkoutSessionId)
 
   const {customer, line_items, payment_intent} = checkoutSession
   const {email, name, id: stripeCustomerId} = customer as Stripe.Customer

--- a/packages/commerce-server/src/record-new-purchase.ts
+++ b/packages/commerce-server/src/record-new-purchase.ts
@@ -7,7 +7,7 @@ import {
   NEW_BULK_COUPON,
   NEW_INDIVIDUAL_PURCHASE,
 } from '@skillrecordings/types'
-import {getStripeSdk} from '@skillrecordings/stripe-sdk/src'
+import {getStripeSdk} from '@skillrecordings/stripe-sdk'
 
 export class PurchaseError extends Error {
   checkoutSessionId: string

--- a/packages/stripe-sdk/.eslintrc.js
+++ b/packages/stripe-sdk/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['custom'],
+}

--- a/packages/stripe-sdk/.gitignore
+++ b/packages/stripe-sdk/.gitignore
@@ -1,0 +1,3 @@
+/dist
+/generated
+.env

--- a/packages/stripe-sdk/package.json
+++ b/packages/stripe-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skillrecordings/commerce-server",
+  "name": "@skillrecordings/stripe-sdk",
   "version": "1.0.0",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -9,36 +9,30 @@
   ],
   "scripts": {
     "build": "tsup",
-    "clean": "rimraf .turbo node_modules dist",
+    "clean": "rimraf node_modules dist",
     "dev": "tsup --watch",
-    "lint": "eslint ./src --fix",
-    "test": "jest"
+    "lint": "eslint ./src --fix"
   },
   "dependencies": {
-    "@casl/ability": "^6.0.0",
-    "@skillrecordings/database": "workspace:*",
-    "@skillrecordings/stripe-sdk": "workspace:*",
+    "cookie": "^0.5.0",
     "date-fns": "^2.28.0",
     "lodash": "^4.17.21",
-    "stripe": "^8.186.1",
-    "zod": "^3.19.1"
+    "node-fetch": "^2.6.7",
+    "encoding": "^0.1.0",
+    "stripe": "^8.186.1"
   },
   "devDependencies": {
-    "@skillrecordings/scripts": "workspace:*",
     "@skillrecordings/tsconfig": "workspace:*",
-    "@skillrecordings/types": "workspace:*",
-    "@types/jest": "^27.5.2",
+    "@types/cookie": "^0.4.1",
     "@types/lodash": "^4.14.179",
     "@types/node": "^18.6.1",
+    "@types/node-fetch": "^2.6.2",
     "eslint": "^8.12.0",
     "eslint-config-custom": "workspace:*",
+    "jest-mock-extended": "^2.0.7",
     "rimraf": "^3.0.2",
     "tsup": "^5.11.13",
     "tsx": "^3.7.1",
     "typescript": "^4.8.3"
-  },
-  "jest": {
-    "preset": "@skillrecordings/scripts/jest/node",
-    "testEnvironment": "node"
   }
 }

--- a/packages/stripe-sdk/process.d.ts
+++ b/packages/stripe-sdk/process.d.ts
@@ -1,0 +1,5 @@
+declare namespace NodeJS {
+  export interface ProcessEnv {
+    STRIPE_SECRET_TOKEN: string
+  }
+}

--- a/packages/stripe-sdk/src/index.ts
+++ b/packages/stripe-sdk/src/index.ts
@@ -1,2 +1,2 @@
 export * from './stripe-client-context'
-export * from './stripe-sdk'
+export {getStripeSdk} from './stripe-sdk'

--- a/packages/stripe-sdk/src/index.ts
+++ b/packages/stripe-sdk/src/index.ts
@@ -1,0 +1,2 @@
+export * from './stripe-client-context'
+export * from './stripe-sdk'

--- a/packages/stripe-sdk/src/stripe-client-context.ts
+++ b/packages/stripe-sdk/src/stripe-client-context.ts
@@ -1,0 +1,23 @@
+import {mockDeep, DeepMockProxy} from 'jest-mock-extended'
+
+import Stripe from 'stripe'
+
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_TOKEN, {
+  apiVersion: '2020-08-27',
+})
+
+export const defaultContext: Context = {stripe: stripeClient}
+
+export type Context = {
+  stripe: Stripe
+}
+
+export type MockContext = {
+  stripe: DeepMockProxy<Stripe>
+}
+
+export const createMockContext = (): MockContext => {
+  return {
+    stripe: mockDeep<Stripe>(),
+  }
+}

--- a/packages/stripe-sdk/src/stripe-sdk.ts
+++ b/packages/stripe-sdk/src/stripe-sdk.ts
@@ -1,0 +1,19 @@
+import {Context, defaultContext} from './stripe-client-context'
+
+type SDKOptions = {ctx?: Context}
+
+export function getStripeSdk(
+  {ctx = defaultContext}: SDKOptions = {ctx: defaultContext},
+) {
+  return {
+    async getCheckoutSession(checkoutSessionId: string) {
+      return await ctx.stripe.checkout.sessions.retrieve(checkoutSessionId, {
+        expand: [
+          'customer',
+          'line_items.data.price.product',
+          'payment_intent.charges',
+        ],
+      })
+    },
+  }
+}

--- a/packages/stripe-sdk/tsconfig.json
+++ b/packages/stripe-sdk/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@skillrecordings/tsconfig/node16.json",
+  "include": ["process.d.ts", "**/*.ts", "**/*.tsx", "tsup.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/stripe-sdk/tsup.config.ts
+++ b/packages/stripe-sdk/tsup.config.ts
@@ -1,0 +1,12 @@
+import {defineConfig} from 'tsup'
+
+const isProduction = process.env.NODE_ENV === 'production'
+
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  minify: isProduction,
+  sourcemap: true,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2856,6 +2856,7 @@ importers:
       '@casl/ability': ^6.0.0
       '@skillrecordings/database': workspace:*
       '@skillrecordings/scripts': workspace:*
+      '@skillrecordings/stripe-sdk': workspace:*
       '@skillrecordings/tsconfig': workspace:*
       '@skillrecordings/types': workspace:*
       '@types/jest': ^27.5.2
@@ -2874,6 +2875,7 @@ importers:
     dependencies:
       '@casl/ability': 6.0.0
       '@skillrecordings/database': link:../database
+      '@skillrecordings/stripe-sdk': link:../stripe-sdk
       date-fns: 2.28.0
       lodash: 4.17.21
       stripe: 8.209.0
@@ -3640,6 +3642,47 @@ importers:
       react-dom: 18.2.0_react@18.2.0
       typescript: 4.8.3
       whatwg-fetch: 3.6.2
+
+  packages/stripe-sdk:
+    specifiers:
+      '@skillrecordings/tsconfig': workspace:*
+      '@types/cookie': ^0.4.1
+      '@types/lodash': ^4.14.179
+      '@types/node': ^18.6.1
+      '@types/node-fetch': ^2.6.2
+      cookie: ^0.5.0
+      date-fns: ^2.28.0
+      encoding: ^0.1.0
+      eslint: ^8.12.0
+      eslint-config-custom: workspace:*
+      jest-mock-extended: ^2.0.7
+      lodash: ^4.17.21
+      node-fetch: ^2.6.7
+      rimraf: ^3.0.2
+      stripe: ^8.186.1
+      tsup: ^5.11.13
+      tsx: ^3.7.1
+      typescript: ^4.8.3
+    dependencies:
+      cookie: 0.5.0
+      date-fns: 2.28.0
+      encoding: 0.1.13
+      lodash: 4.17.21
+      node-fetch: 2.6.7_encoding@0.1.13
+      stripe: 8.209.0
+    devDependencies:
+      '@skillrecordings/tsconfig': link:../tsconfig
+      '@types/cookie': 0.4.1
+      '@types/lodash': 4.14.186
+      '@types/node': 18.6.3
+      '@types/node-fetch': 2.6.2
+      eslint: 8.22.0
+      eslint-config-custom: link:../eslint-config-custom
+      jest-mock-extended: 2.0.7_typescript@4.8.4
+      rimraf: 3.0.2
+      tsup: 5.12.9_typescript@4.8.4
+      tsx: 3.8.0
+      typescript: 4.8.4
 
   packages/time:
     specifiers:
@@ -11441,13 +11484,13 @@ packages:
   /@types/lodash.clonedeep/4.5.7:
     resolution: {integrity: sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==}
     dependencies:
-      '@types/lodash': 4.14.185
+      '@types/lodash': 4.14.186
     dev: false
 
   /@types/lodash.debounce/4.0.7:
     resolution: {integrity: sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==}
     dependencies:
-      '@types/lodash': 4.14.185
+      '@types/lodash': 4.14.186
     dev: false
 
   /@types/lodash/4.14.180:
@@ -11456,10 +11499,10 @@ packages:
 
   /@types/lodash/4.14.185:
     resolution: {integrity: sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==}
+    dev: true
 
   /@types/lodash/4.14.186:
     resolution: {integrity: sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==}
-    dev: true
 
   /@types/markdown-it/12.2.3:
     resolution: {integrity: sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==}
@@ -12788,7 +12831,9 @@ packages:
       abort-controller: 3.0.0
       abortcontroller-polyfill: 1.7.3
       lodash: 4.17.21
-      node-fetch: 2.6.6
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /ajv-errors/1.0.1_ajv@6.12.6:
@@ -20349,6 +20394,16 @@ packages:
       typescript: 4.8.3
     dev: true
 
+  /jest-mock-extended/2.0.7_typescript@4.8.4:
+    resolution: {integrity: sha512-h8brJJN5BZb03hTwplvt+raT6Nj0U2U71Z26Py12Qc3kvYnAjDW/zSuQJLnXCNyyufy592VC9k3X7AOz+2H52g==}
+    peerDependencies:
+      jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0
+      typescript: ^3.0.0 || ^4.0.0
+    dependencies:
+      ts-essentials: 7.0.3_typescript@4.8.4
+      typescript: 4.8.4
+    dev: true
+
   /jest-mock/25.5.0:
     resolution: {integrity: sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==}
     engines: {node: '>= 8.3'}
@@ -23120,7 +23175,7 @@ packages:
       '@corex/deepmerge': 4.0.29
       '@next/env': 12.3.0
       minimist: 1.2.6
-      next: 12.3.1_sfoxds7t5ydpegc3knd667wn6m
+      next: 12.3.1_biqbaboplfbrettd7655fr4n2y
     dev: false
 
   /next-sitemap/3.1.7_next@12.3.1:
@@ -23423,13 +23478,6 @@ packages:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.4.0
-    dev: false
-
-  /node-fetch/2.6.6:
-    resolution: {integrity: sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==}
-    engines: {node: 4.x || >=6.0.0}
-    dependencies:
-      whatwg-url: 5.0.0
     dev: false
 
   /node-fetch/2.6.7:
@@ -29048,6 +29096,14 @@ packages:
     dependencies:
       typescript: 4.8.3
 
+  /ts-essentials/7.0.3_typescript@4.8.4:
+    resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
+    peerDependencies:
+      typescript: '>=3.7.0'
+    dependencies:
+      typescript: 4.8.4
+    dev: true
+
   /ts-expect/1.3.0:
     resolution: {integrity: sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==}
     dev: false
@@ -29236,6 +29292,41 @@ packages:
       sucrase: 3.24.0
       tree-kill: 1.2.2
       typescript: 4.8.3
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
+  /tsup/5.12.9_typescript@4.8.4:
+    resolution: {integrity: sha512-dUpuouWZYe40lLufo64qEhDpIDsWhRbr2expv5dHEMjwqeKJS2aXA/FPqs1dxO4T6mBojo7rvo3jP9NNzaKyDg==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: ^4.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 3.0.4_esbuild@0.14.50
+      cac: 6.7.12
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.14.50
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 3.1.4
+      resolve-from: 5.0.0
+      rollup: 2.77.2
+      source-map: 0.8.0-beta.0
+      sucrase: 3.24.0
+      tree-kill: 1.2.2
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -30824,7 +30915,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@babel/runtime': 7.18.3
-      '@types/lodash': 4.14.185
+      '@types/lodash': 4.14.186
       lodash: 4.17.21
       lodash-es: 4.17.21
       nanoclone: 0.2.1


### PR DESCRIPTION
[⭐️ long 45m end-to-end loom video of creating this PR](https://www.loom.com/share/28d14ea87b7b410092abd70d74d8bcb6)

<img width="642" alt="Screen Shot 2022-11-08 at 10 14 09" src="https://user-images.githubusercontent.com/86834/200643245-7ecfc6e6-9267-4310-a2e7-249682261749.png">

we are exploring how to mock out services to test some of our commerce workflows. In this PR, I looked at how we were mocking `prisma` in the `@skillrecordings/database` package utilizing a database SDK that wraps `prisma` in a lightweight typed mockable context using `jest-mock-extended`

This PR introduces `@skillrecordings/stripe-sdk` which provides a similar mockable context for testing stripe without using a heavier solution for now using simple data objects as mocks.

We should consider moving **all `stripe` calls** into this SDK instead of accessing the `stripe` library across the entire application and package surface area.

IMO, this is true for these service boundaries in general. They get wrapped.

![wrap it up](https://media.giphy.com/media/xVXvIOnkGY8IU/giphy.gif)