### PR TITLE
fix: path to Team Invite should be `/team`

### DIFF
--- a/apps/testingaccessibility/src/pages/thanks/purchase.tsx
+++ b/apps/testingaccessibility/src/pages/thanks/purchase.tsx
@@ -172,7 +172,7 @@ const ThanksVerify: React.FC<React.PropsWithChildren<ThanksProps>> = ({
                 </div>
                 <p className="text-sand-100 max-w-md font-medium leading-relaxed mx-auto mt-2">
                   You can also visit your{' '}
-                  <Link href="/team/invite">
+                  <Link href="/team">
                     <a className="py-1 inline-flex text-base font-medium hover:underline transition">
                       Team Invite
                     </a>

--- a/apps/total-typescript/src/pages/thanks/purchase.tsx
+++ b/apps/total-typescript/src/pages/thanks/purchase.tsx
@@ -123,7 +123,7 @@ const ThanksVerify: React.FC<
                 </div>
                 <p className="mx-auto mt-2 max-w-sm leading-relaxed text-gray-200 sm:text-lg">
                   You can also visit your{' '}
-                  <Link href="/team/invite">
+                  <Link href="/team">
                     <a className="inline-flex py-1 text-base font-medium transition hover:underline">
                       Team Invite
                     </a>


### PR DESCRIPTION
I noticed this path typo which started in TA and was copied into TT. This fixes both spots.

Roam: https://roamresearch.com/#/app/egghead/page/10mtvqNw8

![fix path](https://media2.giphy.com/media/xUPGcM9CazM9H5KrEA/giphy.gif?cid=d1fd59ablnmrfztj0rqevwxj187p75wrcb47945192qbcbev&rid=giphy.gif&ct=g)