### PR TITLE
update(pt): display transfer purchase ui on purchase page and polish its ui

### DIFF
--- a/apps/protailwind/src/components/icons.tsx
+++ b/apps/protailwind/src/components/icons.tsx
@@ -143,6 +143,26 @@ const Icons = {
       d="M9.355.797a1.591 1.591 0 0 1-.58 2.156L4.122 5.647a.401.401 0 0 0-.2.348v4.228a.4.4 0 0 0 .2.347l3.683 2.133a.39.39 0 0 0 .39 0l3.685-2.133a.4.4 0 0 0 .2-.347v-2.63L8.766 9.485a1.55 1.55 0 0 1-2.127-.6 1.592 1.592 0 0 1 .593-2.153l4.739-2.708c1.443-.824 3.228.232 3.228 1.91v4.61a3.015 3.015 0 0 1-1.497 2.612l-4.23 2.448a2.937 2.937 0 0 1-2.948 0l-4.229-2.448A3.016 3.016 0 0 1 .8 10.544v-4.87A3.016 3.016 0 0 1 2.297 3.06L7.225.208a1.55 1.55 0 0 1 2.13.589Z"
     />
   ),
+  MoveDown: () => (
+    <g
+      strokeWidth="1"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="12.5" y1="0.5" x2="12.5" y2="15.5" stroke="currentColor"></line>
+      <polyline
+        points="15.5 12.5 12.5 15.5 9.5 12.5"
+        stroke="currentColor"
+      ></polyline>
+      <polyline points="0.5 2.5 0.5 0.5 2.5 0.5"></polyline>
+      <polyline points="2.5 6.5 0.5 6.5 0.5 4.5"></polyline>
+      <polyline points="6.5 4.5 6.5 6.5 4.5 6.5"></polyline>
+      <polyline points="4.5 0.5 6.5 0.5 6.5 2.5"></polyline>
+      <rect x="0.5" y="9.5" width="6" height="6"></rect>
+    </g>
+  ),
 } as const
 
 export type IconNames = keyof typeof Icons

--- a/apps/protailwind/src/pages/purchases/[purchaseId].tsx
+++ b/apps/protailwind/src/pages/purchases/[purchaseId].tsx
@@ -1,24 +1,13 @@
 import React from 'react'
 import {GetServerSideProps} from 'next'
 import {convertToSerializeForNextResponse} from '@skillrecordings/commerce-server'
-import {createAppAbility} from '@skillrecordings/skill-lesson/utils/ability'
+import PurchaseDetailsTemplate, {
+  type PurchaseDetailsProps,
+} from 'purchase-details/purchase-details-template'
 import {getActiveProduct} from 'path-to-purchase-react/products.server'
-import {getSdk, LessonProgress} from '@skillrecordings/database'
+import {getSdk} from '@skillrecordings/database'
 import {getToken} from 'next-auth/jwt'
-import {Section} from '@skillrecordings/skill-lesson/schemas/section'
-import {find, first, get, indexOf, isEmpty, isString} from 'lodash'
-import {format} from 'date-fns'
-import {trpc} from 'trpc/trpc.client'
-import BuyMoreSeats from 'team/buy-more-seats'
-import Balancer from 'react-wrap-balancer'
-import Layout from 'components/layout'
-import Link from 'next/link'
-import Image from 'next/image'
-import InviteTeam from 'team'
-import {useSession} from 'next-auth/react'
-import Icon, {type IconNames} from 'components/icons'
-import * as Dialog from '@radix-ui/react-dialog'
-import {XIcon} from '@heroicons/react/solid'
+import isString from 'lodash/isString'
 
 export const getServerSideProps: GetServerSideProps = async ({
   res,
@@ -36,6 +25,7 @@ export const getServerSideProps: GetServerSideProps = async ({
         id: purchaseId as string,
       },
       select: {
+        id: true,
         status: true,
         productId: true,
         totalAmount: true,
@@ -91,39 +81,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   }
 }
 
-type PurchaseDetailProps = {
-  welcome: boolean
-  product: {
-    slug: string
-    lessons: {_id: string; slug: string}[]
-    sections: Section[]
-    name: string
-  }
-  user: {
-    email: string
-  }
-  purchase: {
-    status: 'Valid' | 'Refunded' | 'Disputed' | 'Pending'
-    merchantChargeId: string | null
-    bulkCoupon: {id: string; maxUses: number; usedCount: number} | null
-    product: {id: string; name: string}
-    productId: string
-    userId: string
-    createdAt: string
-    totalAmount: number
-  }
-  sanityProduct: {
-    image: {
-      url: string
-    }
-    slug: string
-    lessons: {_id: string; slug: string}[]
-    sections: Section[]
-  }
-  existingPurchase: {id: string; product: {id: string; name: string}}
-}
-
-const PurchaseDetail: React.FC<PurchaseDetailProps> = ({
+const PurchaseDetail: React.FC<PurchaseDetailsProps> = ({
   welcome,
   product,
   user,
@@ -131,322 +89,16 @@ const PurchaseDetail: React.FC<PurchaseDetailProps> = ({
   sanityProduct,
   existingPurchase,
 }) => {
-  const ability = useAbilities()
-  const canInviteTeam = ability.can('invite', 'Team')
-  const canViewContent = ability.can('view', 'Content')
-  const [personalPurchase, setPersonalPurchase] = React.useState(
-    purchase.bulkCoupon ? existingPurchase : purchase,
-  )
-
   return (
-    <Layout meta={{title: `Purchase details for ${product.name}`}}>
-      {welcome ? <WelcomeHeader /> : null}
-      <div className="mx-auto w-full max-w-3xl py-16">
-        <main className="flex flex-col items-start gap-10 bg-gray-50 md:flex-row">
-          <Image
-            src={sanityProduct.image.url}
-            alt=""
-            aria-hidden="true"
-            width={200}
-            height={200}
-            className="flex-shrink-0"
-          />
-          <div className="w-full">
-            <p className="pb-3 font-heading font-extrabold uppercase text-sky-500">
-              Your purchase details for
-            </p>
-            <h1 className="font-heading text-4xl font-black">
-              <Balancer>{product.name}</Balancer>
-            </h1>
-            <div className="-mx-3 flex flex-col items-center justify-center divide-y divide-slate-200 pt-10">
-              <Row label="Invoice" icon="Receipt">
-                <InvoiceLink merchantChargeId={purchase.merchantChargeId} />
-              </Row>
-              {canInviteTeam && (
-                <ManageTeam
-                  purchase={purchase}
-                  email={user.email}
-                  existingPurchase={existingPurchase}
-                  setPersonalPurchase={setPersonalPurchase}
-                />
-              )}
-              <Row label="Amount paid" icon="Dollar">
-                <Price amount={purchase.totalAmount} />{' '}
-                {purchase.status === 'Refunded' && '(Refunded)'}
-              </Row>
-              <Row label="Purchased on" icon="Calendar">
-                <DatePurchased date={purchase.createdAt} />
-              </Row>
-              {user && (
-                <Row label="Associated email address" icon="Email">
-                  {user.email}
-                </Row>
-              )}
-              {((purchase.status === 'Valid' && personalPurchase) ||
-                canViewContent) && (
-                <Row label="Progress" icon="PlayOutline">
-                  <Progress sanityProduct={sanityProduct} />
-                </Row>
-              )}
-            </div>
-          </div>
-        </main>
-      </div>
-      <footer className="flex w-full flex-grow items-center justify-center gap-16 bg-slate-100 py-16">
-        {welcome && <Share />}
-        <BuySeats
-          productName={product.name}
-          productId={purchase.productId}
-          userId={purchase.userId}
-        />
-      </footer>
-    </Layout>
+    <PurchaseDetailsTemplate
+      welcome={welcome}
+      product={product}
+      user={user}
+      purchase={purchase}
+      sanityProduct={sanityProduct}
+      existingPurchase={existingPurchase}
+    />
   )
 }
 
 export default PurchaseDetail
-
-const useAbilities = () => {
-  const {data: abilityRules} = trpc.abilities.getAbilities.useQuery()
-
-  return createAppAbility(abilityRules || [])
-}
-
-const Row: React.FC<
-  React.PropsWithChildren<{label: string; icon: IconNames}>
-> = ({children, label = 'Label', icon = null}) => {
-  return children ? (
-    <div className="flex w-full items-start justify-between py-4 px-3">
-      <div className="flex items-center gap-2">
-        {icon && <Icon className="text-gray-600" name={icon} />} {label}
-      </div>
-      <div className="w-2/5 text-left font-medium">{children}</div>
-    </div>
-  ) : null
-}
-
-const WelcomeHeader = () => {
-  return (
-    <header className="relative flex w-full flex-col items-center justify-center overflow-hidden bg-[#31AEF6] pb-32 text-center text-white sm:pb-10">
-      <Image
-        src={require('../../../public/assets/corgi-waving-upside-down.svg')}
-        alt=""
-        aria-hidden="true"
-        className="relative z-0"
-      />
-      <div className="absolute z-10 w-full px-5 pt-40">
-        <h1 className="font-heading text-3xl font-black sm:text-4xl md:text-5xl">
-          <Balancer>Welcome to Pro Tailwind!</Balancer>
-        </h1>
-        <p className="pt-3 sm:text-lg">
-          <Balancer>
-            You can find details about your purchase below. Happy learning!
-          </Balancer>
-        </p>
-      </div>
-    </header>
-  )
-}
-
-const BuySeats: React.FC<{
-  productId: string
-  userId: string
-  productName: string
-}> = ({productId, productName, userId}) => {
-  return (
-    <div
-      id="buy-more-seats-modal"
-      className="flex max-w-xs flex-col items-center text-center"
-    >
-      <p className="pb-5">
-        Get your team to level up with Tailwind Multi-Theme Strategy Workshop
-      </p>
-      <Dialog.Root>
-        <Dialog.Trigger className="group flex items-center gap-2 rounded-full bg-sky-500 px-5 py-2.5 font-heading font-semibold text-white transition hover:bg-sky-600">
-          Buy more seats
-        </Dialog.Trigger>
-        <Dialog.Overlay className="fixed inset-0 z-10 bg-black/50 backdrop-blur-sm" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 z-40 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white px-6 py-8 shadow-2xl shadow-gray-500/10">
-          <Dialog.Title className="pb-5 text-center font-heading text-2xl font-black leading-tight">
-            <Balancer>Buy more seats for {productName}</Balancer>
-          </Dialog.Title>
-          <BuyMoreSeats productId={productId} userId={userId} />
-          <Dialog.Close className="absolute top-2 right-2 rounded-full p-2 hover:bg-gray-100">
-            <XIcon className="h-5 w-5" />
-          </Dialog.Close>
-        </Dialog.Content>
-      </Dialog.Root>
-    </div>
-  )
-}
-
-const ManageTeam: React.FC<{
-  purchase: {
-    merchantChargeId: string | null
-    bulkCoupon: {id: string; maxUses: number; usedCount: number} | null
-    product: {id: string; name: string}
-  }
-  email: string
-  existingPurchase: {
-    id: string
-    product: {id: string; name: string}
-  }
-  setPersonalPurchase: React.Dispatch<any>
-}> = ({purchase, existingPurchase, setPersonalPurchase}) => {
-  const {data: session, status} = useSession()
-
-  return (
-    <div className="flex w-full flex-col items-baseline justify-between border-b border-gray-200 py-4 px-3">
-      <div className="flex items-center gap-2">
-        <Icon name="Team" className="text-gray-600" /> Your Team
-      </div>
-      <InviteTeam
-        setPersonalPurchase={setPersonalPurchase}
-        session={session}
-        purchase={purchase}
-        existingPurchase={existingPurchase}
-        className="flex w-full flex-col py-3"
-      />
-    </div>
-  )
-}
-
-const InvoiceLink: React.FC<{merchantChargeId: string | null}> = ({
-  merchantChargeId,
-}) => {
-  const ability = useAbilities()
-  const canViewInvoice = ability.can('view', 'Invoice')
-  return canViewInvoice ? (
-    <Link
-      className="text-sky-500 underline"
-      href={{
-        pathname: '/invoices/[merchantChargeId]',
-        query: {
-          merchantChargeId,
-        },
-      }}
-    >
-      View invoice
-    </Link>
-  ) : null
-}
-
-export const Price: React.FC<{amount: number}> = ({amount}) => {
-  const {dollars, cents} = formatUsd(amount)
-  return (
-    <div>
-      <span className="pr-1">USD</span>
-      <span>{dollars}</span>
-      <sup>{cents}</sup>
-    </div>
-  )
-}
-
-export const DatePurchased: React.FC<{date: string}> = ({date}) => {
-  return <>{format(new Date(date), 'MMMM dd, y')}</>
-}
-
-const StartLearning: React.FC<{
-  product: {
-    slug: string
-    lessons: {_id: string; slug: string}[]
-    sections: Section[]
-  }
-}> = ({product}) => {
-  const {lessons, sections} = product
-  const {data: userProgress} = trpc.progress.get.useQuery()
-  const completedLessons = getCompletedLessons({userProgress, lessons})
-  const nextLesson = completedLessons
-    ? lessons[
-        indexOf(
-          lessons,
-          find(lessons, {_id: get(first(completedLessons), 'lessonId')}),
-        ) + 1
-      ]
-    : first(lessons)
-
-  return (
-    <>
-      <Link
-        href={{
-          pathname: '/workshops/[module]/[section]/[lesson]',
-          query: {
-            module: product.slug,
-            section: first(sections)?.slug,
-            lesson: nextLesson?.slug,
-          },
-        }}
-        className="inline-flex rounded-full bg-brand-red px-5 py-2.5 text-sm font-semibold text-white"
-      >
-        {isEmpty(completedLessons) ? 'Start Learning' : 'Continue Learning'}
-      </Link>
-    </>
-  )
-}
-
-const getCompletedLessons = ({
-  userProgress,
-  lessons,
-}: {
-  userProgress: LessonProgress[] | undefined
-  lessons: {_id: string}[]
-}) => {
-  return userProgress?.filter(
-    (completedLesson) =>
-      !isEmpty(find(lessons, {_id: completedLesson.lessonId})) &&
-      completedLesson.completedAt,
-  )
-}
-
-const Share = () => {
-  const tweet = `https://twitter.com/intent/tweet/?text=Pro Tailwind by @${process.env.NEXT_PUBLIC_PARTNER_TWITTER} 🧙 https%3A%2F%2Fwww.protailwind.com%2F`
-  return (
-    <div className="flex flex-col items-center justify-center gap-5 text-center">
-      <p>
-        Tell your friends about {process.env.NEXT_PUBLIC_SITE_TITLE},{' '}
-        <br className="hidden sm:block" />
-        it would help me to get a word out.{' '}
-        <span role="img" aria-label="smiling face">
-          😊
-        </span>
-      </p>
-      <a
-        href={tweet}
-        rel="noopener noreferrer"
-        target="_blank"
-        className="group flex items-center gap-2 rounded-full border border-sky-500 px-5 py-2.5 font-heading font-semibold text-sky-500 transition hover:bg-sky-500 hover:text-white"
-      >
-        <Icon name="Twitter" className="fill-sky-500 group-hover:fill-white" />{' '}
-        Share with your friends!
-      </a>
-    </div>
-  )
-}
-
-const Progress: React.FC<{
-  sanityProduct: {
-    slug: string
-    lessons: {_id: string; slug: string}[]
-    sections: Section[]
-  }
-}> = ({sanityProduct}) => {
-  const {lessons} = sanityProduct
-  const {data: userProgress} = trpc.progress.get.useQuery()
-  const completedLessons = getCompletedLessons({userProgress, lessons})
-  return (
-    <div className="flex flex-col items-start gap-1">
-      {completedLessons?.length}/{lessons.length} lessons completed
-      <StartLearning product={sanityProduct} />
-    </div>
-  )
-}
-
-const formatUsd = (amount: number = 0) => {
-  const formatter = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-  })
-  const formattedPrice = formatter.format(amount).split('.')
-
-  return {dollars: formattedPrice[0], cents: formattedPrice[1]}
-}

--- a/apps/protailwind/src/pages/purchases/index.tsx
+++ b/apps/protailwind/src/pages/purchases/index.tsx
@@ -1,13 +1,10 @@
-import {ArrowRightIcon} from '@heroicons/react/solid'
 import {convertToSerializeForNextResponse} from '@skillrecordings/commerce-server'
-import {getSdk, Purchase} from '@skillrecordings/database'
-import Layout from 'components/layout'
+import {getSdk} from '@skillrecordings/database'
 import {GetServerSideProps} from 'next'
 import {getToken} from 'next-auth/jwt'
-import Link from 'next/link'
-import {DatePurchased, Price} from './[purchaseId]'
-import Balancer from 'react-wrap-balancer'
-import Image from 'next/image'
+import PurchasesIndexTemplate, {
+  type PurchasesIndexProps,
+} from 'purchase-details/purchases-index-template'
 
 export const getServerSideProps: GetServerSideProps = async ({
   res,
@@ -22,74 +19,8 @@ export const getServerSideProps: GetServerSideProps = async ({
   }
 }
 
-const PurchasesIndex: React.FC<{
-  purchases: Purchase &
-    {
-      id: string
-      bulkCoupon: string
-      product: {name: string}
-      createdAt: string
-      totalAmount: number
-      redeemedBulkCouponId: string | null
-    }[]
-}> = ({purchases}) => {
-  console.log({purchases})
-  return (
-    <Layout meta={{title: 'Your Purchases'}}>
-      <header className="px-5 pt-16 text-center sm:pt-20">
-        <h1 className="font-heading text-4xl font-black sm:text-5xl">
-          Your Purchases
-        </h1>
-        <h2 className="mx-auto w-full max-w-lg pt-3 text-lg font-medium text-brand-red">
-          <Balancer>
-            View details about your purchases. Get your invoice, buy more seats,
-            or invite your team members.
-          </Balancer>
-        </h2>
-      </header>
-      <main className="mx-auto flex w-full max-w-2xl flex-col gap-8 py-16 px-5">
-        {purchases
-          ?.filter((p) => !p.redeemedBulkCouponId)
-          .map((purchase) => {
-            return (
-              <article className="rounded-lg border border-gray-200/50 bg-white px-8 pt-10 pb-5 shadow-2xl shadow-gray-500/10">
-                <h2 className="font-heading text-2xl font-black sm:text-2xl">
-                  <Balancer>
-                    <Link
-                      href={`/purchases/${purchase.id}`}
-                      className="hover:underline"
-                    >
-                      {purchase.product.name}
-                    </Link>
-                  </Balancer>
-                </h2>
-                <div className="mt-8 flex w-full items-center justify-between border-t border-dotted border-gray-300 pt-4">
-                  <div className="flex items-center text-gray-600">
-                    <Price amount={purchase.totalAmount} />
-                    {' ・ '}
-                    <DatePurchased date={purchase.createdAt} />
-                  </div>
-                  <Link
-                    href={`/purchases/${purchase.id}`}
-                    className="flex items-center gap-2 font-medium text-sky-500 underline"
-                  >
-                    View details {purchase.bulkCoupon && 'and invite your team'}{' '}
-                    <ArrowRightIcon className="h-4 w-4" />
-                  </Link>
-                </div>
-              </article>
-            )
-          })}
-        <Image
-          src={require('../../../public/assets/hydrant.svg')}
-          aria-hidden="true"
-          alt=""
-          width={64}
-          className="mx-auto pt-10"
-        />
-      </main>
-    </Layout>
-  )
+const PurchasesIndex: React.FC<PurchasesIndexProps> = ({purchases}) => {
+  return <PurchasesIndexTemplate purchases={purchases} />
 }
 
 export default PurchasesIndex

--- a/apps/protailwind/src/pages/welcome/index.tsx
+++ b/apps/protailwind/src/pages/welcome/index.tsx
@@ -158,7 +158,10 @@ const Welcome: React.FC<
       meta={{title: `Welcome to ${process.env.NEXT_PUBLIC_SITE_TITLE}`}}
       footer={null}
     >
-      <main className="mx-auto flex w-full flex-grow flex-col items-center justify-center px-5 pt-10 pb-32">
+      <main
+        className="mx-auto flex w-full flex-grow flex-col items-center justify-center px-5 pt-10 pb-32"
+        id="welcome"
+      >
         <div className="flex w-full max-w-screen-md flex-col gap-3">
           <Header
             workshop={workshop}
@@ -195,10 +198,15 @@ const Welcome: React.FC<
               </div>
             )}
             {isTransferAvailable && purchaseUserTransfers && (
-              <Transfer
-                purchaseUserTransfers={purchaseUserTransfers}
-                refetch={refetch}
-              />
+              <div>
+                <h2 className="pb-2 font-heading text-sm font-black uppercase">
+                  Transfer this purchase to another email address
+                </h2>
+                <Transfer
+                  purchaseUserTransfers={purchaseUserTransfers}
+                  refetch={refetch}
+                />
+              </div>
             )}
           </div>
         </div>

--- a/apps/protailwind/src/purchase-details/purchase-details-template.tsx
+++ b/apps/protailwind/src/purchase-details/purchase-details-template.tsx
@@ -1,0 +1,404 @@
+import React from 'react'
+import {createAppAbility} from '@skillrecordings/skill-lesson/utils/ability'
+import {LessonProgress} from '@skillrecordings/database'
+import {Section} from '@skillrecordings/skill-lesson/schemas/section'
+import {find, first, get, indexOf, isEmpty} from 'lodash'
+import {format} from 'date-fns'
+import {trpc} from 'trpc/trpc.client'
+import BuyMoreSeats from 'team/buy-more-seats'
+import Balancer from 'react-wrap-balancer'
+import Layout from 'components/layout'
+import Link from 'next/link'
+import Image from 'next/image'
+import InviteTeam from 'team'
+import {useSession} from 'next-auth/react'
+import Icon, {type IconNames} from 'components/icons'
+import * as Dialog from '@radix-ui/react-dialog'
+import {XIcon} from '@heroicons/react/solid'
+import {Transfer} from 'purchase-transfer/purchase-transfer'
+
+export type PurchaseDetailsProps = {
+  welcome: boolean
+  product: {
+    slug: string
+    lessons: {_id: string; slug: string}[]
+    sections: Section[]
+    name: string
+  }
+  user: {
+    email: string
+  }
+  purchase: {
+    id: string
+    status: 'Valid' | 'Refunded' | 'Disputed' | 'Pending'
+    merchantChargeId: string | null
+    bulkCoupon: {id: string; maxUses: number; usedCount: number} | null
+    product: {id: string; name: string}
+    productId: string
+    userId: string
+    createdAt: string
+    totalAmount: number
+  }
+  sanityProduct: {
+    image: {
+      url: string
+    }
+    slug: string
+    lessons: {_id: string; slug: string}[]
+    sections: Section[]
+  }
+  existingPurchase: {id: string; product: {id: string; name: string}}
+}
+
+const PurchaseDetailsTemplate: React.FC<PurchaseDetailsProps> = ({
+  welcome,
+  product,
+  user,
+  purchase,
+  sanityProduct,
+  existingPurchase,
+}) => {
+  const ability = useAbilities()
+  const canInviteTeam = ability.can('invite', 'Team')
+  const canViewContent = ability.can('view', 'Content')
+  const [personalPurchase, setPersonalPurchase] = React.useState(
+    purchase.bulkCoupon ? existingPurchase : purchase,
+  )
+
+  return (
+    <Layout meta={{title: `Purchase details for ${product.name}`}}>
+      {welcome ? <WelcomeHeader /> : null}
+      <div className="mx-auto w-full max-w-3xl py-16" id="purchase-detail">
+        <main className="flex flex-col items-start gap-10 bg-gray-50 md:flex-row">
+          <Image
+            src={sanityProduct.image.url}
+            alt=""
+            aria-hidden="true"
+            width={200}
+            height={200}
+            className="flex-shrink-0"
+          />
+          <div className="w-full">
+            <p className="pb-3 font-heading font-extrabold uppercase text-sky-500">
+              Your purchase details for
+            </p>
+            <h1 className="font-heading text-4xl font-black">
+              <Balancer>{product.name}</Balancer>
+            </h1>
+            <div className="-mx-3 flex flex-col items-center justify-center divide-y divide-slate-200 pt-10">
+              <Row label="Invoice" icon="Receipt">
+                <InvoiceLink merchantChargeId={purchase.merchantChargeId} />
+              </Row>
+              {canInviteTeam && (
+                <ManageTeam
+                  purchase={purchase}
+                  email={user.email}
+                  existingPurchase={existingPurchase}
+                  setPersonalPurchase={setPersonalPurchase}
+                />
+              )}
+              <Row label="Amount paid" icon="Dollar">
+                <Price amount={purchase.totalAmount} />{' '}
+                {purchase.status === 'Refunded' && '(Refunded)'}
+              </Row>
+              <Row label="Purchased on" icon="Calendar">
+                <DatePurchased date={purchase.createdAt} />
+              </Row>
+              {user && (
+                <Row label="Associated email address" icon="Email">
+                  {user.email}
+                </Row>
+              )}
+              {((purchase.status === 'Valid' && personalPurchase) ||
+                canViewContent) && (
+                <Row label="Progress" icon="PlayOutline">
+                  <Progress sanityProduct={sanityProduct} />
+                </Row>
+              )}
+              {!purchase.bulkCoupon && <PurchaseTransfer purchase={purchase} />}
+            </div>
+          </div>
+        </main>
+      </div>
+      <footer className="flex w-full flex-grow items-center justify-center gap-16 bg-slate-100 py-16">
+        {welcome && <Share />}
+        <BuySeats
+          productName={product.name}
+          productId={purchase.productId}
+          userId={purchase.userId}
+        />
+      </footer>
+    </Layout>
+  )
+}
+
+export default PurchaseDetailsTemplate
+
+const useAbilities = () => {
+  const {data: abilityRules} = trpc.abilities.getAbilities.useQuery()
+
+  return createAppAbility(abilityRules || [])
+}
+
+const Row: React.FC<
+  React.PropsWithChildren<{label: string; icon: IconNames}>
+> = ({children, label = 'Label', icon = null}) => {
+  return children ? (
+    <div className="flex w-full items-start justify-between py-4 px-3">
+      <div className="flex items-center gap-2">
+        {icon && <Icon className="text-gray-600" name={icon} />} {label}
+      </div>
+      <div className="w-2/4 text-left font-medium">{children}</div>
+    </div>
+  ) : null
+}
+
+const PurchaseTransfer: React.FC<{purchase: {id: string}}> = ({purchase}) => {
+  const {data: purchaseUserTransfers, refetch} =
+    trpc.purchaseUserTransfer.forPurchaseId.useQuery({
+      id: purchase.id,
+    })
+
+  return (
+    <div className="flex w-full flex-col gap-3 py-4 px-3">
+      <div className="flex flex-shrink-0 items-center gap-2">
+        <Icon className="text-gray-600" name="MoveDown" /> Transfer this
+        purchase to another email address
+      </div>
+      <div className="w-full text-left font-medium">
+        {purchaseUserTransfers && (
+          <Transfer
+            purchaseUserTransfers={purchaseUserTransfers}
+            refetch={refetch}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+const WelcomeHeader = () => {
+  return (
+    <header className="relative flex w-full flex-col items-center justify-center overflow-hidden bg-[#31AEF6] pb-32 text-center text-white sm:pb-10">
+      <Image
+        src={require('../../public/assets/corgi-waving-upside-down.svg')}
+        alt=""
+        aria-hidden="true"
+        className="relative z-0"
+      />
+      <div className="absolute z-10 w-full px-5 pt-40">
+        <h1 className="font-heading text-3xl font-black sm:text-4xl md:text-5xl">
+          <Balancer>Welcome to Pro Tailwind!</Balancer>
+        </h1>
+        <p className="pt-3 sm:text-lg">
+          <Balancer>
+            You can find details about your purchase below. Happy learning!
+          </Balancer>
+        </p>
+      </div>
+    </header>
+  )
+}
+
+const BuySeats: React.FC<{
+  productId: string
+  userId: string
+  productName: string
+}> = ({productId, productName, userId}) => {
+  return (
+    <div
+      id="buy-more-seats-modal"
+      className="flex max-w-xs flex-col items-center text-center"
+    >
+      <p className="pb-5">
+        Get your team to level up with Tailwind Multi-Theme Strategy Workshop
+      </p>
+      <Dialog.Root>
+        <Dialog.Trigger className="group flex items-center gap-2 rounded-full bg-sky-500 px-5 py-2.5 font-heading font-semibold text-white transition hover:bg-sky-600">
+          Buy more seats
+        </Dialog.Trigger>
+        <Dialog.Overlay className="fixed inset-0 z-10 bg-black/50 backdrop-blur-sm" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 z-40 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white px-6 py-8 shadow-2xl shadow-gray-500/10">
+          <Dialog.Title className="pb-5 text-center font-heading text-2xl font-black leading-tight">
+            <Balancer>Buy more seats for {productName}</Balancer>
+          </Dialog.Title>
+          <BuyMoreSeats productId={productId} userId={userId} />
+          <Dialog.Close className="absolute top-2 right-2 rounded-full p-2 hover:bg-gray-100">
+            <XIcon className="h-5 w-5" />
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Root>
+    </div>
+  )
+}
+
+const ManageTeam: React.FC<{
+  purchase: {
+    merchantChargeId: string | null
+    bulkCoupon: {id: string; maxUses: number; usedCount: number} | null
+    product: {id: string; name: string}
+  }
+  email: string
+  existingPurchase: {
+    id: string
+    product: {id: string; name: string}
+  }
+  setPersonalPurchase: React.Dispatch<any>
+}> = ({purchase, existingPurchase, setPersonalPurchase}) => {
+  const {data: session, status} = useSession()
+
+  return (
+    <div className="flex w-full flex-col items-baseline justify-between border-b border-gray-200 py-4 px-3">
+      <div className="flex items-center gap-2">
+        <Icon name="Team" className="text-gray-600" /> Your Team
+      </div>
+      <InviteTeam
+        setPersonalPurchase={setPersonalPurchase}
+        session={session}
+        purchase={purchase}
+        existingPurchase={existingPurchase}
+        className="flex w-full flex-col py-3"
+      />
+    </div>
+  )
+}
+
+const InvoiceLink: React.FC<{merchantChargeId: string | null}> = ({
+  merchantChargeId,
+}) => {
+  const ability = useAbilities()
+  const canViewInvoice = ability.can('view', 'Invoice')
+  return canViewInvoice ? (
+    <Link
+      className="text-sky-500 underline"
+      href={{
+        pathname: '/invoices/[merchantChargeId]',
+        query: {
+          merchantChargeId,
+        },
+      }}
+    >
+      View invoice
+    </Link>
+  ) : null
+}
+
+export const Price: React.FC<{amount: number}> = ({amount}) => {
+  const {dollars, cents} = formatUsd(amount)
+  return (
+    <div>
+      <span className="pr-1">USD</span>
+      <span>{dollars}</span>
+      <sup>{cents}</sup>
+    </div>
+  )
+}
+
+export const DatePurchased: React.FC<{date: string}> = ({date}) => {
+  return <>{format(new Date(date), 'MMMM dd, y')}</>
+}
+
+const StartLearning: React.FC<{
+  product: {
+    slug: string
+    lessons: {_id: string; slug: string}[]
+    sections: Section[]
+  }
+}> = ({product}) => {
+  const {lessons, sections} = product
+  const {data: userProgress} = trpc.progress.get.useQuery()
+  const completedLessons = getCompletedLessons({userProgress, lessons})
+  const nextLesson = completedLessons
+    ? lessons[
+        indexOf(
+          lessons,
+          find(lessons, {_id: get(first(completedLessons), 'lessonId')}),
+        ) + 1
+      ]
+    : first(lessons)
+
+  return (
+    <>
+      <Link
+        href={{
+          pathname: '/workshops/[module]/[section]/[lesson]',
+          query: {
+            module: product.slug,
+            section: first(sections)?.slug,
+            lesson: nextLesson?.slug,
+          },
+        }}
+        className="inline-flex flex-shrink-0 rounded-full bg-sky-500 px-4 py-2.5 text-sm font-semibold text-white focus-visible:ring-offset-1"
+      >
+        {isEmpty(completedLessons) ? 'Start Learning' : 'Continue Learning'}
+      </Link>
+    </>
+  )
+}
+
+const getCompletedLessons = ({
+  userProgress,
+  lessons,
+}: {
+  userProgress: LessonProgress[] | undefined
+  lessons: {_id: string}[]
+}) => {
+  return userProgress?.filter(
+    (completedLesson) =>
+      !isEmpty(find(lessons, {_id: completedLesson.lessonId})) &&
+      completedLesson.completedAt,
+  )
+}
+
+const Share = () => {
+  const tweet = `https://twitter.com/intent/tweet/?text=Pro Tailwind by @${process.env.NEXT_PUBLIC_PARTNER_TWITTER} 🧙 https%3A%2F%2Fwww.protailwind.com%2F`
+  return (
+    <div className="flex flex-col items-center justify-center gap-5 text-center">
+      <p>
+        Tell your friends about {process.env.NEXT_PUBLIC_SITE_TITLE},{' '}
+        <br className="hidden sm:block" />
+        it would help me to get a word out.{' '}
+        <span role="img" aria-label="smiling face">
+          😊
+        </span>
+      </p>
+      <a
+        href={tweet}
+        rel="noopener noreferrer"
+        target="_blank"
+        className="group flex items-center gap-2 rounded-full border border-sky-500 px-5 py-2.5 font-heading font-semibold text-sky-500 transition hover:bg-sky-500 hover:text-white"
+      >
+        <Icon name="Twitter" className="fill-sky-500 group-hover:fill-white" />{' '}
+        Share with your friends!
+      </a>
+    </div>
+  )
+}
+
+const Progress: React.FC<{
+  sanityProduct: {
+    slug: string
+    lessons: {_id: string; slug: string}[]
+    sections: Section[]
+  }
+}> = ({sanityProduct}) => {
+  const {lessons} = sanityProduct
+  const {data: userProgress} = trpc.progress.get.useQuery()
+  const completedLessons = getCompletedLessons({userProgress, lessons})
+  return (
+    <div className="flex items-center gap-2">
+      {completedLessons?.length}/{lessons.length} lessons completed
+      <StartLearning product={sanityProduct} />
+    </div>
+  )
+}
+
+const formatUsd = (amount: number = 0) => {
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  })
+  const formattedPrice = formatter.format(amount).split('.')
+
+  return {dollars: formattedPrice[0], cents: formattedPrice[1]}
+}

--- a/apps/protailwind/src/purchase-details/purchase-details.css
+++ b/apps/protailwind/src/purchase-details/purchase-details.css
@@ -1,0 +1,80 @@
+#purchase-detail {
+  #purchase-transfer {
+    [data-transfer-state] {
+      @apply flex flex-col gap-3;
+      p {
+        @apply font-medium text-gray-700;
+      }
+      button {
+        @apply py-2.5 text-sm shadow-none;
+      }
+    }
+    [data-transfer-state='AVAILABLE'] {
+      h2 {
+        @apply hidden;
+      }
+      p:last-of-type {
+        @apply font-semibold;
+      }
+    }
+    [data-transfer-state='INITIATED'] {
+      h2 {
+        @apply text-base font-medium text-gray-700 before:mr-1 before:animate-pulse before:rounded-full before:px-1 before:text-xl before:content-["📧"];
+      }
+      button {
+        @apply self-start bg-gray-300 text-black;
+      }
+    }
+    [data-transfer-state='COMPLETED'] {
+      p:first-of-type {
+        @apply before:mr-1 before:px-1 before:text-xl before:leading-none before:text-emerald-600 before:content-["✓"];
+      }
+    }
+  }
+
+  #purchase-transfer-form {
+    label {
+    }
+    input {
+    }
+    span {
+    }
+    button {
+    }
+  }
+}
+
+#welcome {
+  #purchase-transfer {
+    [data-transfer-state] {
+      @apply flex flex-col gap-3 rounded-lg border border-gray-100 bg-white px-5 py-6 shadow-xl shadow-gray-400/5;
+      p {
+        @apply font-medium text-gray-700;
+      }
+      button {
+        @apply py-2.5 text-sm shadow-none;
+      }
+    }
+    [data-transfer-state='AVAILABLE'] {
+      h2 {
+        @apply hidden;
+      }
+      p:last-of-type {
+        @apply font-semibold;
+      }
+    }
+    [data-transfer-state='INITIATED'] {
+      h2 {
+        @apply text-base font-medium text-gray-700 before:mr-1 before:animate-pulse before:rounded-full before:px-1 before:text-xl before:content-["📧"];
+      }
+      button {
+        @apply self-start bg-gray-300 text-black;
+      }
+    }
+    [data-transfer-state='COMPLETED'] {
+      p:first-of-type {
+        @apply before:mr-1 before:px-1 before:text-xl before:leading-none before:text-emerald-600 before:content-["✓"];
+      }
+    }
+  }
+}

--- a/apps/protailwind/src/purchase-details/purchases-index-template.tsx
+++ b/apps/protailwind/src/purchase-details/purchases-index-template.tsx
@@ -1,0 +1,80 @@
+import {ArrowRightIcon} from '@heroicons/react/solid'
+import {Purchase} from '@skillrecordings/database'
+import Layout from 'components/layout'
+import Link from 'next/link'
+import {DatePurchased, Price} from 'purchase-details/purchase-details-template'
+import Balancer from 'react-wrap-balancer'
+import Image from 'next/image'
+
+export type PurchasesIndexProps = {
+  purchases: Purchase &
+    {
+      id: string
+      bulkCoupon: string
+      product: {name: string}
+      createdAt: string
+      totalAmount: number
+      redeemedBulkCouponId: string | null
+    }[]
+}
+
+const PurchasesIndexTemplate: React.FC<PurchasesIndexProps> = ({purchases}) => {
+  return (
+    <Layout meta={{title: 'Your Purchases'}}>
+      <header className="px-5 pt-16 text-center sm:pt-20">
+        <h1 className="font-heading text-4xl font-black sm:text-5xl">
+          Your Purchases
+        </h1>
+        <h2 className="mx-auto w-full max-w-lg pt-3 text-lg font-medium text-brand-red">
+          <Balancer>
+            View details about your purchases. Get your invoice, buy more seats,
+            or invite your team members.
+          </Balancer>
+        </h2>
+      </header>
+      <main className="mx-auto flex w-full max-w-2xl flex-col gap-8 py-16 px-5">
+        {purchases
+          ?.filter((p) => !p.redeemedBulkCouponId)
+          .map((purchase) => {
+            return (
+              <article className="rounded-lg border border-gray-200/50 bg-white px-8 pt-10 pb-5 shadow-2xl shadow-gray-500/10">
+                <h2 className="font-heading text-2xl font-black sm:text-2xl">
+                  <Balancer>
+                    <Link
+                      href={`/purchases/${purchase.id}`}
+                      className="hover:underline"
+                    >
+                      {purchase.product.name}
+                    </Link>
+                  </Balancer>
+                </h2>
+                <div className="mt-8 flex w-full items-center justify-between border-t border-dotted border-gray-300 pt-4">
+                  <div className="flex items-center text-gray-600">
+                    <Price amount={purchase.totalAmount} />
+                    {' ・ '}
+                    <DatePurchased date={purchase.createdAt} />
+                  </div>
+                  <Link
+                    href={`/purchases/${purchase.id}`}
+                    className="flex items-center gap-2 font-medium text-sky-500 underline"
+                  >
+                    View details {purchase.bulkCoupon && 'and invite your team'}{' '}
+                    <ArrowRightIcon className="h-4 w-4" />
+                  </Link>
+                </div>
+              </article>
+            )
+          })}
+        <Image
+          src={require('../../public/assets/hydrant.svg')}
+          aria-hidden="true"
+          alt=""
+          width={64}
+          className="mx-auto pt-10"
+        />
+      </main>
+    </Layout>
+  )
+}
+
+export default PurchasesIndexTemplate

--- a/apps/protailwind/src/purchase-transfer/purchase-transfer.tsx
+++ b/apps/protailwind/src/purchase-transfer/purchase-transfer.tsx
@@ -43,31 +43,30 @@ const PurchaseTransferForm = ({
   }
 
   return (
-    <div>
-      <form
-        className="flex w-full flex-col gap-2 text-left md:flex-row"
-        onSubmit={handleSubmit(onSubmit)}
+    <form
+      id="purchase-transfer-form"
+      className="flex w-full flex-col gap-2 text-left md:flex-row"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <label className="sr-only" htmlFor="email">
+        Email:
+      </label>
+      <input
+        className="w-full rounded-md bg-gray-200/60 px-3 py-2 shadow-inner placeholder:text-gray-500"
+        type="email"
+        {...register('email', {required: true})}
+        placeholder="somebody@example.com"
+      />
+      {errors.email && <span>This field is required</span>}
+      <button
+        className="relative flex flex-shrink-0 items-center justify-center rounded-full bg-brand-red py-2 px-5 font-semibold text-white shadow-2xl shadow-cyan-900/50 transition focus-visible:ring-white hover:brightness-110"
+        type="submit"
+        disabled={isLoading}
       >
-        <label className="sr-only" htmlFor="email">
-          Email:
-        </label>
-        <input
-          className="w-full rounded-md bg-gray-200/60 px-3 py-2 shadow-inner placeholder:text-gray-500"
-          type="email"
-          {...register('email', {required: true})}
-          placeholder="somebody@example.com"
-        />
-        {errors.email && <span>This field is required</span>}
-        <button
-          className="relative flex flex-shrink-0 items-center justify-center rounded-full bg-brand-red py-2 px-5 font-semibold text-white shadow-2xl shadow-cyan-900/50 transition focus-visible:ring-white hover:brightness-110"
-          type="submit"
-          disabled={isLoading}
-        >
-          Transfer
-        </button>
-        {error && <span>{error.message}</span>}
-      </form>
-    </div>
+        Transfer
+      </button>
+      {error && <span>{error.message}</span>}
+    </form>
   )
 }
 
@@ -83,15 +82,18 @@ export const Transfer = ({
       refetch()
     },
   })
+
   return (
-    <div className="mt-12 flex flex-col gap-3">
+    <div id="purchase-transfer">
       {purchaseUserTransfers.map((purchaseUserTransfer) => {
+        const STATE = purchaseUserTransfer.transferState
+
         return (
-          <>
-            {purchaseUserTransfer.transferState === 'AVAILABLE' && (
+          <div data-transfer-state={STATE} className="flex flex-col gap-3">
+            {STATE === 'AVAILABLE' && (
               <>
                 <h2 className="text-2xl font-bold">
-                  Transfer this purchase to another email address.
+                  Transfer this purchase to another email address
                 </h2>
                 <p>
                   You can transfer your purchase to another email address. We
@@ -111,8 +113,8 @@ export const Transfer = ({
                 />
               </>
             )}
-            {purchaseUserTransfer.transferState === 'INITIATED' && (
-              <div>
+            {STATE === 'INITIATED' && (
+              <>
                 <h2 className="mb-3 text-2xl font-bold">
                   This purchase is being transferred. Once accepted you will no
                   longer have access to this purchase or its associated invoice.
@@ -129,17 +131,17 @@ export const Transfer = ({
                 >
                   Cancel Transfer
                 </button>
-              </div>
+              </>
             )}
-            {purchaseUserTransfer.transferState === 'COMPLETED' && (
-              <div>
+            {STATE === 'COMPLETED' && (
+              <>
                 <p>
                   This purchase has been transferred. You no longer have access
                   to this purchase or its associated invoice.
                 </p>
-              </div>
+              </>
             )}
-          </>
+          </div>
         )
       })}
     </div>

--- a/apps/protailwind/src/styles/globals.css
+++ b/apps/protailwind/src/styles/globals.css
@@ -6,6 +6,7 @@
 @import './focus-visible.css';
 @import './nprogress.css';
 @import './commerce.css';
+@import '../purchase-details/purchase-details.css';
 @import '@skillrecordings/feedback-widget/dist/styles.css';
 @tailwind utilities;
 


### PR DESCRIPTION
- display transfer purchase UI on `purchases/[purchaseId]` pages
- move `purchases` route templates into separate directory inside `src`
- add ability to style transfer purchase ui separately (theming)
- polish styles

<img src="https://user-images.githubusercontent.com/25487857/216973357-da9ea479-b294-4ae3-8d32-472559b39b23.png" width="800" alt="screenshot">

<img src="https://media.giphy.com/media/U4FkC2VqpeNRHjTDQ5/giphy-downsized.gif" width="200" alt="gif">