### PR TITLE
feat(tt): if a Stripe coupon is used, record it

### DIFF
--- a/packages/commerce-server/src/record-new-purchase.ts
+++ b/packages/commerce-server/src/record-new-purchase.ts
@@ -52,7 +52,7 @@ export async function stripeData(options: StripeDataOptions) {
 
   // extract MerchantCoupon identifier if used for purchase
   const discount = first(lineItem.discounts)
-  let stripeCouponId = discount?.discount.coupon.id
+  const stripeCouponId = discount?.discount.coupon.id
 
   return {
     stripeCustomerId,

--- a/packages/commerce-server/src/record-new-purchase.ts
+++ b/packages/commerce-server/src/record-new-purchase.ts
@@ -50,6 +50,10 @@ export async function stripeData(options: StripeDataOptions) {
   const stripeChargeId = stripeCharge?.id as string
   const stripeChargeAmount = stripeCharge?.amount || 0
 
+  // extract MerchantCoupon identifier if used for purchase
+  const discount = first(lineItem.discounts)
+  let stripeCouponId = discount?.discount.coupon.id
+
   return {
     stripeCustomerId,
     email,
@@ -57,6 +61,7 @@ export async function stripeData(options: StripeDataOptions) {
     stripeProductId: stripeProduct.id,
     stripeProduct,
     stripeChargeId,
+    stripeCouponId,
     quantity,
     stripeChargeAmount,
     metadata,
@@ -95,6 +100,7 @@ export async function recordNewPurchase(checkoutSessionId: string): Promise<{
     name,
     stripeProductId,
     stripeChargeId,
+    stripeCouponId,
     quantity,
     stripeChargeAmount,
     metadata,
@@ -124,6 +130,7 @@ export async function recordNewPurchase(checkoutSessionId: string): Promise<{
   const [purchase] = await createMerchantChargeAndPurchase({
     userId: user.id,
     stripeChargeId,
+    stripeCouponId,
     merchantAccountId,
     merchantProductId,
     merchantCustomerId,

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -384,6 +384,7 @@ export function getSdk(
       userId: string
       productId: string
       stripeChargeId: string
+      stripeCouponId?: string
       merchantAccountId: string
       merchantProductId: string
       merchantCustomerId: string
@@ -395,6 +396,7 @@ export function getSdk(
       const {
         userId,
         stripeChargeId,
+        stripeCouponId,
         merchantAccountId,
         merchantProductId,
         merchantCustomerId,
@@ -474,6 +476,10 @@ export function getSdk(
             },
           })
         } else {
+          const merchantCoupon = await ctx.prisma.merchantCoupon.findFirst({
+            where: {identifier: stripeCouponId},
+          })
+
           coupon = ctx.prisma.coupon.create({
             data: {
               id: bulkCouponId,
@@ -481,6 +487,7 @@ export function getSdk(
               maxUses: quantity,
               percentageDiscount: 1.0,
               status: 1,
+              merchantCouponId: merchantCoupon?.id,
             },
           })
         }

--- a/packages/stripe-sdk/src/stripe-sdk.ts
+++ b/packages/stripe-sdk/src/stripe-sdk.ts
@@ -11,6 +11,7 @@ export function getStripeSdk(
         expand: [
           'customer',
           'line_items.data.price.product',
+          'line_items.data.discounts',
           'payment_intent.charges',
         ],
       })


### PR DESCRIPTION
More details in Roam (https://roamresearch.com/#/app/egghead/page/R83NFE69j) and the linear issue.

Essentially, there was nothing in place before this to attempt to tie a purchase's `Coupon` record to a corresponding Stripe `MerchantCoupon`.

I just tested this out with a 5% off bulk purchase locally and it is now tying those records together as expected.

![the office kevin](https://media3.giphy.com/media/SEWEmCymjv8XDbsb8I/giphy.gif?cid=d1fd59abvld3vfjfqsgvrvgwwosrb0j48wdc490sygmzb0x4&rid=giphy.gif&ct=g)