### PR TITLE
feat(tt): add quick-and-dirty logout page

### DIFF
--- a/apps/total-typescript/src/pages/logout.tsx
+++ b/apps/total-typescript/src/pages/logout.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import {signOut} from 'next-auth/react'
+import {GetServerSideProps} from 'next'
+import {LogoutIcon} from '@heroicons/react/outline'
+import {isEmpty} from 'lodash'
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    props: {
+      redirectUrl: process.env.NEXTAUTH_URL,
+    },
+  }
+}
+
+const Logout = ({redirectUrl}: {redirectUrl?: string}) => {
+  const handleSignOut = async (redirectUrl?: string) => {
+    await signOut({
+      callbackUrl: redirectUrl,
+    }).then((data) => data)
+  }
+
+  const SignOutButton = React.forwardRef<
+    HTMLButtonElement,
+    {redirectUrl?: string; className?: string; active: boolean}
+  >(({className, active, redirectUrl, ...rest}, ref) => {
+    return (
+      <button
+        ref={ref}
+        {...rest}
+        onClick={async () => {
+          await handleSignOut(redirectUrl)
+          // toast.success('Signed out successfully')
+        }}
+        className={
+          !isEmpty(className)
+            ? className
+            : `${
+                active ? 'bg-gray-100' : 'text-gray-900'
+              } group flex w-full items-center rounded-md px-2 py-2 font-normal`
+        }
+      >
+        <span className="pr-2">Sign Out</span>
+        <LogoutIcon className="w-4" aria-hidden="true" />
+      </button>
+    )
+  })
+
+  return (
+    <SignOutButton
+      redirectUrl={redirectUrl}
+      active={false}
+      className="font-nav mt-5 flex w-full items-center justify-center rounded-md border border-transparent bg-cyan-500 px-5 py-4 text-lg font-semibold text-black transition focus:outline-none focus:ring-2 focus:ring-cyan-200 hover:bg-cyan-400"
+    />
+  )
+}
+
+export default Logout


### PR DESCRIPTION
I needed a way to log out of an account while building and smoke testing
features. So, I added a `/logout` page with a button that uses
NextAuth's `signOut()` function.

We'll eventually need a more robust logout mechanism. But this will work
for now.

A noteable issue I ran into while implementing this (which I was unable
to debug) is that the button redirects to `localhost:3000` instead of
`localhost:3016`. I've explicitly passed in a full redirect URL, I've
ensure there aren't any env vars set that could be interfering. Beyond
that, I don't have enough expose to NextAuth to know why it would be
redirect to a completely different port.

Even though it redirects to the wrong host, it does successfully clean
up the session, so I can navigate back to `localhost:3016` and continue
with what I'm doing.

<img width="1012" alt="CleanShot 2022-11-16 at 10 15 14@2x" src="https://user-images.githubusercontent.com/694063/202234448-63771038-928e-40fc-b1ca-399bcf4aeb00.png">


![log out](https://media3.giphy.com/media/UGw4U4w7sJ3Hi/giphy.gif?cid=d1fd59abcpxt7sfoz2c2d1wjl1sgekzrsei2ffieytq7cv6d&rid=giphy.gif&ct=g)
