### PR TITLE
solutions need the slug of their container exercise to get next lesson

### DIFF
--- a/packages/skill-lesson/hooks/use-next-lesson.ts
+++ b/packages/skill-lesson/hooks/use-next-lesson.ts
@@ -10,9 +10,17 @@ export const useNextLesson = (
   module: SanityDocument,
   section?: SanityDocument,
 ) => {
+  const router = useRouter()
+
+  let slug = lesson.slug
+
+  if (lesson._type === 'solution') {
+    slug = router.query.lesson as string
+  }
+
   const {data: nextExercise} = trpcSkillLessons.lessons.getNextLesson.useQuery({
     type: lesson._type,
-    slug: lesson.slug,
+    slug,
     module: module.slug.current,
     section: section?.slug,
   })

--- a/packages/skill-lesson/lib/lesson-resource.ts
+++ b/packages/skill-lesson/lib/lesson-resource.ts
@@ -7,14 +7,16 @@ export const LessonSchema = z
   .object({
     _id: z.string().optional(),
     _key: z.string().optional(),
-    solution: z.nullable(
-      z
-        .object({
-          _key: z.string(),
-        })
-        .merge(BaseLessonResourceSchema)
-        .optional(),
-    ),
+    solution: z
+      .nullable(
+        z
+          .object({
+            _key: z.string(),
+          })
+          .merge(BaseLessonResourceSchema)
+          .optional(),
+      )
+      .optional(),
   })
   .merge(BaseLessonResourceSchema)
 
@@ -42,6 +44,8 @@ export const getLesson = async (slug: string): Promise<Lesson> => {
     }`,
     {slug},
   )
+
+  console.log({exercise})
 
   return LessonSchema.parse(exercise)
 }

--- a/packages/skill-lesson/server/routers/lessons.ts
+++ b/packages/skill-lesson/server/routers/lessons.ts
@@ -20,6 +20,7 @@ export const lessonsRouter = router({
     )
     .query(async ({input}) => {
       if (input.module === 'tips') return null
+
       const lesson = await getLesson(input.slug)
       const section = input.section && (await getSection(input.section))
       const module = input.module && (await getModule(input.module))


### PR DESCRIPTION
we can't query for solutions in sanity and need to query their container exercise instead so this uses the route param

![routes](https://media.giphy.com/media/8NlaSg2uBZcD8qkq1S/giphy-downsized.gif)