### PR TITLE
feat(tt): make repls navigatable

### DIFF
--- a/apps/protailwind/src/pages/tutorials/[module]/[lesson]/exercise.tsx
+++ b/apps/protailwind/src/pages/tutorials/[module]/[lesson]/exercise.tsx
@@ -1,0 +1,5 @@
+export {getStaticProps} from './index'
+export {getStaticPaths} from './index'
+import ExercisePage from './index'
+
+export default ExercisePage

--- a/apps/protailwind/src/pages/workshops/[module]/[section]/[lesson]/exercise.tsx
+++ b/apps/protailwind/src/pages/workshops/[module]/[section]/[lesson]/exercise.tsx
@@ -1,0 +1,5 @@
+export {getStaticProps} from './index'
+export {getStaticPaths} from './index'
+import ExercisePage from './index'
+
+export default ExercisePage

--- a/apps/protailwind/src/video/lesson-list.tsx
+++ b/apps/protailwind/src/video/lesson-list.tsx
@@ -72,7 +72,8 @@ const ExerciseListItem = ({
   const currentPath = section
     ? `${path}/${module.slug.current}/${section.slug}/${exercise?.slug}`
     : `${path}/${module.slug.current}/${exercise?.slug}`
-  const isActive = router.asPath === currentPath
+  const isActive =
+    router.asPath === currentPath || router.asPath === currentPath + '/exercise'
   return exercise ? (
     <ul className="text-gray-700">
       <li key={exercise.slug + `exercise`}>

--- a/apps/total-typescript/src/pages/tutorials/[module]/[lesson]/exercise.tsx
+++ b/apps/total-typescript/src/pages/tutorials/[module]/[lesson]/exercise.tsx
@@ -1,0 +1,5 @@
+export {getStaticProps} from './index'
+export {getStaticPaths} from './index'
+import ExercisePage from './index'
+
+export default ExercisePage

--- a/apps/total-typescript/src/pages/workshops/[module]/[section]/[lesson]/exercise.tsx
+++ b/apps/total-typescript/src/pages/workshops/[module]/[section]/[lesson]/exercise.tsx
@@ -1,0 +1,5 @@
+export {getStaticProps} from './index'
+export {getStaticPaths} from './index'
+import ExercisePage from './index'
+
+export default ExercisePage

--- a/apps/total-typescript/src/video/exercise-overlay.tsx
+++ b/apps/total-typescript/src/video/exercise-overlay.tsx
@@ -7,7 +7,7 @@ import {IconGithub} from '../components/icons'
 import snakeCase from 'lodash/snakeCase'
 import Image from 'next/legacy/image'
 import {useMuxPlayer} from '@skillrecordings/skill-lesson/hooks/use-mux-player'
-import {XIcon} from '@heroicons/react/solid'
+import {CodeIcon, XIcon} from '@heroicons/react/solid'
 import cx from 'classnames'
 import {track} from '@skillrecordings/skill-lesson/utils/analytics'
 import {setUserId} from '@amplitude/analytics-browser'
@@ -94,7 +94,7 @@ const Actions = () => {
           handlePlay()
         }}
       >
-        Replay <span aria-hidden="true">↺</span>
+        <span aria-hidden="true">↺</span> Replay
       </button>
       {nextExercise && (
         <button
@@ -137,7 +137,7 @@ const ExerciseOverlay = () => {
 
   const {exerciseGitHubUrl} = getExerciseGitHubUrl({stackblitz, module})
 
-  return status !== 'loading' ? (
+  return (
     <div className=" bg-black/30 ">
       {stackblitz ? (
         <>
@@ -252,7 +252,7 @@ const ExerciseOverlay = () => {
         </div>
       )}
     </div>
-  ) : null
+  )
 }
 
 const DefaultOverlay = () => {
@@ -262,6 +262,10 @@ const DefaultOverlay = () => {
   const {image} = module
   const addProgressMutation = trpc.progress.add.useMutation()
   const utils = trpc.useContext()
+  const {data: stackblitz} = trpc.stackblitz.byExerciseSlug.useQuery({
+    slug: router.query.lesson as string,
+    type: lesson._type,
+  })
 
   return (
     <OverlayWrapper className="px-5">
@@ -281,7 +285,7 @@ const DefaultOverlay = () => {
         <span className="font-normal text-gray-200">Up next:</span>{' '}
         {nextExercise?.title}
       </p>
-      <div className="flex items-center justify-center gap-5 py-4 sm:py-8">
+      <div className="flex flex-wrap items-center justify-center gap-3 py-4 sm:py-8">
         <button
           className="rounded bg-gray-800 px-3 py-1 text-lg font-semibold transition hover:bg-gray-700 sm:px-5 sm:py-3"
           onClick={() => {
@@ -295,8 +299,17 @@ const DefaultOverlay = () => {
             handlePlay()
           }}
         >
-          Replay ↺
+          <span aria-hidden="true">↺</span> Replay
         </button>
+        {stackblitz && (
+          <Link
+            href={router.asPath.replace('solution', 'exercise')}
+            className="flex items-center gap-1 rounded bg-gray-800 px-3 py-1 text-lg font-semibold transition hover:bg-gray-700 sm:px-5 sm:py-3"
+          >
+            <CodeIcon className="h-5 w-5" aria-hidden="true" />
+            Try Again
+          </Link>
+        )}
         <button
           className="rounded bg-cyan-600 px-3 py-1 text-lg font-semibold transition hover:bg-cyan-500 sm:px-5 sm:py-3"
           onClick={() => {
@@ -600,6 +613,10 @@ const FinishedSectionOverlay = () => {
   const utils = trpc.useContext()
   const nextExercise = first(nextSection?.lessons) as Lesson
   const router = useRouter()
+  const {data: stackblitz} = trpc.stackblitz.byExerciseSlug.useQuery({
+    slug: router.query.lesson as string,
+    type: lesson._type,
+  })
 
   return (
     <OverlayWrapper className="px-5">
@@ -614,14 +631,13 @@ const FinishedSectionOverlay = () => {
           />
         </div>
       )}
-
       {nextSection && (
         <p className="pt-4 text-xl font-semibold sm:text-3xl">
           <span className="font-normal text-gray-200">Up next:</span>{' '}
           {nextSection.title}
         </p>
       )}
-      <div className="flex items-center justify-center gap-5 py-4 sm:py-8">
+      <div className="flex flex-wrap items-center justify-center gap-3 py-4 sm:py-8">
         <button
           className="rounded bg-gray-800 px-3 py-1 text-lg font-semibold transition hover:bg-gray-700 sm:px-5 sm:py-3"
           onClick={() => {
@@ -635,8 +651,17 @@ const FinishedSectionOverlay = () => {
             handlePlay()
           }}
         >
-          Replay ↺
+          <span aria-hidden="true">↺</span> Replay
         </button>
+        {stackblitz && (
+          <Link
+            href={router.asPath.replace('solution', 'exercise')}
+            className="flex items-center gap-1 rounded bg-gray-800 px-3 py-1 text-lg font-semibold transition hover:bg-gray-700 sm:px-5 sm:py-3"
+          >
+            Try Again
+            <CodeIcon className="h-5 w-5" aria-hidden="true" />
+          </Link>
+        )}
         <button
           className="rounded bg-cyan-600 px-3 py-1 text-lg font-semibold transition hover:bg-cyan-500 sm:px-5 sm:py-3"
           onClick={() => {

--- a/apps/total-typescript/src/video/video.tsx
+++ b/apps/total-typescript/src/video/video.tsx
@@ -30,6 +30,7 @@ export const Video: React.FC<VideoProps> = React.forwardRef(
       muxPlayerProps,
       displayOverlay,
       nextExercise,
+      nextExerciseStatus,
       canShowVideo,
       loadingUserStatus,
       nextSection,
@@ -39,12 +40,28 @@ export const Video: React.FC<VideoProps> = React.forwardRef(
       <>
         {displayOverlay && (
           <>
-            {nextExercise ? (
-              <>{isExercise ? <ExerciseOverlay /> : <DefaultOverlay />}</>
-            ) : nextSection ? (
-              <FinishedSectionOverlay />
+            {nextExerciseStatus === 'loading' ? (
+              <LoadingOverlay />
             ) : (
-              <FinishedOverlay />
+              <>
+                {nextExercise ? (
+                  <>
+                    {isExercise ? (
+                      canShowVideo ? (
+                        <ExerciseOverlay />
+                      ) : (
+                        <BlockedOverlay />
+                      )
+                    ) : (
+                      <DefaultOverlay />
+                    )}
+                  </>
+                ) : nextSection ? (
+                  <FinishedSectionOverlay />
+                ) : (
+                  <FinishedOverlay />
+                )}
+              </>
             )}
           </>
         )}

--- a/packages/skill-lesson/hooks/use-mux-player.tsx
+++ b/packages/skill-lesson/hooks/use-mux-player.tsx
@@ -28,6 +28,7 @@ type VideoContextType = {
   handlePlay: () => void
   displayOverlay: boolean
   nextExercise?: Lesson | null
+  nextExerciseStatus?: 'error' | 'success' | 'loading'
   nextSection: Section | null
   path: string
   video?: {muxPlaybackId?: string}
@@ -55,12 +56,17 @@ export const VideoProvider: React.FC<
   exerciseSlug,
 }) => {
   const router = useRouter()
+
   const {subscriber} = useConvertkit()
   const {videoResource, loadingVideoResource} = useVideoResource()
   const {lesson, section, module} = useLesson()
   useGlobalPlayerShortcuts(muxPlayerRef)
 
-  const nextExercise = useNextLesson(lesson, module, section)
+  const {nextExercise, nextExerciseStatus} = useNextLesson(
+    lesson,
+    module,
+    section,
+  )
 
   const nextSection = section
     ? getNextSection({
@@ -84,6 +90,7 @@ export const VideoProvider: React.FC<
   const {setPlayerPrefs, autoplay, getPlayerPrefs} = usePlayerPrefs()
   const [autoPlay, setAutoPlay] = React.useState(getPlayerPrefs().autoplay)
   const [displayOverlay, setDisplayOverlay] = React.useState(false)
+
   const title = get(lesson, 'title') || get(lesson, 'label')
   const loadingUserStatus =
     abilityRulesStatus === 'loading' || loadingVideoResource
@@ -106,20 +113,23 @@ export const VideoProvider: React.FC<
 
   const handleNext = React.useCallback(
     (autoPlay: boolean) => {
-      nextExerciseSlug && autoPlay
-        ? router.push({
-            pathname: '/[module]/[lesson]',
-            query: {module: moduleSlug, lesson: nextExerciseSlug},
-          })
-        : setDisplayOverlay(true)
+      if (nextExercise?._type === 'exercise') {
+        setDisplayOverlay(true)
+      } else {
+        router.push(router.asPath + '/exercise').then(() => {
+          setDisplayOverlay(true)
+        })
+      }
     },
     [moduleSlug, nextExerciseSlug, router],
   )
 
   // initialize player state
   React.useEffect(() => {
-    setDisplayOverlay(false)
-  }, [lesson])
+    router.asPath.endsWith('/exercise')
+      ? setDisplayOverlay(true)
+      : setDisplayOverlay(false)
+  }, [lesson, router.asPath])
 
   const playbackRate = getPlayerPrefs().playbackRate
   const playbackId = videoResource?.muxPlaybackId
@@ -199,6 +209,7 @@ export const VideoProvider: React.FC<
     handlePlay,
     displayOverlay,
     nextExercise,
+    nextExerciseStatus,
     nextSection,
     video: videoResource,
     path,

--- a/packages/skill-lesson/hooks/use-mux-player.tsx
+++ b/packages/skill-lesson/hooks/use-mux-player.tsx
@@ -121,7 +121,7 @@ export const VideoProvider: React.FC<
         })
       }
     },
-    [moduleSlug, nextExerciseSlug, router],
+    [moduleSlug, nextExercise, router],
   )
 
   // initialize player state

--- a/packages/skill-lesson/hooks/use-next-lesson.ts
+++ b/packages/skill-lesson/hooks/use-next-lesson.ts
@@ -20,12 +20,13 @@ export const useNextLesson = (
     slug = router.query.lesson as string
   }
 
-  const {data: nextExercise} = trpcSkillLessons.lessons.getNextLesson.useQuery({
-    type: lesson._type,
-    slug,
-    module: module.slug.current,
-    section: section?.slug,
-  })
+  const {data: nextExercise, status: nextExerciseStatus} =
+    trpcSkillLessons.lessons.getNextLesson.useQuery({
+      type: lesson._type,
+      slug,
+      module: module.slug.current,
+      section: section?.slug,
+    })
 
-  return nextExercise
+  return {nextExercise, nextExerciseStatus}
 }


### PR DESCRIPTION
there's definitely more ways to approach this and I'm open for suggestions. this approach consists of a single check inside  effect and new `/exercise` route.

https://user-images.githubusercontent.com/25487857/217041615-7bd9ac31-2fbe-48b5-a5e3-081de3499b12.mp4

<img src="https://media.giphy.com/media/FFb9yZK6t0oDu/giphy.gif" width="200" alt="gif">