### PR TITLE
fix(tt): record bulk and non-bulk coupon relation

### DIFF
--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -292,6 +292,12 @@ export function getSdk(
         },
       })
     },
+    async getCouponWithBulkPurchases(couponId: string) {
+      return await ctx.prisma.coupon.findFirst({
+        where: {id: couponId},
+        include: {bulkCouponPurchases: {select: {bulkCouponId: true}}},
+      })
+    },
     async getPurchase(args: Prisma.PurchaseFindUniqueArgs) {
       return await ctx.prisma.purchase.findUnique(args)
     },

--- a/packages/skill-api/src/core/services/redeem-golden-ticket.ts
+++ b/packages/skill-api/src/core/services/redeem-golden-ticket.ts
@@ -56,7 +56,7 @@ export async function redeemGoldenTicket({
       // if the Coupon is the Bulk Coupon of a Bulk Purchase,
       // then a bulk coupon is being redeemed
       const bulkCouponRedemption = Boolean(
-        coupon?.bulkCouponPurchases[0].bulkCouponId,
+        coupon.bulkCouponPurchases[0]?.bulkCouponId,
       )
 
       const {user} = await findOrCreateUser(email)


### PR DESCRIPTION
When either a bulk coupon (single-seat) or a non-bulk coupon is
redeemed, we need to tie the $0 purchase record to that coupon.

![coupe](https://media2.giphy.com/media/hH0B9PI1FDKEjqZ1zZ/giphy.gif?cid=d1fd59abfd6yz8n5esl6j68a2w6u3z08k7jcat1jezabjmwm&rid=giphy.gif&ct=g)