### PR TITLE
fix: typo in index.mdx TypeScript Course

### DIFF
--- a/apps/typescriptcourse/src/pages/index.mdx
+++ b/apps/typescriptcourse/src/pages/index.mdx
@@ -83,7 +83,7 @@ So why isn't anyone helping you do that?
 
 Everyone wants to teach you how to “master” TypeScript.
 
-But no one's teaching you how to <span classNam="text-white">**build full-stack production-grade applications**</span> that help you move your career forward.
+But no one's teaching you how to <span className="text-white">**build full-stack production-grade applications**</span> that help you move your career forward.
 
 Solving another batch of type challenges won’t create an inflection point in your career.
 


### PR DESCRIPTION
This fixes a minor typo of `className` on the index page.