### PR TITLE
feat(db): move bulk coupon create into SDK

### DIFF
--- a/packages/commerce-server/src/record-new-purchase.ts
+++ b/packages/commerce-server/src/record-new-purchase.ts
@@ -83,6 +83,7 @@ export async function recordNewPurchase(checkoutSessionId: string): Promise<{
     findOrCreateUser,
     findOrCreateMerchantCustomer,
     createMerchantChargeAndPurchase,
+    getMerchantProduct,
   } = getSdk()
 
   const purchaseInfo = await stripeData({checkoutSessionId})
@@ -101,11 +102,7 @@ export async function recordNewPurchase(checkoutSessionId: string): Promise<{
 
   const {user, isNewUser} = await findOrCreateUser(email, name)
 
-  const merchantProduct = await prisma.merchantProduct.findFirst({
-    where: {
-      identifier: stripeProductId,
-    },
-  })
+  const merchantProduct = await getMerchantProduct(stripeProductId)
 
   if (!merchantProduct)
     throw new PurchaseError(

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -308,6 +308,13 @@ export function getSdk(
 
       return purchases
     },
+    async getMerchantProduct(stripeProductId: string) {
+      return ctx.prisma.merchantProduct.findFirst({
+        where: {
+          identifier: stripeProductId,
+        },
+      })
+    },
     async createMerchantChargeAndPurchase(options: {
       userId: string
       productId: string

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -323,6 +323,7 @@ export function getSdk(
       merchantProductId: string
       merchantCustomerId: string
       stripeChargeAmount: number
+      quantity?: number
     }) {
       const {
         userId,
@@ -332,6 +333,7 @@ export function getSdk(
         merchantCustomerId,
         productId,
         stripeChargeAmount,
+        quantity = 1,
       } = options
       // we are using uuids so we can generate this!
       // this is needed because the following actions
@@ -350,6 +352,56 @@ export function getSdk(
         },
       })
 
+      // Check if this user has already purchased a bulk coupon, in which
+      // case, we'll be able to treat this purchase as adding seats.
+      //
+      // TODO: I believe the `maxUses` check is redundant. If there is at
+      // least one `bulkCouponPurchase` attached to this Coupon, then it is a
+      // bulk coupon for this user.
+      const existingBulkCoupon = await ctx.prisma.coupon.findFirst({
+        where: {
+          maxUses: {
+            gt: 1,
+          },
+          bulkCouponPurchases: {
+            some: {userId},
+          },
+        },
+      })
+
+      // Note: if the user already has a bulk purchase/coupon, then if they are
+      // only adding 1 seat to the team, then it is still a "bulk purchase" and
+      // we need to add it to their existing Bulk Coupon.
+      const isBulkPurchase = quantity > 1 || !!existingBulkCoupon
+
+      let bulkCouponId = null
+      let coupon = null
+
+      if (isBulkPurchase) {
+        bulkCouponId = existingBulkCoupon ? existingBulkCoupon.id : v4()
+
+        // Create or Update Bulk Coupon Record
+        if (existingBulkCoupon) {
+          coupon = ctx.prisma.coupon.update({
+            where: {
+              id: existingBulkCoupon.id,
+            },
+            data: {
+              maxUses: existingBulkCoupon.maxUses + quantity,
+            },
+          })
+        } else {
+          coupon = ctx.prisma.coupon.create({
+            data: {
+              restrictedToProductId: productId,
+              maxUses: quantity,
+              percentageDiscount: 1.0,
+              status: 1,
+            },
+          })
+        }
+      }
+
       const purchase = ctx.prisma.purchase.create({
         data: {
           id: purchaseId,
@@ -357,12 +409,15 @@ export function getSdk(
           productId,
           merchantChargeId,
           totalAmount: stripeChargeAmount / 100,
+          bulkCouponId,
         },
       })
 
-      const result = await ctx.prisma.$transaction([merchantCharge, purchase])
-
-      return result
+      if (coupon) {
+        return await ctx.prisma.$transaction([merchantCharge, purchase, coupon])
+      } else {
+        return await ctx.prisma.$transaction([merchantCharge, purchase])
+      }
     },
     async findOrCreateMerchantCustomer({
       user,


### PR DESCRIPTION
The bulk coupon always gets created along with the purchase if it is a
purchase of a bulk coupon (or bulk coupon addition), so it makes sense
to push that up into the `createMerchantChargeAndPurchase` function.

This has the added benefit of removing the remaining direct Prisma DB
calls from the recordNewPurchase module.

![danny dvito](https://media0.giphy.com/media/uX7yXTe5UrCRW72DNr/giphy.gif?cid=d1fd59abdr9t1hqvuu03k6l303vryj8te5o0mx6ldv99gsid&rid=giphy.gif&ct=g)