### PR TITLE
feat(commerce): put qty and checkout session in DB

### DIFF
--- a/packages/commerce-server/src/format-prices-for-product.test.ts
+++ b/packages/commerce-server/src/format-prices-for-product.test.ts
@@ -369,6 +369,7 @@ function getMockExistingBulkPurchase(
     couponId: null,
     redeemedBulkCouponId: null,
     merchantChargeId: 'ch-123',
+    checkoutSessionId: 'cs-123',
     upgradedFromId: null,
     status: 'Valid',
     bulkCouponId: 'coupon-123',
@@ -379,6 +380,7 @@ function getMockExistingBulkPurchase(
     userId,
     productId,
     bulkCoupon: {maxUses: quantity},
+    quantity,
     ...inconsequentialValues,
   }
 }

--- a/packages/commerce-server/src/record-new-purchase.ts
+++ b/packages/commerce-server/src/record-new-purchase.ts
@@ -1,10 +1,9 @@
 import {Stripe} from 'stripe'
-import {first, isEmpty} from 'lodash'
+import {first} from 'lodash'
 import {type Purchase, getSdk} from '@skillrecordings/database'
 import {
   getStripeSdk,
   Context as StripeContext,
-  defaultContext as defaultStripeContext,
 } from '@skillrecordings/stripe-sdk'
 import {NEW_INDIVIDUAL_PURCHASE} from '@skillrecordings/types'
 import {determinePurchaseType, PurchaseType} from './determine-purchase-type'
@@ -128,6 +127,7 @@ export async function recordNewPurchase(checkoutSessionId: string): Promise<{
     productId,
     stripeChargeAmount,
     quantity,
+    checkoutSessionId,
   })
 
   let purchaseType = await determinePurchaseType({checkoutSessionId})

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -202,6 +202,8 @@ model Purchase {
   redeemedBulkCouponId String?
   productId            String
   merchantChargeId     String?
+  quantity             Int?
+  checkoutSessionId    String?
   upgradedFromId       String?         @unique
   upgradedFrom         Purchase?       @relation("UpgradedToPurchase", fields: [upgradedFromId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   upgradedTo           Purchase?       @relation("UpgradedToPurchase")

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -346,6 +346,7 @@ export function getSdk(
       merchantCustomerId: string
       stripeChargeAmount: number
       quantity?: number
+      checkoutSessionId: string
     }) {
       const {
         userId,
@@ -356,6 +357,7 @@ export function getSdk(
         productId,
         stripeChargeAmount,
         quantity = 1,
+        checkoutSessionId,
       } = options
       // we are using uuids so we can generate this!
       // this is needed because the following actions
@@ -434,6 +436,8 @@ export function getSdk(
           merchantChargeId,
           totalAmount: stripeChargeAmount / 100,
           bulkCouponId,
+          quantity,
+          checkoutSessionId,
         },
       })
 


### PR DESCRIPTION
_Pitch for this work: https://github.com/skillrecordings/products/discussions/656_

Record `quantity` and `checkoutSessionId` when creating a Purchase.

This way each Purchase record has a cached value of the quantity
purchased and a reference to the Stripe checkout session via ID to be
able to quickly look up other data related to that Purchase's checkout
session in Stripe.

Before this can go out, the database changes need to be applied to the TA and TT databases in Planetscale. I'll post links to those deploy requests once they are up.

- TA (deployed): https://app.planetscale.com/skill-recordings/testing-accessibility/deploy-requests/15
- TT (deployed): https://app.planetscale.com/skill-recordings/total-typescript/deploy-requests/4

Expand and Contract details for applying these changes to planetscale as deploy requests are documented here: https://roamresearch.com/#/app/egghead/page/KwQNqwYHS

### Next Steps

- Consider scripting a backfill process to add `quantity` and `checkoutSessionId` to all existing Purchases. This should just need to happen in the TA database.

![perch](https://media1.giphy.com/media/Osub6rry9Pu2k/giphy.gif?cid=d1fd59abht8psku4xktu8vulqnylxot3qa1pobtvm6qm51ev&rid=giphy.gif&ct=g)


