### PR TITLE
feat(tt): check purchase details for lesson access

### DIFF
--- a/apps/total-typescript/src/ability/ability.test.ts
+++ b/apps/total-typescript/src/ability/ability.test.ts
@@ -68,8 +68,7 @@ test('can view workshop content if a purchase exists', () => {
   const user = {
     purchases: [
       {
-        bulk: true,
-        seats: 1,
+        bulkCouponId: null,
       },
     ],
   }
@@ -115,6 +114,39 @@ test('blocked second workshop lesson if no purchase exists', () => {
   })
   const ability = createAppAbility(rules)
   expect(ability.can('view', 'Content')).toBe(false)
+})
+
+describe("team owner who hasn't redeemed purchase for self", () => {
+  test('cannot view second workshop lesson', () => {
+    const user = {
+      purchases: [{bulkCouponId: '123'}],
+    }
+    const rules = defineRulesForPurchases({
+      user,
+      module: mockWorkshop,
+      lesson: mockExerciseTwo,
+    })
+    const ability = createAppAbility(rules)
+    expect(ability.can('view', 'Content')).toBe(false)
+  })
+})
+
+describe('team owner who has redeemed purchase for self', () => {
+  test('can view second workshop lesson', () => {
+    const user = {
+      purchases: [
+        {bulkCouponId: '123'},
+        {bulkCouponId: null, redeemedBulkCouponId: '123'},
+      ],
+    }
+    const rules = defineRulesForPurchases({
+      user,
+      module: mockWorkshop,
+      lesson: mockExerciseTwo,
+    })
+    const ability = createAppAbility(rules)
+    expect(ability.can('view', 'Content')).toBe(true)
+  })
 })
 
 const mockExerciseOne = {

--- a/apps/total-typescript/src/ability/ability.ts
+++ b/apps/total-typescript/src/ability/ability.ts
@@ -48,12 +48,14 @@ const canViewTutorial = ({user, subscriber, module}: ViewerAbilityInput) => {
 const canViewWorkshop = ({user, module, lesson}: ViewerAbilityInput) => {
   const contentIsWorkshop = module?.moduleType === 'workshop'
 
-  // TODO remove this once we have a better way to determine if a workshop is
-  //  available to the user (see below)
-  const userHasPurchases = Boolean(user && user.purchases.length > 0)
+  const purchases = user?.purchases || []
+  const userHasPurchaseWithAccess = Boolean(
+    purchases.find((purchase) => purchase.bulkCouponId === null),
+  )
+
   const hasVideo = Boolean(lesson?.muxPlaybackId)
 
-  return contentIsWorkshop && userHasPurchases && hasVideo
+  return contentIsWorkshop && userHasPurchaseWithAccess && hasVideo
 
   // TODO a given module is associated with a product
   //  if the user has a valid purchase of that product


### PR DESCRIPTION
Look more closely at the details of the purchase records. If a purchase
record is only the bulk purchase and not a redemption or individual
purchase, then the user should not be able to view content.

Attempting to make the check that @vojtaholik was working on in https://github.com/skillrecordings/products/pull/634

We can determine if a user should have access based on whether they have a purchase that isn't just a bulk coupon purchase (i.e. it does not have a `bulkCouponId`). This works for both individual purchases and bulk coupon redemptions, as you can see in this Arctype screenshot.

![CleanShot 2022-11-30 at 13 34 10@2x](https://user-images.githubusercontent.com/694063/204894742-4575a85f-8273-48b8-bdb1-d0527c73d156.png)


![purch](https://media4.giphy.com/media/RHIYhjyA2R8IibyqPU/giphy.gif?cid=d1fd59ab6cxs22ugbtci0wazh44ncv3rp4fgmvvax8fmd3eg&rid=giphy.gif&ct=g)
