### PR TITLE
improve(tt): block body copy on lesson pages

### DIFF
--- a/apps/total-typescript/src/components/exercise-overlay.tsx
+++ b/apps/total-typescript/src/components/exercise-overlay.tsx
@@ -438,10 +438,10 @@ const BlockedOverlay: React.FC = () => {
                 />
               </div>
               <h2 className="text-4xl font-semibold">
-                Level up with {module.title}
+                Level up your {module.title}
               </h2>
-              <h3 className="pb-5 text-xl">
-                {ctaText && <PortableText value={ctaText} />}
+              <h3 className="max-w-sm pb-5 text-xl">
+                This {lesson._type} in part of the {module.title} workshop.
               </h3>
               <Link
                 href={{
@@ -449,7 +449,7 @@ const BlockedOverlay: React.FC = () => {
                 }}
               >
                 <a className="group mt-5 inline-block gap-2 rounded bg-gray-800 px-4 py-2 font-medium transition hover:bg-gray-700">
-                  Buy Now{' '}
+                  Unlock this {lesson._type} now{' '}
                   <span
                     aria-hidden="true"
                     className="text-gray-300 transition group-hover:text-white"

--- a/apps/total-typescript/src/components/exercise/exercise-description.tsx
+++ b/apps/total-typescript/src/components/exercise/exercise-description.tsx
@@ -2,14 +2,37 @@ import * as React from 'react'
 import {Exercise} from '../../lib/exercises'
 import {PortableText} from '@portabletext/react'
 import PortableTextComponents from '../portable-text'
+import {take} from 'lodash'
+import {useMuxPlayer} from '../../hooks/use-mux-player'
+import Link from 'next/link'
 
 export const ExerciseDescription: React.FC<{exercise: Exercise}> = ({
   exercise,
 }) => {
+  const {canShowVideo, loadingUserStatus, lesson} = useMuxPlayer()
   const {body} = exercise
+
+  const displayedBody = canShowVideo ? body : take(body, 1)
   return (
     <div className="prose max-w-none pt-5 prose-headings:font-semibold prose-headings:text-gray-100 prose-p:text-gray-300 sm:prose-lg xl:pt-8 2xl:pt-5">
-      <PortableText value={body} components={PortableTextComponents} />
+      <PortableText value={displayedBody} components={PortableTextComponents} />
+      {!canShowVideo && loadingUserStatus && (
+        <p className="text-gray-300">
+          Loading {lesson._type}... (this may take a few seconds)
+        </p>
+      )}
+      {!canShowVideo && !loadingUserStatus && (
+        <p className="text-gray-300">
+          This {lesson._type} is part of{' '}
+          <Link href={'/buy'}>
+            <a>Total TypeScript Vol. 1</a>
+          </Link>{' '}
+          and can be unlocked immediately after purchase. Already purchased?{' '}
+          <Link href="/login">
+            <a>Log in here.</a>
+          </Link>
+        </p>
+      )}
     </div>
   )
 }

--- a/apps/total-typescript/src/components/exercise/github-link.tsx
+++ b/apps/total-typescript/src/components/exercise/github-link.tsx
@@ -3,6 +3,7 @@ import {Exercise} from '../../lib/exercises'
 import {SanityDocument} from '@sanity/client'
 import {track} from '../../utils/analytics'
 import {IconGithub} from '../icons'
+import {useMuxPlayer} from '../../hooks/use-mux-player'
 
 export const GitHubLink: React.FC<{
   exercise: Exercise
@@ -10,15 +11,16 @@ export const GitHubLink: React.FC<{
 }> = ({exercise, module}) => {
   const {github} = module
 
-  if (!github || !exercise.stackblitz) {
+  const {canShowVideo} = useMuxPlayer()
+
+  if (!canShowVideo || !github || !exercise.stackblitz) {
     return null
   }
 
   const openFile = exercise.stackblitz?.split(',')[0]
 
   return (
-    <div className="pt-14">
-      <h2 className="pb-4 text-2xl font-semibold sm:text-3xl">Code</h2>
+    <div className="pb-4">
       <div className="flex items-center gap-2">
         <a
           onClick={() => {

--- a/apps/total-typescript/src/templates/exercise-template.tsx
+++ b/apps/total-typescript/src/templates/exercise-template.tsx
@@ -94,8 +94,8 @@ const ExerciseTemplate: React.FC<{
             <article className="relative flex-shrink-0 sm:bg-black/20 2xl:bg-transparent">
               <div className="relative z-10 mx-auto max-w-4xl px-5 py-5 lg:py-8 2xl:max-w-xl">
                 <ExerciseTitle exercise={exercise} />
-                <ExerciseDescription exercise={exercise} />
                 <GitHubLink exercise={exercise} module={module} />
+                <ExerciseDescription exercise={exercise} />
               </div>
               <div className="relative z-10 block 2xl:hidden">
                 <VideoTranscript


### PR DESCRIPTION

<img width="1316" alt="Screen Shot 2022-11-30 at 12 42 17" src="https://user-images.githubusercontent.com/86834/204903851-943a08ab-71c1-4cbe-a462-38e91d143842.png">

<img width="1224" alt="Screen Shot 2022-11-30 at 12 42 39" src="https://user-images.githubusercontent.com/86834/204903896-ba98ad0d-1979-410c-9deb-bb57595e583f.png">


![gates](https://media.giphy.com/media/pmcakBV6ukolp5YZAv/giphy.gif)