### PR TITLE
feat(kcd): add scripts for importing TJS data

### DIFF
--- a/apps/testing-javascript/src/data/lesson-progress-import.ts
+++ b/apps/testing-javascript/src/data/lesson-progress-import.ts
@@ -1,0 +1,103 @@
+// Running this script:
+//
+// Ensure you have the `LESSON_PROGRESS_DATA_IMPORT_FILE_PATH` env var (in
+// `.env.local`) set to the location of the TJS lesson progress data JSON
+// export.
+//
+// Execute the Lesson Progress Import like so:
+//
+// ```
+// npx ts-node --files --skipProject src/data/lesson-progress-import.ts
+// ```
+
+import fs from 'fs'
+import {z} from 'zod'
+import chunk from 'lodash/chunk'
+import {prisma} from '@skillrecordings/database'
+
+require('dotenv-flow').config({
+  default_node_env: 'development',
+})
+
+const dataFilePath = z
+  .string()
+  .parse(process.env.LESSON_PROGRESS_DATA_IMPORT_FILE_PATH)
+
+const readJsonData = (path: string) => {
+  let fileData = fs.readFileSync(path)
+  return JSON.parse(fileData.toString())
+}
+
+const LessonProgressSchema = z
+  .object({
+    id: z.string(),
+    userId: z.string().nullable(),
+    lessonSlug: z.string(),
+    lessonVersion: z.coerce.string(),
+    completedAt: z.string().nullable(),
+    updatedAt: z.string(),
+    createdAt: z.string(),
+    lessonId: z.string(),
+  })
+  .transform(({createdAt, updatedAt, completedAt, ...rest}) => {
+    return {
+      createdAt: new Date(createdAt),
+      updatedAt: new Date(updatedAt),
+      completedAt: completedAt && new Date(completedAt),
+      ...rest,
+    }
+  })
+
+// from: https://github.com/sindresorhus/type-fest/blob/main/source/set-non-nullable.d.ts
+type SetNonNullable<BaseType, Keys extends keyof BaseType = keyof BaseType> = {
+  [Key in keyof BaseType]: Key extends Keys
+    ? NonNullable<BaseType[Key]>
+    : BaseType[Key]
+}
+
+type LessonProgress = z.infer<typeof LessonProgressSchema>
+type ValidLessonProgress = SetNonNullable<LessonProgress, 'userId'>
+
+const FileDataSchema = z.object({
+  lessonProgress: z.array(LessonProgressSchema),
+})
+
+const importLessonProgressData = async () => {
+  // Make sure this only gets run against the KCD Products database
+  if (process.env.DATABASE_URL !== 'mysql://root@localhost:3309/kcd-products') {
+    console.log('This is only meant to run against the kcd-products database.')
+    process.exit(1)
+  }
+
+  // ***************************************
+  // ** Read and Parse Full Purchase JSON **
+  // ***************************************
+  let {lessonProgress} = FileDataSchema.parse(readJsonData(dataFilePath))
+
+  const shortRun = false
+
+  const chunkData = <T>(data: Array<T>): Array<T>[] => {
+    const chunks = chunk(data, 1000)
+
+    if (shortRun) {
+      return chunks.slice(0, 1)
+    } else {
+      return chunks
+    }
+  }
+
+  for (const lessonProgressChunk of chunkData(lessonProgress)) {
+    const validLessonProgressRecords =
+      lessonProgressChunk.filter<ValidLessonProgress>(
+        (lessonProgress): lessonProgress is ValidLessonProgress => {
+          return lessonProgress.userId !== null
+        },
+      )
+    await prisma.lessonProgress.createMany({
+      data: validLessonProgressRecords,
+      skipDuplicates: true,
+    })
+  }
+}
+
+importLessonProgressData()

--- a/apps/testing-javascript/src/data/purchase-import.ts
+++ b/apps/testing-javascript/src/data/purchase-import.ts
@@ -1,0 +1,260 @@
+// Running this script:
+//
+// Ensure you have the `PURCHASE_DATA_IMPORT_FILE_PATH` env var (in
+// `.env.local`) set to the location of the TJS purchase data JSON export.
+//
+// Execute the Purchase Import like so:
+//
+// ```
+// npx ts-node --files --skipProject src/data/purchase-import.ts
+// ```
+
+import fs from 'fs'
+import {z} from 'zod'
+import chunk from 'lodash/chunk'
+import {prisma} from '@skillrecordings/database'
+
+require('dotenv-flow').config({
+  default_node_env: 'development',
+})
+
+const dataFilePath = z
+  .string()
+  .parse(process.env.PURCHASE_DATA_IMPORT_FILE_PATH)
+
+const now = new Date().toISOString()
+
+const readJsonData = (path: string) => {
+  let fileData = fs.readFileSync(path)
+  return JSON.parse(fileData.toString())
+}
+
+const UserSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().nullable(),
+    email: z.string(),
+    emailVerified: z.boolean(),
+    image: z.string().nullable(),
+    role: z.string().nullable(),
+  })
+  .transform((user) => {
+    const {role, emailVerified, ...rest} = user
+    return {
+      ...rest,
+      emailVerified: emailVerified ? now : undefined,
+      roles: role || undefined,
+    }
+  })
+
+const CouponSchema = z
+  .object({
+    id: z.string(),
+    code: z.string(),
+    createdAt: z.string(),
+    expires: z.string().nullable(),
+    maxUses: z.number().nullable(),
+    default: z.boolean(),
+    merchantCouponId: z.string().nullable(),
+    status: z.number(),
+    usedCount: z.number(),
+    percentageDiscount: z.string(),
+    restrictedToProductId: z.string().nullable(),
+    bulkPurchaseId: z.string().nullable(),
+  })
+  .transform((coupon) => {
+    return {
+      ...coupon,
+      percentageDiscount: Number.parseFloat(coupon.percentageDiscount),
+      maxUses: coupon.maxUses || undefined,
+    }
+  })
+  .transform(({createdAt, expires, ...rest}) => {
+    return {
+      createdAt: new Date(createdAt),
+      expires: expires && new Date(expires),
+      ...rest,
+    }
+  })
+
+const MerchantCustomerSchema = z
+  .object({
+    id: z.string(),
+    userId: z.string(),
+    merchantAccountId: z.string(),
+    identifier: z.string(),
+    createdAt: z.string(),
+    status: z.number(),
+  })
+  .transform(({createdAt, ...rest}) => {
+    return {
+      createdAt: new Date(createdAt),
+      ...rest,
+    }
+  })
+
+const MerchantChargeSchema = z
+  .object({
+    id: z.string(),
+    status: z.number(),
+    identifier: z.string(),
+    userId: z.string(),
+    merchantAccountId: z.string(),
+    merchantProductId: z.string(),
+    merchantCustomerId: z.string().nullable(),
+  })
+  .transform((merchantCharge) => {
+    return {
+      ...merchantCharge,
+      merchantCustomerId: merchantCharge.merchantCustomerId || undefined,
+    }
+  })
+
+type MerchantCharge = z.infer<typeof MerchantChargeSchema>
+
+// from: https://github.com/sindresorhus/type-fest/blob/main/source/set-non-nullable.d.ts
+type SetNonNullable<BaseType, Keys extends keyof BaseType = keyof BaseType> = {
+  [Key in keyof BaseType]: Key extends Keys
+    ? NonNullable<BaseType[Key]>
+    : BaseType[Key]
+}
+
+type CleanMerchantCharge = SetNonNullable<MerchantCharge, 'merchantCustomerId'>
+
+const PurchaseSchema = z
+  .object({
+    id: z.string(),
+    userId: z.string(),
+    createdAt: z.string(),
+    totalAmount: z.coerce.number(),
+    city: z.string().nullable(),
+    state: z.string().nullable(),
+    country: z.string().nullable(),
+    ip_address: z.string().nullable(),
+    status: z.union([
+      z.literal('Valid'),
+      z.literal('Refunded'),
+      z.literal('Banned'),
+    ]),
+    productId: z.string(),
+    couponId: z.string().nullable(),
+    merchantChargeId: z.string().nullable(),
+    upgradedFromId: z.string().nullable(),
+    bulkCouponId: z.string().nullable(),
+    redeemedBulkCouponId: z.string().nullable(),
+    merchantPurchaseId: z.string().nullable(),
+    // quantity: z.number().nullable(),
+  })
+  .transform(({createdAt, merchantPurchaseId, ...rest}) => {
+    return {
+      createdAt: new Date(createdAt),
+      merchantSessionId: merchantPurchaseId,
+      ...rest,
+    }
+  })
+
+const FileDataSchema = z.object({
+  users: z.array(UserSchema),
+  coupons: z.array(CouponSchema),
+  merchantCustomers: z.array(MerchantCustomerSchema),
+  merchantCharges: z.array(MerchantChargeSchema),
+  purchases: z.array(PurchaseSchema),
+})
+
+const importPurchaseData = async () => {
+  // Make sure this only gets run against the KCD Products database
+  if (process.env.DATABASE_URL !== 'mysql://root@localhost:3309/kcd-products') {
+    console.log('This is only meant to run against the kcd-products database.')
+    process.exit(1)
+  }
+
+  // ***************************************
+  // ** Read and Parse Full Purchase JSON **
+  // ***************************************
+  let {users, coupons, merchantCustomers, merchantCharges, purchases} =
+    FileDataSchema.parse(readJsonData(dataFilePath))
+
+  const shortRun = false
+
+  const chunkData = <T>(data: Array<T>): Array<T>[] => {
+    const chunks = chunk(data, 1000)
+
+    if (shortRun) {
+      return chunks.slice(0, 1)
+    } else {
+      return chunks
+    }
+  }
+
+  // These UUIDs have no significance and aren't related to existing data. They
+  // were generated to be used as a consistent ID value for the User and
+  // Customer records.
+  const nullUserId = 'EFAEA7AA-2D37-481B-883E-E2D0DAF5ACD4' as string
+  const nullCustomerId = 'kcd_50A6E8C7-0ECA-43C1-848B-91080EAD7B4D' as string
+
+  // Create a null customer if it doesn't already exist
+  await prisma.user.create({
+    data: {
+      id: nullUserId,
+      name: 'Null Customer',
+      email: 'nullcustomer@egghead.io',
+      emailVerified: null,
+    },
+  })
+  await prisma.merchantCustomer.create({
+    data: {
+      id: nullCustomerId,
+      userId: nullUserId,
+      merchantAccountId: 'kcd_ff532118-69fe-4263-85a5-50b7b03a4b1e',
+      identifier: 'cus_kcd_null_customer',
+      createdAt: now,
+      status: 0,
+    },
+  })
+
+  for (const userChunk of chunkData(users)) {
+    await prisma.user.createMany({data: userChunk, skipDuplicates: true})
+  }
+
+  for (const couponChunk of chunkData(coupons)) {
+    await prisma.coupon.createMany({data: couponChunk, skipDuplicates: true})
+  }
+
+  for (const merchantCustomerChunk of chunkData(merchantCustomers)) {
+    await prisma.merchantCustomer.createMany({
+      data: merchantCustomerChunk,
+      skipDuplicates: true,
+    })
+  }
+
+  for (const merchantChargeChunk of chunkData(merchantCharges)) {
+    const fillInNullCustomer = (
+      merchantCharge: MerchantCharge,
+    ): CleanMerchantCharge => {
+      const validCustomerId =
+        merchantCharge.merchantCustomerId || nullCustomerId
+
+      return {
+        ...merchantCharge,
+        merchantCustomerId: validCustomerId,
+      }
+    }
+
+    const cleanedMerchantChargeChunk =
+      merchantChargeChunk.map(fillInNullCustomer)
+
+    await prisma.merchantCharge.createMany({
+      data: cleanedMerchantChargeChunk,
+      skipDuplicates: true,
+    })
+  }
+
+  for (const purchaseChunk of chunkData(purchases)) {
+    await prisma.purchase.createMany({
+      data: purchaseChunk,
+      skipDuplicates: true,
+    })
+  }
+}
+
+importPurchaseData()


### PR DESCRIPTION
These scripts will import the Purchase data and Lesson Progress data for
Testing JavaScript into the Planetscale database. These scripts target
JSON files that were created by rake task exports located in the
egghead-rails codebase.

This PR includes two scripts:
1. Imports all Purchase, User, Coupon, Merchant Charge, Merchant Customer data
2. Imports all Lesson Progress data

The reason these are split out is that 1 is more critical data, whereas the app could function (temporarily) without Lesson Progress. And the lesson progress export is massive (~600k records) relative to the other export.

There are details in each script about how to run them. The idea is that they would be run back-to-back during a hard cutover from the old site and database to the new site and database.

More details about how these perform in Roam: https://roamresearch.com/#/app/egghead/page/mC7MHA8FM

![banshees](https://media3.giphy.com/media/qsNFGVlMry5JgKSANa/giphy.gif?cid=d1fd59abfjoej5kcpyl98fafa7vx0nszd1cox28t7kn6280f&rid=giphy.gif&ct=g)