### PR TITLE
feat(tt): load purchases in pricing endpoint

### DIFF
--- a/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
+++ b/apps/total-typescript/src/path-to-purchase-react/pricing.tsx
@@ -92,7 +92,6 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
         quantity: debouncedQuantity,
         couponId,
         merchantCoupon,
-        purchases,
       },
     ],
     {

--- a/apps/total-typescript/src/team/buy-more-seats.tsx
+++ b/apps/total-typescript/src/team/buy-more-seats.tsx
@@ -35,7 +35,6 @@ const BuyMoreSeats = (props: BuyMoreSeatsProps) => {
       productId,
       userId,
       quantity: debouncedQuantity,
-      purchases: [],
     },
   ])
 


### PR DESCRIPTION
instead of relying on the client to carry the user's purchases around,
we can just look them up on demand.

![demand](https://media0.giphy.com/media/owiQbg074wmyc/giphy.gif?cid=d1fd59abemo3prpviro2xsq4l9w728re3kuyxqs747d34b4m&rid=giphy.gif&ct=g)