### PR TITLE
jbranchaud/tt 106 make sure buy more seats route create a

### DIFF
--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -394,6 +394,26 @@ export function getSdk(
         },
       })
 
+      // if this user has already purchased this product, then an additional
+      // purchase (even for only 1 seat) should be processed as a bulk
+      // purchase so that they can distribute the seat to someone else.
+      //
+      // if an existingPurchase is found, but no existingBulkCoupon is found,
+      // then the logic below will account for that and create a new bulk
+      // coupon for the requested quantity.
+      const existingPurchase = await ctx.prisma.purchase.findFirst({
+        where: {
+          productId,
+          userId,
+          status: 'Valid',
+        },
+      })
+
+      // TODO: This doesn't seem to be looking up the bulk coupon based
+      // on the product ID which will become an issue when any particular
+      // app has more than one product.
+      // E.g. should probably account for `restrictedToProductId`
+      //
       // Check if this user has already purchased a bulk coupon, in which
       // case, we'll be able to treat this purchase as adding seats.
       //
@@ -415,7 +435,10 @@ export function getSdk(
       // only adding 1 seat to the team, then it is still a "bulk purchase" and
       // we need to add it to their existing Bulk Coupon.
       const isBulkPurchase =
-        quantity > 1 || Boolean(existingBulkCoupon) || options.bulk
+        quantity > 1 ||
+        Boolean(existingBulkCoupon) ||
+        options.bulk ||
+        Boolean(existingPurchase)
 
       let bulkCouponId = null
       let coupon = null

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -481,11 +481,12 @@ export function getSdk(
         },
       })
 
+      const oneWeekInMilliseconds = 1000 * 60 * 60 * 24 * 7
       const purchaseUserTransfer = ctx.prisma.purchaseUserTransfer.create({
         data: {
           sourceUserId: userId,
           purchaseId: purchaseId,
-          expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
+          expiresAt: new Date(Date.now() + oneWeekInMilliseconds),
         },
       })
 


### PR DESCRIPTION
### feat(tt): handle another bulk purchase scenario

If a user has already purchased a product and then while not
authenticated they go back through the purchase flow, we should be able
to recognize that they have already purchased and create a bulk coupon
for their new purchase that they can share with their team.

Here is the post-purchase screen that they get now if they are making a subsequent individual purchase of the product.

<img width="1058" alt="CleanShot 2023-02-14 at 11 30 01@2x" src="https://user-images.githubusercontent.com/694063/218814805-4c925157-e27a-4ad6-a838-a7bd6988edb6.png">

![doritos](https://media3.giphy.com/media/3oKIPk8SXtvoSTpdyE/giphy.gif?cid=d1fd59abbk88eaqqqtsmyrfpe3811bc7ndk79i971zk8skun&rid=giphy.gif&ct=g)
