### PR TITLE
feat: improve 'out of seats' state of Team page

### DIFF
--- a/apps/engmanagement/src/components/team/self-redeem-button.tsx
+++ b/apps/engmanagement/src/components/team/self-redeem-button.tsx
@@ -20,7 +20,7 @@ const SelfRedeemButton: React.FC<
   return (
     <Button
       isLoading={isLoading}
-      isDisabled={!userEmail}
+      disabled={!userEmail}
       className={className}
       onClick={() => {
         if (userEmail) {

--- a/apps/kcdbundle/src/pages/buy/email.tsx
+++ b/apps/kcdbundle/src/pages/buy/email.tsx
@@ -191,7 +191,7 @@ const BuyEmailForm: React.FC<React.PropsWithChildren<BuyEmailFormProps>> = ({
                           <div className="flex justify-center items-center w-full">
                             <Button
                               type="submit"
-                              isDisabled={isSubmitting}
+                              disabled={isSubmitting}
                               isLoading={isSubmitting}
                               className="mt-4 w-full flex items-center justify-center text-center bg-gradient-to-t from-blue-600 to-blue-500 rounded-md text-white px-5 py-4 font-medium shadow-md hover:scale-105 transition-all ease-in-out duration-200 hover:shadow-lg border border-blue-700 border-opacity-20"
                             >

--- a/apps/testingaccessibility/src/components/team/copy-invite-link.tsx
+++ b/apps/testingaccessibility/src/components/team/copy-invite-link.tsx
@@ -34,7 +34,7 @@ const CopyInviteLink: React.FC<
           className={`flex text-sm flex-shrink-0 border bg-gray-100 transition items-center px-5 py-2 rounded-md gap-1 font-semibold ${
             disabled ? 'cursor-not-allowed' : 'hover:bg-gray-200/80'
           }`}
-          isDisabled={disabled}
+          disabled={disabled}
         >
           Copy Link
         </Button>

--- a/apps/testingaccessibility/src/components/team/copy-invite-link.tsx
+++ b/apps/testingaccessibility/src/components/team/copy-invite-link.tsx
@@ -4,8 +4,8 @@ import {useCopyToClipboard} from 'react-use'
 import toast from 'react-hot-toast'
 
 const CopyInviteLink: React.FC<
-  React.PropsWithChildren<{bulkCouponId: string; disabled: boolean}>
-> = ({bulkCouponId, disabled}) => {
+  React.PropsWithChildren<{bulkCouponId: string; disabled?: boolean}>
+> = ({bulkCouponId, disabled = false}) => {
   const [_, setCopied] = useCopyToClipboard()
   const inviteLink = `${process.env.NEXT_PUBLIC_URL}?code=${bulkCouponId}`
 

--- a/apps/testingaccessibility/src/components/team/copy-invite-link.tsx
+++ b/apps/testingaccessibility/src/components/team/copy-invite-link.tsx
@@ -4,8 +4,8 @@ import {useCopyToClipboard} from 'react-use'
 import toast from 'react-hot-toast'
 
 const CopyInviteLink: React.FC<
-  React.PropsWithChildren<{bulkCouponId: string}>
-> = ({bulkCouponId}) => {
+  React.PropsWithChildren<{bulkCouponId: string; disabled: boolean}>
+> = ({bulkCouponId, disabled}) => {
   const [_, setCopied] = useCopyToClipboard()
   const inviteLink = `${process.env.NEXT_PUBLIC_URL}?code=${bulkCouponId}`
 
@@ -20,6 +20,7 @@ const CopyInviteLink: React.FC<
           className="w-full text-sm rounded-md bg-gray-50 text-gray-700 shadow-inner py-2 px-3 border border-gray-300 selection:bg-green-500 selection:text-white font-semibold"
           id="inviteLink"
           onClick={(e) => {
+            if (disabled) return
             e.currentTarget.select()
           }}
           value={inviteLink}
@@ -30,7 +31,10 @@ const CopyInviteLink: React.FC<
             setCopied(inviteLink)
             toast.success('Copied')
           }}
-          className="flex text-sm flex-shrink-0 border bg-gray-100 transition hover:bg-gray-200/80 items-center px-5 py-2 rounded-md gap-1 font-semibold"
+          className={`flex text-sm flex-shrink-0 border bg-gray-100 transition items-center px-5 py-2 rounded-md gap-1 font-semibold ${
+            disabled ? 'cursor-not-allowed' : 'hover:bg-gray-200/80'
+          }`}
+          isDisabled={disabled}
         >
           Copy Link
         </Button>

--- a/apps/testingaccessibility/src/components/team/index.tsx
+++ b/apps/testingaccessibility/src/components/team/index.tsx
@@ -30,9 +30,7 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
     purchase?.bulkCoupon &&
     purchase?.bulkCoupon.maxUses - purchase.bulkCoupon.usedCount
 
-  const [canRedeem, setCanRedeem] = React.useState(
-    Boolean(redemptionsLeft && !existingPurchase),
-  )
+  const [canRedeem, setCanRedeem] = React.useState(Boolean(!existingPurchase))
   const userEmail = session?.user?.email
   const bulkCouponId = purchase?.bulkCoupon?.id
 
@@ -44,10 +42,13 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
           bulkCouponId &&
           'Send the invite link below to your colleagues to get started:'}
       </p>
-      {redemptionsLeft && bulkCouponId && (
+      {bulkCouponId && (
         <>
           <div className="w-full ">
-            <CopyInviteLink bulkCouponId={bulkCouponId} />
+            <CopyInviteLink
+              bulkCouponId={bulkCouponId}
+              disabled={!redemptionsLeft}
+            />
           </div>
           {canRedeem && (
             <div className="flex sm:flex-row flex-col items-center sm:justify-between border-t border-gray-100 sm:mt-8 pt-5 mt-5 gap-3">
@@ -61,19 +62,11 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
                   setCanRedeem(false)
                   setPersonalPurchase(redeemedPurchase)
                 }}
+                disabled={!redemptionsLeft}
               />
             </div>
           )}
         </>
-      )}
-      {!redemptionsLeft && (
-        <div className="flex items-center justify-between mt-5 pt-5 border-t border-gray-100">
-          <Link href="/#buy">
-            <a className="font-semibold bg-green-500 transition text-white px-4 py-2 hover:bg-green-600 rounded-md flex-shrink-0">
-              Buy more seats
-            </a>
-          </Link>
-        </div>
       )}
     </>
   )

--- a/apps/testingaccessibility/src/components/team/self-redeem-button.tsx
+++ b/apps/testingaccessibility/src/components/team/self-redeem-button.tsx
@@ -9,19 +9,23 @@ const SelfRedeemButton: React.FC<
     userEmail: string | null | undefined
     bulkCouponId: string
     onSuccess: (redeemedPurchase: Purchase) => void
+    disabled: boolean
     className?: string
   }>
 > = ({
   userEmail,
   bulkCouponId,
   onSuccess,
-  className = 'border border-green-500 transition text-green-600 px-4 py-2 hover:bg-green-600/5 rounded-md font-semibold',
+  disabled,
+  className = `border border-green-500 transition text-green-600 px-4 py-2 rounded-md font-semibold ${
+    disabled ? 'cursor-not-allowed opacity-75' : 'hover:bg-green-600/5'
+  }`,
 }) => {
   const [isLoading, setIsLoading] = React.useState(false)
   return (
     <Button
       isLoading={isLoading}
-      isDisabled={!userEmail}
+      isDisabled={disabled || !userEmail}
       className={className}
       onClick={() => {
         if (userEmail) {

--- a/apps/testingaccessibility/src/components/team/self-redeem-button.tsx
+++ b/apps/testingaccessibility/src/components/team/self-redeem-button.tsx
@@ -25,7 +25,7 @@ const SelfRedeemButton: React.FC<
   return (
     <Button
       isLoading={isLoading}
-      isDisabled={disabled || !userEmail}
+      disabled={disabled || !userEmail}
       className={className}
       onClick={() => {
         if (userEmail) {

--- a/apps/total-typescript/src/offer/survey/survey-question.tsx
+++ b/apps/total-typescript/src/offer/survey/survey-question.tsx
@@ -320,7 +320,7 @@ const SurveyQuestionSubmit = React.forwardRef(function QuestionSubmit(
 
   return isAnswered ? null : (
     <Comp {...props} ref={forwardRef} data-sr-quiz-question-submit="">
-      <Button isDisabled={isAnswered} isLoading={isSubmitting} type="submit">
+      <Button disabled={isAnswered} isLoading={isSubmitting} type="submit">
         {children}
       </Button>
     </Comp>

--- a/apps/total-typescript/src/team/copy-invite-link.tsx
+++ b/apps/total-typescript/src/team/copy-invite-link.tsx
@@ -4,8 +4,8 @@ import {useCopyToClipboard} from 'react-use'
 import toast from 'react-hot-toast'
 
 const CopyInviteLink: React.FC<
-  React.PropsWithChildren<{bulkCouponId: string; disabled: boolean}>
-> = ({bulkCouponId, disabled}) => {
+  React.PropsWithChildren<{bulkCouponId: string; disabled?: boolean}>
+> = ({bulkCouponId, disabled = false}) => {
   const [_, setCopied] = useCopyToClipboard()
   const inviteLink = `${process.env.NEXT_PUBLIC_URL}?code=${bulkCouponId}`
 

--- a/apps/total-typescript/src/team/copy-invite-link.tsx
+++ b/apps/total-typescript/src/team/copy-invite-link.tsx
@@ -42,7 +42,7 @@ const CopyInviteLink: React.FC<
           className={`flex flex-shrink-0 items-center gap-1 rounded-md bg-cyan-400/20 px-5 py-2 text-sm font-semibold text-cyan-300 transition ${
             disabled ? 'cursor-not-allowed opacity-30' : 'hover:bg-cyan-400/30'
           }`}
-          isDisabled={disabled}
+          disabled={disabled}
         >
           Copy Link
         </Button>

--- a/apps/total-typescript/src/team/copy-invite-link.tsx
+++ b/apps/total-typescript/src/team/copy-invite-link.tsx
@@ -4,8 +4,8 @@ import {useCopyToClipboard} from 'react-use'
 import toast from 'react-hot-toast'
 
 const CopyInviteLink: React.FC<
-  React.PropsWithChildren<{bulkCouponId: string}>
-> = ({bulkCouponId}) => {
+  React.PropsWithChildren<{bulkCouponId: string; disabled: boolean}>
+> = ({bulkCouponId, disabled}) => {
   const [_, setCopied] = useCopyToClipboard()
   const inviteLink = `${process.env.NEXT_PUBLIC_URL}?code=${bulkCouponId}`
 
@@ -20,6 +20,7 @@ const CopyInviteLink: React.FC<
           className="w-full rounded-md border border-gray-800 bg-gray-900 py-2 px-3 text-sm font-semibold text-white shadow-inner selection:bg-cyan-500 selection:text-white"
           id="inviteLink"
           onClick={(e) => {
+            if (disabled) return
             e.currentTarget.select()
           }}
           value={inviteLink}
@@ -30,7 +31,10 @@ const CopyInviteLink: React.FC<
             setCopied(inviteLink)
             toast.success('Copied')
           }}
-          className="flex flex-shrink-0 items-center gap-1 rounded-md bg-cyan-400/20 px-5 py-2 text-sm font-semibold text-cyan-300 transition hover:bg-cyan-400/30"
+          className={`flex flex-shrink-0 items-center gap-1 rounded-md bg-cyan-400/20 px-5 py-2 text-sm font-semibold text-cyan-300 transition ${
+            disabled ? 'cursor-not-allowed' : 'hover:bg-cyan-400/30'
+          }`}
+          isDisabled={disabled}
         >
           Copy Link
         </Button>

--- a/apps/total-typescript/src/team/copy-invite-link.tsx
+++ b/apps/total-typescript/src/team/copy-invite-link.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {Button} from '@skillrecordings/react'
 import {useCopyToClipboard} from 'react-use'
 import toast from 'react-hot-toast'
+import cx from 'classnames'
 
 const CopyInviteLink: React.FC<
   React.PropsWithChildren<{bulkCouponId: string; disabled?: boolean}>
@@ -17,13 +18,20 @@ const CopyInviteLink: React.FC<
       <div className="flex gap-3 pt-2">
         <input
           readOnly
-          className="w-full rounded-md border border-gray-800 bg-gray-900 py-2 px-3 text-sm font-semibold text-white shadow-inner selection:bg-cyan-500 selection:text-white"
+          className={cx(
+            'w-full rounded-md border border-gray-800 bg-gray-900 py-2 px-3 text-sm font-semibold text-white shadow-inner selection:bg-cyan-500 selection:text-white',
+            {
+              'opacity-50': disabled,
+            },
+          )}
           id="inviteLink"
           onClick={(e) => {
             if (disabled) return
             e.currentTarget.select()
           }}
-          value={inviteLink}
+          value={
+            disabled ? 'Buy more seats to view your invite link' : inviteLink
+          }
         />
         <Button
           type="button"
@@ -32,7 +40,7 @@ const CopyInviteLink: React.FC<
             toast.success('Copied')
           }}
           className={`flex flex-shrink-0 items-center gap-1 rounded-md bg-cyan-400/20 px-5 py-2 text-sm font-semibold text-cyan-300 transition ${
-            disabled ? 'cursor-not-allowed' : 'hover:bg-cyan-400/30'
+            disabled ? 'cursor-not-allowed opacity-30' : 'hover:bg-cyan-400/30'
           }`}
           isDisabled={disabled}
         >

--- a/apps/total-typescript/src/team/index.tsx
+++ b/apps/total-typescript/src/team/index.tsx
@@ -69,12 +69,9 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
         {hasRedemptionsLeft &&
           bulkCouponId &&
           'Send the invite link below to your colleagues to get started:'}
+        {usedCount > 0 &&
+          `Your team has already redeemed ${usedCount} of ${maxUses} seats.`}
       </p>
-      {usedCount > 0 && (
-        <p className="pb-3 text-xs">
-          Your team has already redeemed {usedCount} of {maxUses} seats.
-        </p>
-      )}
       {bulkCouponId && (
         <>
           <div className="w-full ">

--- a/apps/total-typescript/src/team/index.tsx
+++ b/apps/total-typescript/src/team/index.tsx
@@ -66,11 +66,11 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
           {numberOfRedemptionsLeft} seats left
         </strong>
         .<br />
+        {usedCount > 0 &&
+          `Your team has already redeemed ${usedCount} of ${maxUses} seats. `}
         {hasRedemptionsLeft &&
           bulkCouponId &&
           'Send the invite link below to your colleagues to get started:'}
-        {usedCount > 0 &&
-          `Your team has already redeemed ${usedCount} of ${maxUses} seats.`}
       </p>
       {bulkCouponId && (
         <>

--- a/apps/total-typescript/src/team/index.tsx
+++ b/apps/total-typescript/src/team/index.tsx
@@ -55,9 +55,7 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
     hasRedemptionsLeft,
   } = bulkCouponSchema.parse(purchase.bulkCoupon)
 
-  const [canRedeem, setCanRedeem] = React.useState(
-    Boolean(hasRedemptionsLeft && !existingPurchase),
-  )
+  const [canRedeem, setCanRedeem] = React.useState(Boolean(!existingPurchase))
   const userEmail = session?.user?.email
 
   return (
@@ -77,10 +75,13 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
           Your team has already redeemed {usedCount} of {maxUses} seats.
         </p>
       )}
-      {hasRedemptionsLeft && bulkCouponId && (
+      {bulkCouponId && (
         <>
           <div className="w-full ">
-            <CopyInviteLink bulkCouponId={bulkCouponId} />
+            <CopyInviteLink
+              bulkCouponId={bulkCouponId}
+              disabled={!hasRedemptionsLeft}
+            />
           </div>
           {canRedeem && (
             <div className="mt-5 flex flex-col items-center gap-3 border-t border-gray-800 pt-5 sm:mt-8 sm:flex-row sm:justify-between">
@@ -94,19 +95,11 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
                   setCanRedeem(false)
                   setPersonalPurchase(redeemedPurchase)
                 }}
+                disabled={!hasRedemptionsLeft}
               />
             </div>
           )}
         </>
-      )}
-      {!hasRedemptionsLeft && (
-        <div className="mt-5 flex items-center justify-between border-t border-gray-100 pt-5">
-          <Link href="/#buy">
-            <a className="flex-shrink-0 rounded-md bg-cyan-500 px-4 py-2 font-semibold text-white transition hover:bg-cyan-600">
-              Buy more seats
-            </a>
-          </Link>
-        </div>
       )}
     </>
   )

--- a/apps/total-typescript/src/team/self-redeem-button.tsx
+++ b/apps/total-typescript/src/team/self-redeem-button.tsx
@@ -18,14 +18,14 @@ const SelfRedeemButton: React.FC<
   onSuccess,
   disabled,
   className = `border border-cyan-500 transition text-cyan-400 px-4 py-2 rounded-md font-semibold ${
-    disabled ? 'cursor-not-allowed opacity-75' : 'hover:bg-cyan-600/20'
+    disabled ? 'cursor-not-allowed opacity-30' : 'hover:bg-cyan-600/20'
   }`,
 }) => {
   const [isLoading, setIsLoading] = React.useState(false)
   return (
     <Button
       isLoading={isLoading}
-      isDisabled={disabled || !userEmail}
+      disabled={disabled || !userEmail}
       className={className}
       onClick={() => {
         if (userEmail) {

--- a/apps/total-typescript/src/team/self-redeem-button.tsx
+++ b/apps/total-typescript/src/team/self-redeem-button.tsx
@@ -9,19 +9,23 @@ const SelfRedeemButton: React.FC<
     userEmail: string | null | undefined
     bulkCouponId: string
     onSuccess: (redeemedPurchase: Purchase) => void
+    disabled: boolean
     className?: string
   }>
 > = ({
   userEmail,
   bulkCouponId,
   onSuccess,
-  className = 'border border-cyan-500 transition text-cyan-400 px-4 py-2 hover:bg-cyan-600/20 rounded-md font-semibold',
+  disabled,
+  className = `border border-cyan-500 transition text-cyan-400 px-4 py-2 rounded-md font-semibold ${
+    disabled ? 'cursor-not-allowed opacity-75' : 'hover:bg-cyan-600/20'
+  }`,
 }) => {
   const [isLoading, setIsLoading] = React.useState(false)
   return (
     <Button
       isLoading={isLoading}
-      isDisabled={!userEmail}
+      isDisabled={disabled || !userEmail}
       className={className}
       onClick={() => {
         if (userEmail) {

--- a/packages/quiz/src/components/question/index.tsx
+++ b/packages/quiz/src/components/question/index.tsx
@@ -327,7 +327,7 @@ const QuestionSubmit = React.forwardRef(function QuestionSubmit(
 
   return isAnswered ? null : (
     <Comp {...props} ref={forwardRef} data-sr-quiz-question-submit="">
-      <Button isDisabled={isAnswered} isLoading={isSubmitting} type="submit">
+      <Button disabled={isAnswered} isLoading={isSubmitting} type="submit">
         {children}
       </Button>
     </Comp>

--- a/packages/react/src/components/button/index.tsx
+++ b/packages/react/src/components/button/index.tsx
@@ -72,7 +72,11 @@ const Button: React.FC<React.PropsWithChildren<ButtonProps>> = ({
   const contentProps = {rightIcon, leftIcon, children}
 
   return (
-    <button data-sr-button {...rest} disabled={isLoading || rest.disabled}>
+    <button
+      data-sr-button
+      {...rest}
+      disabled={isLoading || isDisabled || rest.disabled}
+    >
       {isLoading ? (
         <>
           <ButtonIcon>

--- a/packages/react/src/components/button/index.tsx
+++ b/packages/react/src/components/button/index.tsx
@@ -9,7 +9,7 @@ type ButtonOptions = {
   /**
    * If `true`, the button will be disabled.
    */
-  isDisabled?: boolean
+  disabled?: boolean
   /**
    * If added, the button will show an icon before the button's label.
    * @type React.ReactElement
@@ -64,19 +64,15 @@ const ButtonIcon: React.FC<
 const Button: React.FC<React.PropsWithChildren<ButtonProps>> = ({
   children,
   isLoading,
-  isDisabled,
   leftIcon,
   rightIcon,
+  disabled,
   ...rest
 }) => {
   const contentProps = {rightIcon, leftIcon, children}
 
   return (
-    <button
-      data-sr-button
-      {...rest}
-      disabled={isLoading || isDisabled || rest.disabled}
-    >
+    <button data-sr-button {...rest} disabled={isLoading || disabled}>
       {isLoading ? (
         <>
           <ButtonIcon>


### PR DESCRIPTION
This gets rid of the old 'buy more seats' button that conditionally
displays when there are no more seats. We can instead rely on the 'Buy
More Seats' widget below this that is always visible.

It also adds a disabled attribute and disabled styles to the various
team buttons, instead of hiding them, to make it clearer what is
available if you get more seats.

## Total TypeScript


https://user-images.githubusercontent.com/694063/207927412-83204784-8824-40d3-ae63-cc07ebffc711.mp4



## Testing Accessibility


https://user-images.githubusercontent.com/694063/207927470-4b4ee89a-0d68-4ff5-b0d9-4d2e11c3a496.mp4

![out of seats](https://media0.giphy.com/media/w89ak63KNl0nJl80ig/giphy.gif?cid=d1fd59abdd8h7kg70lwmdwbxqzbuby74tep8576xcvairgkd&rid=giphy.gif&ct=g)