### PR TITLE
chore(pt): switch route param from `exercise` to `lesson`

### DIFF
--- a/apps/protailwind/src/components/exercise-navigator.tsx
+++ b/apps/protailwind/src/components/exercise-navigator.tsx
@@ -50,11 +50,11 @@ const ExerciseNavigator: React.FC<{
                 <Link
                   href={{
                     pathname: section
-                      ? `${path}/[module]/[section]/[exercise]`
-                      : `${path}/[module]/[exercise]`,
+                      ? `${path}/[module]/[section]/[lesson]`
+                      : `${path}/[module]/[lesson]`,
                     query: {
                       module: module.slug.current,
-                      exercise: exercise.slug,
+                      lesson: exercise.slug,
                       ...(section && {section: section.slug}),
                     },
                   }}
@@ -94,11 +94,11 @@ const ExerciseNavigator: React.FC<{
                       <Link
                         href={{
                           pathname: section
-                            ? `${path}/[module]/[section]/[exercise]`
-                            : `${path}/[module]/[exercise]`,
+                            ? `${path}/[module]/[section]/[lesson]`
+                            : `${path}/[module]/[lesson]`,
                           query: {
                             module: module.slug.current,
-                            exercise: exercise.slug,
+                            lesson: exercise.slug,
                             ...(section && {section: section.slug}),
                           },
                         }}
@@ -170,11 +170,11 @@ const SolutionLink = ({
       <Link
         href={{
           pathname: section
-            ? `${path}/[module]/[section]/[exercise]/solution`
-            : `${path}/[module]/[exercise]/solution`,
+            ? `${path}/[module]/[section]/[lesson]/solution`
+            : `${path}/[module]/[lesson]/solution`,
           query: {
             module: module.slug.current,
-            exercise: exercise.slug,
+            lesson: exercise.slug,
             ...(section && {section: section.slug}),
           },
         }}

--- a/apps/protailwind/src/components/exercise-overlay.tsx
+++ b/apps/protailwind/src/components/exercise-overlay.tsx
@@ -286,10 +286,10 @@ const FinishedOverlay = () => {
           onClick={() => {
             router
               .push({
-                pathname: `/${path}/[module]/[exercise]`,
+                pathname: `/${path}/[module]/[lesson]`,
                 query: {
                   module: module.slug.current,
-                  exercise: module.exercises[0].slug.current,
+                  lesson: module.exercises[0].slug.current,
                 },
               })
               .then(handlePlay)
@@ -440,16 +440,16 @@ const handleContinue = async ({
 
     return await router
       .push({
-        query: {module: module.slug.current, exercise: exercise.slug},
-        pathname: `${path}/[module]/[exercise]/solution`,
+        query: {module: module.slug.current, lesson: exercise.slug},
+        pathname: `${path}/[module]/[lesson]/solution`,
       })
       .then(() => handlePlay())
   }
 
   return await router
     .push({
-      query: {module: module.slug.current, exercise: nextExercise?.slug},
-      pathname: `${path}/[module]/[exercise]`,
+      query: {module: module.slug.current, lesson: nextExercise?.slug},
+      pathname: `${path}/[module]/[lesson]`,
     })
     .then(() => handlePlay())
 }

--- a/apps/protailwind/src/components/portable-text/index.tsx
+++ b/apps/protailwind/src/components/portable-text/index.tsx
@@ -142,10 +142,10 @@ const InternalLink: React.FC<InternalLinkProps> = ({value, children}) => {
   return (
     <Link
       href={{
-        pathname: '/tutorials/[module]/[exercise]',
+        pathname: '/tutorials/[module]/[lesson]',
         query: {
           module: value.module.slug,
-          exercise: value.slug,
+          lesson: value.slug,
         },
       }}
     >

--- a/apps/protailwind/src/hooks/use-mux-player.tsx
+++ b/apps/protailwind/src/hooks/use-mux-player.tsx
@@ -71,8 +71,8 @@ export const VideoProvider: React.FC<
     (autoPlay: boolean) => {
       nextExerciseSlug && autoPlay
         ? router.push({
-            pathname: '/[module]/[exercise]',
-            query: {module: moduleSlug, exercise: nextExerciseSlug},
+            pathname: '/[module]/[lesson]',
+            query: {module: moduleSlug, lesson: nextExerciseSlug},
           })
         : setDisplayOverlay(true)
     },

--- a/apps/protailwind/src/pages/tutorials/[module]/[lesson]/index.tsx
+++ b/apps/protailwind/src/pages/tutorials/[module]/[lesson]/index.tsx
@@ -10,10 +10,10 @@ import {VideoResourceProvider} from '@skillrecordings/skill-lesson/hooks/use-vid
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const {params} = context
-  const exerciseSlug = params?.exercise as string
+  const lessonSLug = params?.lesson as string
 
   const module = await getTutorial(params?.module as string)
-  const lesson = await getExercise(exerciseSlug)
+  const lesson = await getExercise(lessonSLug)
 
   const tutorialDirectory = path.join(
     process.cwd(),
@@ -43,7 +43,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
         return {
           params: {
             module: tutorial.slug.current,
-            exercise: exercise.slug,
+            lesson: exercise.slug,
           },
         }
       }),

--- a/apps/protailwind/src/pages/tutorials/[module]/[lesson]/solution.tsx
+++ b/apps/protailwind/src/pages/tutorials/[module]/[lesson]/solution.tsx
@@ -8,7 +8,7 @@ import {VideoResourceProvider} from '@skillrecordings/skill-lesson/hooks/use-vid
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const {params} = context
-  const exerciseSlug = params?.exercise as string
+  const exerciseSlug = params?.lesson as string
 
   const module = await getTutorial(params?.module as string)
   const lesson = await getExercise(exerciseSlug)
@@ -38,7 +38,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
           return {
             params: {
               module: tutorial.slug.current,
-              exercise: exercise.slug,
+              lesson: exercise.slug,
             },
           }
         }),

--- a/apps/protailwind/src/templates/tutorial-template.tsx
+++ b/apps/protailwind/src/templates/tutorial-template.tsx
@@ -91,10 +91,10 @@ const Header: React.FC<{tutorial: SanityDocument}> = ({tutorial}) => {
               {exercises?.[0] && (
                 <Link
                   href={{
-                    pathname: '/tutorials/[module]/[exercise]',
+                    pathname: '/tutorials/[module]/[lesson]',
                     query: {
                       module: slug.current,
-                      exercise: exercises[0].slug,
+                      lesson: exercises[0].slug,
                     },
                   }}
                 >
@@ -162,10 +162,10 @@ const TutorialExerciseNavigator: React.FC<{tutorial: SanityDocument}> = ({
               <li key={exercise.slug}>
                 <Link
                   href={{
-                    pathname: '/tutorials/[module]/[exercise]',
+                    pathname: '/tutorials/[module]/[lesson]',
                     query: {
                       module: slug.current,
-                      exercise: exercise.slug,
+                      lesson: exercise.slug,
                     },
                   }}
                   passHref

--- a/apps/total-typescript/src/components/exercise-overlay.tsx
+++ b/apps/total-typescript/src/components/exercise-overlay.tsx
@@ -120,7 +120,7 @@ const ExerciseOverlay = () => {
   const {lesson, module} = useLesson()
   const router = useRouter()
   const {data: stackblitz, status} = trpc.stackblitz.byExerciseSlug.useQuery({
-    slug: router.query.exercise as string,
+    slug: router.query.lesson as string,
     type: lesson._type,
   })
   const {github} = module
@@ -276,17 +276,17 @@ const FinishedOverlay = () => {
     router
       .push({
         pathname: section
-          ? `/${path}/[module]/[section]/[exercise]`
-          : `/${path}/[module]/[exercise]`,
+          ? `/${path}/[module]/[section]/[lesson]`
+          : `/${path}/[module]/[lesson]`,
         query: section
           ? {
               module: module.slug.current,
               section: module.sections[0].slug,
-              exercise: module.sections[0].exercises[0].slug,
+              lesson: module.sections[0].exercises[0].slug,
             }
           : {
               module: module.slug.current,
-              exercise: module.exercises[0].slug,
+              lesson: module.exercises[0].slug,
             },
       })
       .then(handlePlay)
@@ -622,10 +622,10 @@ const handleContinue = async ({
           query: {
             module: module.slug.current,
             section: section.slug,
-            exercise: exercise.slug,
+            lesson: exercise.slug,
           },
 
-          pathname: `${path}/[module]/[section]/[exercise]/solution`,
+          pathname: `${path}/[module]/[section]/[lesson]/solution`,
         })
         .then(() => handlePlay())
     } else {
@@ -638,10 +638,10 @@ const handleContinue = async ({
         .push({
           query: {
             module: module.slug.current,
-            exercise: exercise.slug,
+            lesson: exercise.slug,
           },
 
-          pathname: `${path}/[module]/[exercise]/solution`,
+          pathname: `${path}/[module]/[lesson]/solution`,
         })
         .then(() => handlePlay())
     }
@@ -652,16 +652,16 @@ const handleContinue = async ({
         query: {
           module: module.slug.current,
           section: section.slug,
-          exercise: nextExercise?.slug,
+          lesson: nextExercise?.slug,
         },
-        pathname: `${path}/[module]/[section]/[exercise]`,
+        pathname: `${path}/[module]/[section]/[lesson]`,
       })
       .then(() => handlePlay())
   } else {
     return await router
       .push({
-        query: {module: module.slug.current, exercise: nextExercise?.slug},
-        pathname: `${path}/[module]/[exercise]`,
+        query: {module: module.slug.current, lesson: nextExercise?.slug},
+        pathname: `${path}/[module]/[lesson]`,
       })
       .then(() => handlePlay())
   }

--- a/apps/total-typescript/src/components/exercise/github-link.tsx
+++ b/apps/total-typescript/src/components/exercise/github-link.tsx
@@ -18,7 +18,7 @@ export const GitHubLink: React.FC<{
 
   const router = useRouter()
   const {data: stackblitz, status} = trpc.stackblitz.byExerciseSlug.useQuery({
-    slug: router.query.exercise as string,
+    slug: router.query.lesson as string,
     type: exercise._type,
   })
 

--- a/apps/total-typescript/src/components/exercise/stackblitz-iframe.tsx
+++ b/apps/total-typescript/src/components/exercise/stackblitz-iframe.tsx
@@ -14,7 +14,7 @@ export const StackBlitzIframe: React.FC<{
 }> = ({exercise, module}) => {
   const router = useRouter()
   const {data: stackblitz, status} = trpc.stackblitz.byExerciseSlug.useQuery({
-    slug: router.query.exercise as string,
+    slug: router.query.lesson as string,
     type: exercise._type,
   })
 

--- a/apps/total-typescript/src/pages/tutorials/[module]/[lesson]/index.tsx
+++ b/apps/total-typescript/src/pages/tutorials/[module]/[lesson]/index.tsx
@@ -8,7 +8,7 @@ import {LessonProvider} from '@skillrecordings/skill-lesson/hooks/use-lesson'
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const {params} = context
-  const exerciseSlug = params?.exercise as string
+  const exerciseSlug = params?.lesson as string
 
   const module = await getTutorial(params?.module as string)
   const exercise = await getExercise(exerciseSlug)

--- a/apps/total-typescript/src/pages/tutorials/[module]/[lesson]/index.tsx
+++ b/apps/total-typescript/src/pages/tutorials/[module]/[lesson]/index.tsx
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
         return {
           params: {
             module: tutorial.slug.current,
-            exercise: exercise.slug,
+            lesson: exercise.slug,
           },
         }
       }),

--- a/apps/total-typescript/src/pages/tutorials/[module]/[lesson]/solution.tsx
+++ b/apps/total-typescript/src/pages/tutorials/[module]/[lesson]/solution.tsx
@@ -8,7 +8,7 @@ import {LessonProvider} from '@skillrecordings/skill-lesson/hooks/use-lesson'
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const {params} = context
-  const exerciseSlug = params?.exercise as string
+  const exerciseSlug = params?.lesson as string
 
   const module = await getTutorial(params?.module as string)
   const exercise = await getExercise(exerciseSlug)
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
         return {
           params: {
             module: tutorial.slug.current,
-            exercise: exercise.slug,
+            lesson: exercise.slug,
           },
         }
       }),

--- a/apps/total-typescript/src/pages/workshops/[module]/[section]/[lesson]/index.tsx
+++ b/apps/total-typescript/src/pages/workshops/[module]/[section]/[lesson]/index.tsx
@@ -40,7 +40,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
             params: {
               module: workshop.slug.current,
               section: section.slug,
-              exercise: exercise.slug,
+              lesson: exercise.slug,
             },
           })) || []
         )

--- a/apps/total-typescript/src/pages/workshops/[module]/[section]/[lesson]/solution.tsx
+++ b/apps/total-typescript/src/pages/workshops/[module]/[section]/[lesson]/solution.tsx
@@ -43,7 +43,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
               params: {
                 module: workshop.slug.current,
                 section: section.slug,
-                exercise: exercise.slug,
+                lesson: exercise.slug,
               },
             })) || []
         )

--- a/apps/total-typescript/src/templates/exercise-template.tsx
+++ b/apps/total-typescript/src/templates/exercise-template.tsx
@@ -35,7 +35,7 @@ const ExerciseTemplate: React.FC<{
   return (
     <VideoProvider
       muxPlayerRef={muxPlayerRef}
-      exerciseSlug={router.query.exercise as string}
+      exerciseSlug={router.query.lesson as string}
       path={path}
     >
       <Layout

--- a/apps/total-typescript/src/templates/tutorial-template.tsx
+++ b/apps/total-typescript/src/templates/tutorial-template.tsx
@@ -89,10 +89,10 @@ const Header: React.FC<{tutorial: SanityDocument}> = ({tutorial}) => {
               {exercises?.[0] && (
                 <Link
                   href={{
-                    pathname: '/tutorials/[module]/[exercise]',
+                    pathname: '/tutorials/[module]/[lesson]',
                     query: {
                       module: slug.current,
-                      exercise: exercises[0].slug,
+                      lesson: exercises[0].slug,
                     },
                   }}
                 >
@@ -168,10 +168,10 @@ const TutorialExerciseNavigator: React.FC<{tutorial: SanityDocument}> = ({
               <li key={exercise.slug}>
                 <Link
                   href={{
-                    pathname: '/tutorials/[module]/[exercise]',
+                    pathname: '/tutorials/[module]/[lesson]',
                     query: {
                       module: slug.current,
-                      exercise: exercise.slug,
+                      lesson: exercise.slug,
                     },
                   }}
                   passHref

--- a/apps/total-typescript/src/templates/workshop-template.tsx
+++ b/apps/total-typescript/src/templates/workshop-template.tsx
@@ -84,11 +84,11 @@ const Header: React.FC<{workshop: SanityDocument}> = ({workshop}) => {
               {firstSection && (
                 <Link
                   href={{
-                    pathname: '/workshops/[module]/[section]/[exercise]',
+                    pathname: '/workshops/[module]/[section]/[lesson]',
                     query: {
                       module: slug.current,
                       section: firstSection.slug,
-                      exercise: firstExercise?.slug,
+                      lesson: firstExercise?.slug,
                     },
                   }}
                 >
@@ -220,10 +220,10 @@ const LessonListItem = ({
     <li key={lessonResource.slug}>
       <Link
         href={{
-          pathname: '/workshops/[module]/[section]/[exercise]',
+          pathname: '/workshops/[module]/[section]/[lesson]',
           query: {
             section: section.slug,
-            exercise: lessonResource.slug,
+            lesson: lessonResource.slug,
             module: moduleSlug,
           },
         }}

--- a/apps/total-typescript/src/video/lesson-list.tsx
+++ b/apps/total-typescript/src/video/lesson-list.tsx
@@ -52,11 +52,11 @@ const LessonList: React.FC<{
                 <Link
                   href={{
                     pathname: section
-                      ? `${path}/[module]/[section]/[exercise]`
-                      : `${path}/[module]/[exercise]`,
+                      ? `${path}/[module]/[section]/[lesson]`
+                      : `${path}/[module]/[lesson]`,
                     query: {
                       module: module.slug.current,
-                      exercise: exercise.slug,
+                      lesson: exercise.slug,
                       ...(section && {section: section.slug}),
                     },
                   }}
@@ -89,11 +89,11 @@ const LessonList: React.FC<{
                       <Link
                         href={{
                           pathname: section
-                            ? `${path}/[module]/[section]/[exercise]`
-                            : `${path}/[module]/[exercise]`,
+                            ? `${path}/[module]/[section]/[lesson]`
+                            : `${path}/[module]/[lesson]`,
                           query: {
                             module: module.slug.current,
-                            exercise: exercise.slug,
+                            lesson: exercise.slug,
                             ...(section && {section: section.slug}),
                           },
                         }}
@@ -137,11 +137,11 @@ const LessonList: React.FC<{
                       <Link
                         href={{
                           pathname: section
-                            ? `${path}/[module]/[section]/[exercise]`
-                            : `${path}/[module]/[exercise]`,
+                            ? `${path}/[module]/[section]/[lesson]`
+                            : `${path}/[module]/[lesson]`,
                           query: {
                             module: module.slug.current,
-                            exercise: exercise.slug,
+                            lesson: exercise.slug,
                             ...(section && {section: section.slug}),
                           },
                         }}
@@ -253,11 +253,11 @@ const SolutionLink = ({
       <Link
         href={{
           pathname: section
-            ? `${path}/[module]/[section]/[exercise]/solution`
-            : `${path}/[module]/[exercise]/solution`,
+            ? `${path}/[module]/[section]/[lesson]/solution`
+            : `${path}/[module]/[lesson]/solution`,
           query: {
             module: module.slug.current,
-            exercise: exercise.slug,
+            lesson: exercise.slug,
             ...(section && {section: section.slug}),
           },
         }}

--- a/packages/skill-lesson/hooks/use-mux-player.tsx
+++ b/packages/skill-lesson/hooks/use-mux-player.tsx
@@ -100,8 +100,8 @@ export const VideoProvider: React.FC<
     (autoPlay: boolean) => {
       nextExerciseSlug && autoPlay
         ? router.push({
-            pathname: '/[module]/[exercise]',
-            query: {module: moduleSlug, exercise: nextExerciseSlug},
+            pathname: '/[module]/[lesson]',
+            query: {module: moduleSlug, lesson: nextExerciseSlug},
           })
         : setDisplayOverlay(true)
     },


### PR DESCRIPTION
this is a sweeping route change in modules renaming `[exercise]` as `[lesson]` where an `Exercise` is a specific type of lesson and the `[lesson]` route supports a number of different shapes of `LessonResource`

![change](https://media.giphy.com/media/Rubq2zDiRjHSxv7CHX/giphy.gif)