### PR TITLE
refactor(tt): use existing `getPurchaseForStripeCharge` function

### DIFF
--- a/apps/total-typescript/src/pages/invoices/[merchantChargeId].tsx
+++ b/apps/total-typescript/src/pages/invoices/[merchantChargeId].tsx
@@ -37,23 +37,13 @@ export const getServerSideProps: GetServerSideProps = async ({
     if (merchantCharge && merchantCharge.identifier) {
       const charge = await stripe.charges.retrieve(merchantCharge.identifier)
 
-      const merchantProductId = merchantCharge.merchantProductId
-      const merchantProduct = await prisma.merchantProduct.findUnique({
-        where: {
-          id: merchantProductId as string,
-        },
-        select: {
-          productId: true,
-        },
-      })
       const purchase = await getPurchaseForStripeCharge(
         merchantCharge.identifier,
       )
       const bulkCoupon = purchase && purchase.bulkCoupon
 
-      const productId = merchantProduct?.productId
       const product = await getProduct({
-        where: {id: productId},
+        where: {id: purchase?.productId},
       })
 
       res.setHeader('Cache-Control', 's-maxage=1, stale-while-revalidate')

--- a/packages/commerce-server/src/prisma-next-serializer.ts
+++ b/packages/commerce-server/src/prisma-next-serializer.ts
@@ -8,6 +8,8 @@ export function convertToSerializeForNextResponse(result: any) {
       result[resultKey] = result[resultKey].toISOString()
     } else if (result[resultKey]?.constructor?.name === 'Decimal') {
       result[resultKey] = result[resultKey].toNumber()
+    } else if (result[resultKey] instanceof Object) {
+      result[resultKey] = convertToSerializeForNextResponse(result[resultKey])
     }
   }
 


### PR DESCRIPTION
Some refactoring based on my comments in https://github.com/skillrecordings/products/pull/632

- feat: serialize objects recursively for Next
- refactor(tt): use existing SDK function
- refactor(tt): eliminate unnecessary query

![refa](https://media0.giphy.com/media/Rd9bJAHZX5FRxTnant/giphy.gif?cid=d1fd59ab719lh0qcoslh95i4qudmussweegeedlp2wl29723&rid=giphy.gif&ct=g)