### PR TITLE
feat(tt,commerce-server) support cross-purchase tiered pricing

### DIFF
--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -51,14 +51,8 @@ export async function formatPricesForProduct(
     userId,
   } = noContextOptions
 
-  const {
-    getProduct,
-    getMerchantCoupon,
-    getCoupon,
-    getPrice,
-    getPurchase,
-    getPurchasesForUser,
-  } = getSdk({ctx})
+  const {getProduct, getMerchantCoupon, getCoupon, getPrice, getPurchase} =
+    getSdk({ctx})
 
   const upgradeFromPurchase = upgradeFromPurchaseId
     ? await getPurchase({

--- a/packages/skill-api/src/core/services/load-prices.ts
+++ b/packages/skill-api/src/core/services/load-prices.ts
@@ -13,7 +13,8 @@ export async function loadPrices({
   params: SkillRecordingsHandlerParams
 }): Promise<OutgoingResponse> {
   try {
-    const {req} = params
+    const {req, token} = params
+    const userId = token?.sub
 
     const {availableUpgradesForProduct} = getSdk()
 
@@ -67,6 +68,7 @@ export async function loadPrices({
       code,
       merchantCouponId: activeMerchantCoupon && activeMerchantCoupon.id,
       ...(upgradeFromPurchaseId && {upgradeFromPurchaseId}),
+      userId,
     })
 
     return {


### PR DESCRIPTION
@garrettdimon, @Creeland, and I worked on adding support for tiered pricing that accounts for multiple bulk purchases. If you have already bought some seats and now you are buying more, enough to surpass a tiered pricing threshold, then the appropriate discount should be applied to the new purchase.

- feat(tt): add cross-purchase tiered pricing
- refactor(tt): pull seat count logic into function
- test(tt): test cross-purchase tiered discounts

![tier](https://media0.giphy.com/media/lq4ZwdXew7fznx4MRZ/giphy.gif?cid=d1fd59abbvnxwhahi6ez1a1cal3zte4w3furfloyf1clxw7n&rid=giphy.gif&ct=g)
