### PR TITLE
feat(tt): exit fullscreen on video ended

### DIFF
--- a/packages/skill-lesson/hooks/use-mux-player.tsx
+++ b/packages/skill-lesson/hooks/use-mux-player.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import get from 'lodash/get'
+import isEmpty from 'lodash/isEmpty'
 import {type SanityDocument} from '@sanity/client'
 import {useRouter} from 'next/router'
 import {type MuxPlayerProps} from '@mux/mux-player-react/*'
@@ -87,6 +88,12 @@ export const VideoProvider: React.FC<
     return videoElement?.play()
   }, [])
 
+  const exitFullscreen = () => {
+    if (!isEmpty(window.document.fullscreenElement)) {
+      window.document.exitFullscreen()
+    }
+  }
+
   const moduleSlug = module?.slug?.current
   const nextExerciseSlug = nextExercise?.slug
 
@@ -132,6 +139,7 @@ export const VideoProvider: React.FC<
   }, [lesson._type, lesson.slug, module.moduleType, module.slug])
 
   const onEndedCallback = React.useCallback(async () => {
+    exitFullscreen()
     handleNext(getPlayerPrefs().autoplay)
     track('completed lesson video', {
       module: module.slug.current,


### PR DESCRIPTION
this prevents content from being non-interactive when finishing a video in fullscreen mode by proactively exiting it. 

likely not ideal, but I couldn't figure out how to prevent default muxplayer's behavior and target its container as fullscreen wrapper to make it so video overlays could persist with fullscreen mode turned on. I tried listening for `onfullscreenchange` event on muxplayer's ref in combination with `e.preventDefault()` but that didn't work (weird).

<img src="https://media.giphy.com/media/l0NwPdduX7IL1rS1i/giphy.gif" width="250" alt="gif">