### PR TITLE
Add Vision Plugin to Pro Tailwind and Total TypeScript studios

### DIFF
--- a/apps/protailwind/studio/sanity.json
+++ b/apps/protailwind/studio/sanity.json
@@ -14,7 +14,8 @@
     "@sanity/desk-tool",
     "taxonomy-manager",
     "@sanity/code-input",
-    "cloudinary"
+    "cloudinary",
+    "@sanity/vision"
   ],
   "env": {
     "development": {

--- a/apps/protailwind/studio/sanity.json
+++ b/apps/protailwind/studio/sanity.json
@@ -17,11 +17,6 @@
     "cloudinary",
     "@sanity/vision"
   ],
-  "env": {
-    "development": {
-      "plugins": ["@sanity/vision"]
-    }
-  },
   "parts": [
     {
       "name": "part:@sanity/base/schema",

--- a/apps/protailwind/studio/yarn.lock
+++ b/apps/protailwind/studio/yarn.lock
@@ -1930,9 +1930,9 @@
     rxjs "^6.5.3"
 
 "@sanity/vision@^2.35.2":
-  version "2.35.2"
-  resolved "https://registry.yarnpkg.com/@sanity/vision/-/vision-2.35.2.tgz#74d58f3148369a3f6114587c7b9422229f28112a"
-  integrity sha512-3bNsqCpY8yFX3Tcjuq7exSip5g0V76agOgFhLZ3cPNwuN298JNuirXXXSNd7rBaILYBPgYXSQHZHT4abbpNh3A==
+  version "2.35.6"
+  resolved "https://registry.yarnpkg.com/@sanity/vision/-/vision-2.35.6.tgz#6e3d5dcbd657486768da36d1869a7f88d4fd3c5f"
+  integrity sha512-jjwOcy2yC7is5+gacRrsnWtn78hl2u4xiQxIpoAmfN6Xg5JyvYO6I4NEpy+eakpDZ7xdq5KzCP4dRblBFXoJYQ==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
     "@sanity/icons" "^1.3.4"
@@ -1940,7 +1940,7 @@
     classnames "^2.2.5"
     codemirror "^5.47.0"
     is-hotkey "^0.1.6"
-    json5 "^1.0.1"
+    json5 "^2.2.3"
     lodash "^4.17.15"
     query-string "^4.3.2"
     react-codemirror2 "^6.0.0"
@@ -6395,6 +6395,11 @@ json5@^2.1.2, json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+
+json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonfile@^4.0.0:
   version "4.0.0"

--- a/apps/total-typescript/studio/sanity.json
+++ b/apps/total-typescript/studio/sanity.json
@@ -13,6 +13,7 @@
     "@sanity/default-login",
     "@sanity/desk-tool",
     "@sanity/code-input",
+    "@sanity/vision",
     "cloudinary",
     "taxonomy-manager"
   ],

--- a/apps/total-typescript/studio/sanity.json
+++ b/apps/total-typescript/studio/sanity.json
@@ -17,11 +17,6 @@
     "cloudinary",
     "taxonomy-manager"
   ],
-  "env": {
-    "development": {
-      "plugins": ["@sanity/vision"]
-    }
-  },
   "parts": [
     {
       "name": "part:@sanity/base/schema",


### PR DESCRIPTION
I wanted to experiment with queries today with our data but I saw that vision wasn't currently being used. This includes the plugin for both the Pro Tailwind and Total TypeScript studios

![ring eye angel](https://media1.giphy.com/media/fBq4IBhQkC69ancGiJ/giphy.gif?cid=01d288b0aew8cgi6xzo0w06bjwxzildveyfitwkpgagbhdda&rid=giphy.gif&ct=g)