### PR TITLE
chore(tt): remove bonus mention in ppp copy

### DIFF
--- a/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
+++ b/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
@@ -430,10 +430,6 @@ const RegionalPricingBox: React.FC<
           {country}. To help facilitate global learning, we are offering
           purchasing power parity pricing.
         </strong>
-        <p>
-          Please note that you will only be able to view content from within{' '}
-          {country}, and no bonuses will be provided.
-        </p>
         <p>If that is something that you need:</p>
       </div>
       <label>


### PR DESCRIPTION
<img width="350" alt="screenshot" src="https://user-images.githubusercontent.com/25487857/206195361-3d5e1db0-1a95-4094-a7c9-84d6493cd388.png">

idea: we could make this dynamic by adding a `type` field on product feature item and checking whether a bonus type is included in given product... 

<img src="https://media.giphy.com/media/YIXnEGNfdG4cE/giphy.gif" width="200" alt="gif">