### PR TITLE
feat(tt): add Buy More Seats to Buy page

### DIFF
--- a/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
+++ b/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
@@ -12,11 +12,10 @@ import SaleCountdown from './sale-countdown'
 import Spinner from 'components/spinner'
 import Image from 'next/image'
 import find from 'lodash/find'
-import cx from 'classnames'
 import {Purchase} from '@skillrecordings/database'
 import ReactMarkdown from 'react-markdown'
 import {isSellingLive} from '../utils/is-selling-live'
-import {MailIcon} from '@heroicons/react/solid'
+import {MailIcon, TicketIcon} from '@heroicons/react/solid'
 import {
   redirectUrlBuilder,
   SubscribeToConvertkitForm,
@@ -25,6 +24,8 @@ import {useConvertkit} from '../hooks/use-convertkit'
 import {setUserId} from '@amplitude/analytics-browser'
 import {track} from '../utils/analytics'
 import {useRouter} from 'next/router'
+import BuyMoreSeats from 'team/buy-more-seats'
+import Card from 'team/card'
 
 function getFirstPPPCoupon(availableCoupons: any[] = []) {
   return find(availableCoupons, (coupon) => coupon.type === 'ppp') || false
@@ -168,6 +169,21 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
                   <CheckCircleIcon aria-hidden="true" /> Purchased
                 </div>
               </div>
+              {userId !== undefined && (
+                <div id="team-upgrade-pricing-inline">
+                  <Card
+                    title={{content: 'Get more seats', as: 'h2'}}
+                    icon={
+                      <TicketIcon
+                        className="w-5 text-cyan-500"
+                        aria-hidden="true"
+                      />
+                    }
+                  >
+                    <BuyMoreSeats productId={productId} userId={userId} />
+                  </Card>
+                </div>
+              )}
             </>
           ) : isSellingLive ? (
             isDowngrade(formattedPrice) ? (

--- a/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
+++ b/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
@@ -15,7 +15,7 @@ import find from 'lodash/find'
 import {Purchase} from '@skillrecordings/database'
 import ReactMarkdown from 'react-markdown'
 import {isSellingLive} from '../utils/is-selling-live'
-import {MailIcon, TicketIcon} from '@heroicons/react/solid'
+import {MailIcon} from '@heroicons/react/solid'
 import {
   redirectUrlBuilder,
   SubscribeToConvertkitForm,
@@ -24,8 +24,7 @@ import {useConvertkit} from '../hooks/use-convertkit'
 import {setUserId} from '@amplitude/analytics-browser'
 import {track} from '../utils/analytics'
 import {useRouter} from 'next/router'
-import BuyMoreSeats from 'team/buy-more-seats'
-import Card from 'team/card'
+import Link from 'next/link'
 
 function getFirstPPPCoupon(availableCoupons: any[] = []) {
   return find(availableCoupons, (coupon) => coupon.type === 'ppp') || false
@@ -169,21 +168,33 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
                   <CheckCircleIcon aria-hidden="true" /> Purchased
                 </div>
               </div>
-              {userId !== undefined && (
-                <div id="team-upgrade-pricing-inline">
-                  <Card
-                    title={{content: 'Get more seats', as: 'h2'}}
-                    icon={
-                      <TicketIcon
-                        className="w-5 text-cyan-500"
-                        aria-hidden="true"
-                      />
-                    }
+              <div className="flex justify-center">
+                <Link
+                  href={{
+                    pathname: '/team/buy-more-seats',
+                    query: {
+                      productId: productId,
+                    },
+                  }}
+                >
+                  <a
+                    className="group mt-5 inline-block gap-2 rounded bg-gray-800 py-2 pl-4 pr-6 font-medium transition hover:bg-gray-700"
+                    // onClick={() => {
+                    //   track('clicked view workshop module', {
+                    //     module: slug.current,
+                    //   })
+                    // }}
                   >
-                    <BuyMoreSeats productId={productId} userId={userId} />
-                  </Card>
-                </div>
-              )}
+                    <span className="pr-2">Buy More Seats</span>
+                    <span
+                      aria-hidden="true"
+                      className="absolute text-gray-300 transition group-hover:translate-x-1 group-hover:text-white"
+                    >
+                      →
+                    </span>
+                  </a>
+                </Link>
+              </div>
             </>
           ) : isSellingLive ? (
             isDowngrade(formattedPrice) ? (

--- a/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
+++ b/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
@@ -179,11 +179,11 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
                 >
                   <a
                     className="group mt-5 inline-block gap-2 rounded bg-gray-800 py-2 pl-4 pr-6 font-medium transition hover:bg-gray-700"
-                    // onClick={() => {
-                    //   track('clicked view workshop module', {
-                    //     module: slug.current,
-                    //   })
-                    // }}
+                    onClick={() => {
+                      track('clicked buy more seats', {
+                        location: 'pricing',
+                      })
+                    }}
                   >
                     <span className="pr-2">Buy More Seats</span>
                     <span


### PR DESCRIPTION
This PR adds a link to the Buy page, if you've already purchased, that links you to the Buy More Seats page. This way we don't dead-end users on the Buy page when they want to upgrade to a team or get more seats for their team.

![CleanShot 2022-12-15 at 12 29 13@2x](https://user-images.githubusercontent.com/694063/207939912-263fff3b-5e91-46fa-8e7c-ad0f957ac7a0.png)


![bu](https://media4.giphy.com/media/9J3zu4Wj5gPSTiTtx9/giphy.gif?cid=d1fd59abepjvjnntaigv0mwtpnmvgif39s8128a0vssnbfi1&rid=giphy.gif&ct=g)