### PR TITLE
cleanup(tt): clarify logic and removed unused imports in Ability

### DIFF
--- a/apps/total-typescript/src/ability/ability.ts
+++ b/apps/total-typescript/src/ability/ability.ts
@@ -2,12 +2,7 @@ import {Ability, AbilityBuilder, AbilityClass} from '@casl/ability'
 import {Exercise} from '../lib/exercises'
 import {SanityDocument} from '@sanity/client'
 import z from 'zod'
-import {Purchase} from '@skillrecordings/database'
-import {
-  hasAvailableSeats,
-  hasBulkPurchase,
-  hasInvoice,
-} from '@skillrecordings/ability'
+import {hasAvailableSeats, hasBulkPurchase} from '@skillrecordings/ability'
 
 const adminRoles = ['ADMIN', 'SUPERADMIN']
 


### PR DESCRIPTION
Using the tests that @joelhooks recently added for the Ability files to do some refactoring. My goal was to make the logic clearer and to remove some redundancy in the checks.

- cleanup(tt): remove unused Ability imports
- cleanup(tt): rearrange and clarify Ability logic

The git diff looks messy, but the resulting _determine rules block_ looks much cleaner at a glance.

<img width="686" alt="CleanShot 2022-11-21 at 11 52 18@2x" src="https://user-images.githubusercontent.com/694063/203125902-2baa7c11-2f08-4c49-90a9-0dbda3939197.png">



![clean up](https://media1.giphy.com/media/9PtfS5tTC8ejlYfCLU/giphy.gif?cid=d1fd59abft8tmnq5omhxprl1nyptfek5efkduhw28oir2kt9&rid=giphy.gif&ct=g)
