### PR TITLE
feat(db): make customer id field optional

### DIFF
--- a/apps/testing-javascript/package.json
+++ b/apps/testing-javascript/package.json
@@ -11,7 +11,8 @@
     "db:studio": "prisma studio",
     "db:push": "prisma db push",
     "db:schema": "prisma migrate dev --create-only",
-    "db:start": "docker compose up -d"
+    "db:start": "docker compose up -d",
+    "db:generate": "pnpm -w generate"
   },
   "dependencies": {
     "@mdx-js/loader": "^2.1.2",

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -100,7 +100,7 @@ model MerchantCharge {
   merchantAccountId  String
   merchantProductId  String
   createdAt          DateTime          @default(now())
-  merchantCustomerId String
+  merchantCustomerId String?
   merchantAccount    MerchantAccount   @relation(fields: [merchantAccountId], references: [id], onDelete: Cascade)
   merchantCustomer   MerchantCustomer? @relation(fields: [merchantCustomerId], references: [id], onDelete: Cascade)
   merchantProduct    MerchantProduct   @relation(fields: [merchantProductId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
The prisma relation was already marked as optional, so the id field
itself should be nullable as well.

I need this for the Testing JavaScript data import because there are tons of `MerchantCharge` records that do not have a `MerchantCustomer` because of how Stripe purchases used to be done.

- [ ] Once these changes get the greenlight, I need to set up schema Deploy Requests across all the planetscale databases.

![CleanShot 2023-03-10 at 12 06 25@2x](https://user-images.githubusercontent.com/694063/224391486-e1df2c55-59e3-4e0d-9c4d-84084113610b.png)
