### PR TITLE
Pro Tailwind - only allows for sections and products in module schema

### DIFF
--- a/apps/protailwind/studio/schemas/documents/module.js
+++ b/apps/protailwind/studio/schemas/documents/module.js
@@ -57,17 +57,13 @@ export default {
     {
       name: 'resources',
       title: 'Resources',
-      description: 'Exercises, Sections, Explainers or Products in the Module',
+      description: 'Sections or Products in the Module',
       type: 'array',
       of: [
         {
-          title: 'Exercise, Section, or Explainer',
+          title: 'Section',
           type: 'reference',
-          to: [
-            {title: 'Exercise', type: 'exercise'},
-            {title: 'Section', type: 'section'},
-            {title: 'Explainer', type: 'explainer'},
-          ],
+          to: [{title: 'Section', type: 'section'}],
         },
         {title: 'Product', type: 'product'},
       ],


### PR DESCRIPTION
Now that all modules have their content within sections, we can make this adjustment to the schema.

![](https://media3.giphy.com/media/2AZTlU3hdlgj4byt77/giphy.gif?cid=01d288b07minhxt8qaxkx56f5ov5gcvzmqt3d2iv6pxzqz21&rid=giphy.gif&ct=g)