### PR TITLE
fix(skill-lesson): global shortcuts should ignore content editable elements

### DIFF
--- a/packages/skill-lesson/hooks/use-global-player-shortcut.ts
+++ b/packages/skill-lesson/hooks/use-global-player-shortcut.ts
@@ -1,5 +1,6 @@
 import React from 'react'
 import {MuxPlayerRefAttributes} from '@mux/mux-player-react/*'
+import get from 'lodash/get'
 
 const ignoredInputs = ['input', 'select', 'button', 'textarea', 'mux-player']
 
@@ -9,9 +10,12 @@ export const useGlobalPlayerShortcuts = (muxPlayerRef: {
   const handleUserKeyPress = React.useCallback(
     (e: any) => {
       const activeElement = document.activeElement
+      const isContentEditable = get(activeElement, 'contentEditable') === 'true'
+
       if (
         activeElement &&
-        ignoredInputs.indexOf(activeElement.tagName.toLowerCase()) === -1
+        ignoredInputs.indexOf(activeElement.tagName.toLowerCase()) === -1 &&
+        !isContentEditable
       ) {
         if (muxPlayerRef.current) {
           if (e.key === ' ') {

--- a/packages/skill-lesson/hooks/use-global-player-shortcut.ts
+++ b/packages/skill-lesson/hooks/use-global-player-shortcut.ts
@@ -36,6 +36,12 @@ export const useGlobalPlayerShortcuts = (muxPlayerRef: {
               muxPlayerRef.current.currentTime -
               (muxPlayerRef.current.forwardSeekOffset || 10)
           }
+          if (e.key === 'f') {
+            e.preventDefault()
+            document.fullscreenElement
+              ? document.exitFullscreen()
+              : muxPlayerRef.current.requestFullscreen()
+          }
         }
       }
     },


### PR DESCRIPTION
<img src="https://media.giphy.com/media/MdpSuAccvSeR3VjUrS/giphy-downsized.gif" width="300" alt="gif">