### PR TITLE
refactor(tt): experiment with better page types

### DIFF
--- a/apps/total-typescript/src/pages/invoices/[merchantChargeId].tsx
+++ b/apps/total-typescript/src/pages/invoices/[merchantChargeId].tsx
@@ -4,7 +4,7 @@ import {convertToSerializeForNextResponse} from '@skillrecordings/commerce-serve
 import {useLocalStorage} from 'react-use'
 import {GetServerSideProps} from 'next'
 import {stripe} from '@skillrecordings/commerce-server'
-import {Coupon, getSdk, MerchantProduct} from '@skillrecordings/database'
+import {Coupon, getSdk} from '@skillrecordings/database'
 import {Stripe} from 'stripe'
 import fromUnixTime from 'date-fns/fromUnixTime'
 import Layout from 'components/app/layout'
@@ -71,10 +71,9 @@ const Invoice: React.FC<
     charge: Stripe.Charge
     product: {name: string}
     merchantChargeId: string
-    merchantProduct: MerchantProduct
     bulkCoupon: Coupon
   }>
-> = ({charge, product, merchantChargeId, merchantProduct, bulkCoupon}) => {
+> = ({charge, product, merchantChargeId, bulkCoupon}) => {
   const [invoiceMetadata, setInvoiceMetadata] = useLocalStorage(
     'invoice-metadata',
     '',


### PR DESCRIPTION
Use Next.js type helpers to get better typing across the
`getServerSideProps` and rendered component boundaries. It is not
perfect and will get more out of `tRPC` as we continue to expand how we
are using that. Nevertheless, we have a lot of pages that us
`getServerSideProps` and this can help improve our typings for those
situations.

[getServerSideProps with TypeScript](https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#getserversideprops-with-typescript)

![props](https://media4.giphy.com/media/fioTafJ6R8K0hO2riI/giphy.gif?cid=d1fd59abpj2sfuwk2mclfbzz97z0xh4fet5bzu7eeooo10y5&rid=giphy.gif&ct=g)