### PR TITLE
feat(csa): Sanity updates (use TS & update schemas and studio to work properly in v3)

### DIFF
--- a/packages/create-skill-app/templates/next/.config-templates/sanity.config.ts
+++ b/packages/create-skill-app/templates/next/.config-templates/sanity.config.ts
@@ -9,17 +9,14 @@ import {cloudinarySchemaPlugin} from 'sanity-plugin-cloudinary'
 export default defineConfig({
   name: 'default',
   title: '{{appName}}',
-
   projectId: 'sanity_product_id',
   dataset: 'production',
-
   plugins: [
     deskTool({structure: deskStructure}),
     visionTool(),
     codeInput(),
     cloudinarySchemaPlugin(),
   ],
-
   schema: {
     types: schemaTypes,
   },

--- a/packages/create-skill-app/templates/next/sanity.cli.ts
+++ b/packages/create-skill-app/templates/next/sanity.cli.ts
@@ -1,8 +1,11 @@
 import {defineCliConfig} from 'sanity/cli'
 
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET
+
 export default defineCliConfig({
   api: {
-    projectId: 'sanity_project_id',
-    dataset: 'production',
+    projectId,
+    dataset,
   },
 })

--- a/packages/create-skill-app/templates/next/schemas/documents/article.tsx
+++ b/packages/create-skill-app/templates/next/schemas/documents/article.tsx
@@ -1,19 +1,20 @@
 import React from 'react'
 import {MdOutlineArticle} from 'react-icons/md'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'article',
   type: 'document',
   title: 'Article',
   icon: MdOutlineArticle,
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
       validation: (Rule) => Rule.required(),
-    },
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -22,8 +23,8 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'state',
       title: 'Current State',
       type: 'string',
@@ -35,35 +36,38 @@ export default {
           {title: 'published', value: 'published'},
         ],
       },
-    },
-    {
+    }),
+    defineField({
       name: 'resources',
       title: 'Resources',
       type: 'array',
-      of: [{type: 'linkResource'}, {type: 'tweet'}],
-    },
-    {
+      of: [
+        defineArrayMember({type: 'linkResource'}),
+        defineArrayMember({type: 'tweet'}),
+      ],
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       name: 'summary',
       title: 'Summary',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       name: 'image',
       title: 'Image',
       type: 'image',
-    },
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'Short Description',
       description: 'Used as a short "SEO" summary on Twitter cards etc.',
       type: 'text',
       validation: (Rule) => Rule.max(160),
-    },
+    }),
   ],
   preview: {
     select: {
@@ -79,4 +83,4 @@ export default {
       }
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/cta.ts
+++ b/packages/create-skill-app/templates/next/schemas/documents/cta.ts
@@ -1,15 +1,17 @@
-export default {
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
   name: 'cta',
   title: 'CTA',
   type: 'document',
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
       validation: (Rule) => Rule.required(),
-    },
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -18,20 +20,19 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
       validation: (Rule) => Rule.required(),
-    },
-
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'SEO Description',
       type: 'text',
       validation: (Rule) => Rule.max(160),
-    },
+    }),
   ],
   preview: {
     select: {
@@ -44,4 +45,4 @@ export default {
       }
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/exercise.tsx
+++ b/packages/create-skill-app/templates/next/schemas/documents/exercise.tsx
@@ -1,26 +1,38 @@
 import {MdOutlineWorkspaces} from 'react-icons/md'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'exercise',
   type: 'document',
   title: 'Exercise',
   description:
     'A type of Lesson that has 2-parts, a problem (the exercise) and a solution.',
   icon: MdOutlineWorkspaces,
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare({title}) {
+      return {
+        media: MdOutlineWorkspaces,
+        title: `${title} (Exercise)`,
+      }
+    },
+  },
   fields: [
-    {
+    defineField({
       name: 'label',
       title: 'Label',
       type: 'string',
       hidden: true,
-    },
-    {
+    }),
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
       validation: (Rule) => Rule.max(90),
-    },
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -29,35 +41,35 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'resources',
       title: 'Resources',
       type: 'array',
       of: [
-        {
+        defineArrayMember({
           title: 'Video Resource',
           type: 'reference',
           to: [{type: 'videoResource'}],
-        },
-        {type: 'solution'},
-        {type: 'muxVideo'},
-        {type: 'stackblitz'},
-        {type: 'testimonial'},
-        {type: 'linkResource'},
+        }),
+        defineArrayMember({type: 'solution'}),
+        defineArrayMember({type: 'muxVideo'}),
+        defineArrayMember({type: 'stackblitz'}),
+        defineArrayMember({type: 'testimonial'}),
+        defineArrayMember({type: 'linkResource'}),
       ],
-    },
-    {
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'Short Description',
       description: 'Used as a short "SEO" summary on Twitter cards etc.',
       type: 'text',
       validation: (Rule) => Rule.max(160),
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/explainer.tsx
+++ b/packages/create-skill-app/templates/next/schemas/documents/explainer.tsx
@@ -1,26 +1,38 @@
 import {MdRecordVoiceOver} from 'react-icons/md'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'explainer',
   type: 'document',
   title: 'Explainer',
   description:
     'A type of Lesson that works as intro or outro for a module or section.',
   icon: MdRecordVoiceOver,
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare({title}) {
+      return {
+        media: MdRecordVoiceOver,
+        title: `${title} (Explainer)`,
+      }
+    },
+  },
   fields: [
-    {
+    defineField({
       name: 'label',
       title: 'Label',
       type: 'string',
       hidden: true,
-    },
-    {
+    }),
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
       validation: (Rule) => Rule.max(90),
-    },
-    {
+    }),
+    defineField({
       name: 'explainerType',
       title: 'Explainer Type',
       type: 'string',
@@ -33,8 +45,8 @@ export default {
           {title: 'General (other)', value: 'general'},
         ],
       },
-    },
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -43,34 +55,34 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'resources',
       title: 'Resources',
       type: 'array',
       of: [
-        {
+        defineArrayMember({
           title: 'Video Resource',
           type: 'reference',
           to: [{type: 'videoResource'}],
-        },
-        {type: 'muxVideo'},
-        {type: 'stackblitz'},
-        {type: 'testimonial'},
-        {type: 'linkResource'},
+        }),
+        defineArrayMember({type: 'muxVideo'}),
+        defineArrayMember({type: 'stackblitz'}),
+        defineArrayMember({type: 'testimonial'}),
+        defineArrayMember({type: 'linkResource'}),
       ],
-    },
-    {
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'Short Description',
       description: 'Used as a short "SEO" summary on Twitter cards etc.',
       type: 'text',
       validation: (Rule) => Rule.max(160),
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/linkResource.tsx
+++ b/packages/create-skill-app/templates/next/schemas/documents/linkResource.tsx
@@ -1,24 +1,35 @@
-/* eslint-disable import/no-anonymous-default-export */
 import {MdLink} from 'react-icons/md'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'linkResource',
   title: 'Link Resource',
   type: 'document',
   icon: MdLink,
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare({title}) {
+      return {
+        media: MdLink,
+        title: `${title} (Link)`,
+      }
+    },
+  },
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'url',
       title: 'Url',
       description: 'A URL link to the source',
       type: 'url',
-    },
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -26,13 +37,13 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'Short Description',
       description: 'Describe why the linked resource is useful.',
       type: 'text',
       validation: (Rule) => Rule.max(160).required(),
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/module.tsx
+++ b/packages/create-skill-app/templates/next/schemas/documents/module.tsx
@@ -1,20 +1,21 @@
 import * as React from 'react'
 import {capitalize} from 'lodash'
 import {MdRadio} from 'react-icons/md'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'module',
   title: 'Module',
   type: 'document',
   icon: MdRadio,
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
       validation: (Rule) => Rule.required(),
-    },
-    {
+    }),
+    defineField({
       name: 'moduleType',
       title: 'Module Type',
       type: 'string',
@@ -25,8 +26,8 @@ export default {
           {title: 'Tutorial', value: 'tutorial'},
         ],
       },
-    },
-    {
+    }),
+    defineField({
       name: 'state',
       title: 'Current State',
       type: 'string',
@@ -38,8 +39,8 @@ export default {
           {title: 'published', value: 'published'},
         ],
       },
-    },
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -48,19 +49,19 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'github',
       title: 'GitHub',
       type: 'github',
-    },
-    {
+    }),
+    defineField({
       name: 'resources',
       title: 'Resources',
       description: 'Exercises, Sections, or Explainers in the Module',
       type: 'array',
       of: [
-        {
+        defineArrayMember({
           title: 'Exercise, Sections and Explainers',
           type: 'reference',
           to: [
@@ -69,30 +70,30 @@ export default {
             {title: 'Explainer', type: 'explainer'},
             {type: 'linkResource'},
           ],
-        },
+        }),
       ],
-    },
-    {
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       name: 'image',
       title: 'Image',
       type: 'image',
-    },
-    {
+    }),
+    defineField({
       name: 'ogImage',
       title: 'Share card URL',
       type: 'url',
-    },
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'SEO Description',
       type: 'text',
       validation: (Rule) => Rule.max(160),
-    },
+    }),
   ],
   preview: {
     select: {
@@ -108,4 +109,4 @@ export default {
       }
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/pricing.ts
+++ b/packages/create-skill-app/templates/next/schemas/documents/pricing.ts
@@ -1,27 +1,27 @@
-import React from 'react'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'pricing',
   title: 'Pricing',
   type: 'document',
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'subtitle',
       title: 'Subtitle',
       type: 'text',
       rows: 3,
-    },
-    {
+    }),
+    defineField({
       name: 'products',
       title: 'Products',
       type: 'array',
-      of: [{type: 'reference', to: [{type: 'product'}]}],
-    },
+      of: [defineArrayMember({type: 'reference', to: [{type: 'product'}]})],
+    }),
   ],
   preview: {
     select: {
@@ -34,4 +34,4 @@ export default {
       }
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/product.tsx
+++ b/packages/create-skill-app/templates/next/schemas/documents/product.tsx
@@ -1,50 +1,51 @@
 import React from 'react'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'product',
   title: 'Product',
   type: 'document',
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'productId',
       title: 'Product ID',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'Description',
       type: 'text',
       rows: 3,
-    },
-    {
+    }),
+    defineField({
       name: 'features',
       title: 'Features',
       type: 'array',
-      of: [{type: 'feature'}],
-    },
-    {
+      of: [defineArrayMember({type: 'feature'})],
+    }),
+    defineField({
       name: 'modules',
       title: 'Modules',
       type: 'array',
-      of: [{type: 'reference', to: [{type: 'module'}]}],
-    },
-    {
+      of: [defineArrayMember({type: 'reference', to: [{type: 'module'}]})],
+    }),
+    defineField({
       name: 'action',
       title: 'Call to action',
       type: 'string',
-    },
-    {name: 'image', title: 'Image', type: 'externalImage'},
-    {
+    }),
+    defineField({name: 'image', title: 'Image', type: 'externalImage'}),
+    defineField({
       name: 'order',
       title: 'Order',
       type: 'number',
       hidden: true,
-    },
+    }),
   ],
   preview: {
     select: {
@@ -59,4 +60,4 @@ export default {
       }
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/section.tsx
+++ b/packages/create-skill-app/templates/next/schemas/documents/section.tsx
@@ -1,19 +1,31 @@
 import {MdOutlineGroupWork} from 'react-icons/md'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'section',
   type: 'document',
-  title: 'Workshop Section',
+  title: 'Section',
   description: 'A named group of resources within a module.',
   icon: MdOutlineGroupWork,
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare({title}) {
+      return {
+        media: MdOutlineGroupWork,
+        title: `${title} (Section)`,
+      }
+    },
+  },
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
       validation: (Rule) => Rule.max(90),
-    },
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -22,30 +34,30 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'resources',
       title: 'Resources',
       type: 'array',
       description: 'Exercises, Explainers, or Link Resources in the Section',
       of: [
-        {
+        defineArrayMember({
           type: 'reference',
           to: [{type: 'exercise'}, {type: 'explainer'}, {type: 'linkResource'}],
-        },
+        }),
       ],
-    },
-    {
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'Short Description',
       description: 'Used as a short "SEO" summary on Twitter cards etc.',
       type: 'text',
       validation: (Rule) => Rule.max(160),
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/testimonial.tsx
+++ b/packages/create-skill-app/templates/next/schemas/documents/testimonial.tsx
@@ -1,42 +1,43 @@
 import * as React from 'react'
-import {capitalize, truncate} from 'lodash'
+import {truncate} from 'lodash'
 import {MdQuestionAnswer} from 'react-icons/md'
 import {toPlainText} from '@portabletext/react'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'testimonial',
   title: 'Testimonial',
   type: 'document',
   icon: MdQuestionAnswer,
   fields: [
-    {
+    defineField({
       name: 'body',
       title: 'Testimonial',
       type: 'body',
       validation: (Rule) => Rule.required(),
-    },
-    {
+    }),
+    defineField({
       name: 'author',
       title: 'Author',
       type: 'object',
       fields: [
-        {
+        defineField({
           name: 'name',
           title: 'Name',
           type: 'string',
-        },
-        {
+        }),
+        defineField({
           name: 'image',
           title: 'Image',
           type: 'image',
-        },
+        }),
       ],
-    },
-    {
+    }),
+    defineField({
       name: 'external_url',
       title: 'External URL',
       type: 'url',
-    },
+    }),
   ],
   preview: {
     select: {
@@ -44,13 +45,13 @@ export default {
       media: 'author.image.asset.url',
     },
     prepare(selection) {
-      const {title, media, type} = selection
+      const {title, media} = selection
       return {
         title: `${truncate(toPlainText(title), {
           length: 60,
-        })} ${capitalize(type)}`,
+        })}`,
         media: media && <img src={media} alt={title} />,
       }
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/tip.ts
+++ b/packages/create-skill-app/templates/next/schemas/documents/tip.ts
@@ -1,19 +1,30 @@
 import {MdOutlineLightbulb} from 'react-icons/md'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'tip',
   type: 'document',
   title: 'Tip',
   icon: MdOutlineLightbulb,
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare({title}) {
+      return {
+        media: MdOutlineLightbulb,
+        title: `${title} (Tip)`,
+      }
+    },
+  },
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
       validation: (Rule) => Rule.required(),
-    },
-
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -22,29 +33,32 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'resources',
       title: 'Resources',
       type: 'array',
-      of: [{type: 'reference', to: [{type: 'videoResource'}]}, {type: 'tweet'}],
-    },
-    {
+      of: [
+        defineArrayMember({type: 'reference', to: [{type: 'videoResource'}]}),
+        defineArrayMember({type: 'tweet'}),
+      ],
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       name: 'summary',
       title: 'Summary',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'Short Description',
       description: 'Used as a short "SEO" summary on Twitter cards etc.',
       type: 'text',
       validation: (Rule) => Rule.max(160),
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/documents/videoResource.tsx
+++ b/packages/create-skill-app/templates/next/schemas/documents/videoResource.tsx
@@ -1,24 +1,35 @@
-/* eslint-disable import/no-anonymous-default-export */
 import {MdVideocam} from 'react-icons/md'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'videoResource',
   title: 'Video Resource',
   type: 'document',
   icon: MdVideocam,
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare({title}) {
+      return {
+        media: MdVideocam,
+        title: `${title} (Video)`,
+      }
+    },
+  },
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'originalMediaUrl',
       title: 'AWS S3 Url',
       description: 'A URL to the source video in an S3 Bucket',
       type: 'url',
-    },
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -26,22 +37,22 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'muxAsset',
       title: 'Mux Asset',
       type: 'muxAsset',
-    },
-    {
+    }),
+    defineField({
       name: 'castingwords',
       title: 'Castingwords',
       type: 'castingwordsTranscript',
-    },
-    {
+    }),
+    defineField({
       name: 'duration',
       title: 'Duration',
       type: 'number',
       readOnly: true,
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/body.tsx
+++ b/packages/create-skill-app/templates/next/schemas/objects/body.tsx
@@ -4,20 +4,15 @@ import {
   HiOutlineClock,
   HiLink,
 } from 'react-icons/hi'
-import React, {forwardRef} from 'react'
-import {BlockEditor} from 'sanity'
-import {handlePaste} from '../customization/onPaste'
-
-const CustomEditor = forwardRef((props, ref) => (
-  <BlockEditor {...props} ref={ref} onPaste={handlePaste} />
-))
+import {defineArrayMember, defineField} from 'sanity'
 
 // TODO: Exercises (don't have to have solutions), Challenges (always have solutions, sometimes multiple parts)
-export default {
+export default defineField({
   name: 'body',
   type: 'array',
+  title: 'Body',
   of: [
-    {
+    defineArrayMember({
       type: 'block',
       // styles: [
       //   {title: 'Normal', value: 'normal'},
@@ -31,13 +26,11 @@ export default {
       // ],
       marks: {
         annotations: [
-          {
+          defineArrayMember({
             name: 'link',
             type: 'object',
             title: 'External link',
-            blockEditor: {
-              icon: HiExternalLink,
-            },
+            icon: HiExternalLink,
             fields: [
               {
                 name: 'href',
@@ -51,14 +44,12 @@ export default {
                 type: 'boolean',
               },
             ],
-          },
-          {
+          }),
+          defineArrayMember({
             name: 'internalLink',
             type: 'object',
             title: 'Internal link',
-            blockEditor: {
-              icon: HiLink,
-            },
+            icon: HiLink,
             fields: [
               {
                 name: 'reference',
@@ -67,14 +58,12 @@ export default {
                 to: [{type: 'exercise'}, {type: 'module'}],
               },
             ],
-          },
-          {
+          }),
+          defineArrayMember({
             name: 'emoji',
             type: 'object',
             title: 'Emoji',
-            blockEditor: {
-              icon: HiOutlineEmojiHappy,
-            },
+            icon: HiOutlineEmojiHappy,
             fields: [
               {
                 name: 'emoji',
@@ -90,14 +79,12 @@ export default {
                 ],
               },
             ],
-          },
-          {
+          }),
+          defineArrayMember({
             name: 'timestamp',
             type: 'object',
             title: 'Timestamp',
-            blockEditor: {
-              icon: HiOutlineClock,
-            },
+            icon: HiOutlineClock,
             fields: [
               {
                 name: 'timestamp',
@@ -106,17 +93,31 @@ export default {
                 validation: (Rule) => Rule.required(),
               },
             ],
-          },
+          }),
         ],
       },
-    },
-    {type: 'bodyImage'},
-    {type: 'bodyVideo'},
-    {type: 'code'},
-    {type: 'callout'},
-    {type: 'divider'},
-    {type: 'grid'},
-    {type: 'bodyTestimonial'},
+    }),
+    defineArrayMember({type: 'bodyImage'}),
+    defineArrayMember({type: 'bodyVideo'}),
+    defineArrayMember({type: 'code'}),
+    defineArrayMember({type: 'callout'}),
+    defineArrayMember({type: 'divider'}),
+    defineArrayMember({type: 'grid'}),
+    defineArrayMember({type: 'bodyTestimonial'}),
   ],
-  inputComponent: CustomEditor,
-}
+  // TODO: This makes pasting to stop working
+  // components: {
+  //   input: CustomEditor,
+  // },
+})
+
+// import React, {forwardRef} from 'react'
+// import {BlockEditor} from 'sanity'
+// import {handlePaste} from '../customization/onPaste'
+// const CustomEditor = forwardRef((props, ref) => (
+//   <BlockEditor
+//     {...props}
+//     ref={ref}
+//     onPaste={handlePaste}
+//   />
+// ))

--- a/packages/create-skill-app/templates/next/schemas/objects/bodyImage.tsx
+++ b/packages/create-skill-app/templates/next/schemas/objects/bodyImage.tsx
@@ -1,36 +1,41 @@
 import React from 'react'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'bodyImage',
   type: 'object',
   title: 'Image',
   fields: [
-    {
+    defineField({
+      title: 'Cloudinary Asset',
       type: 'cloudinary.asset',
       name: 'image',
       description: 'This asset is served from Cloudinary',
-    },
-    {
+    }),
+    defineField({
       name: 'alt',
       type: 'string',
       title: 'Alternative text',
       validation: (Rule) => Rule.required(),
-    },
-    {
+    }),
+    defineField({
       name: 'caption',
       title: 'Caption',
       type: 'mediaCaption',
-    },
-    {
+    }),
+    defineField({
       name: 'href',
       title: 'External link',
       type: 'url',
-    },
+    }),
   ],
   preview: {
     select: {image: 'image', alt: 'alt', caption: 'caption'},
-    component: ({value}) => {
-      const {alt, caption, image} = value
+  },
+  components: {
+    preview: (props: any) => {
+      const {alt, caption, image} = props
+
       return image ? (
         <>
           <div>
@@ -43,4 +48,4 @@ export default {
       )
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/bodyTestimonial.tsx
+++ b/packages/create-skill-app/templates/next/schemas/objects/bodyTestimonial.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'bodyTestimonial',
   type: 'object',
   title: 'Testimonial',
   fields: [
-    {
+    defineField({
       name: 'testimonial',
       title: 'Testimonial',
       type: 'reference',
@@ -15,7 +16,7 @@ export default {
         },
       ],
       validation: (Rule) => Rule.required(),
-    },
+    }),
   ],
   preview: {
     select: {
@@ -24,7 +25,9 @@ export default {
       authorName: 'testimonial.author.name',
       authorImage: 'testimonial.author.image.asset.url',
     },
-    component: ({value}) => {
+  },
+  components: {
+    preview: (value: any) => {
       const {testimonial, authorName, authorImage, externalUrl} = value
 
       return (
@@ -59,4 +62,4 @@ export default {
       )
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/bodyVideo.tsx
+++ b/packages/create-skill-app/templates/next/schemas/objects/bodyVideo.tsx
@@ -1,31 +1,32 @@
 import React from 'react'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'bodyVideo',
   type: 'object',
   title: 'Video',
   fields: [
-    {
+    defineField({
       name: 'url',
       type: 'url',
       title: 'Video URL',
       validation: (Rule) => Rule.required(),
-    },
-    {
+    }),
+    defineField({
       name: 'title',
       type: 'string',
       title: 'Title',
-    },
-    {
+    }),
+    defineField({
       name: 'videoOptions',
       type: 'videoOptions',
       title: 'Video Options',
-    },
-    {
+    }),
+    defineField({
       name: 'caption',
       title: 'Transcript',
       type: 'mediaCaption',
-    },
+    }),
   ],
   preview: {
     select: {
@@ -34,8 +35,10 @@ export default {
       transcript: 'caption',
       videoOptions: 'videoOptions',
     },
-    component: ({value}) => {
-      const {url, transcript, title, videoOptions} = value
+  },
+  components: {
+    preview: (selection: any) => {
+      const {url, transcript, title, videoOptions} = selection
       const {autoPlay, loop, controls} = videoOptions
 
       return (
@@ -66,4 +69,4 @@ export default {
       )
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/callout.tsx
+++ b/packages/create-skill-app/templates/next/schemas/objects/callout.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import {PortableText} from '@portabletext/react'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'callout',
   type: 'object',
   title: 'Callout',
   fields: [
-    {
+    defineField({
       name: 'type',
       title: 'Type',
       type: 'string',
@@ -20,16 +21,18 @@ export default {
           {title: 'Caution', value: 'caution'},
         ],
       },
-    },
-    {
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
-    },
+    }),
   ],
   preview: {
     select: {body: 'body', type: 'type'},
-    component: ({value}) => {
+  },
+  components: {
+    preview: (value: any) => {
       const {body, type} = value
       const getImage = () => {
         switch (type) {
@@ -53,4 +56,4 @@ export default {
       )
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/castingwordsTranscript.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/castingwordsTranscript.ts
@@ -1,31 +1,32 @@
-/* eslint-disable import/no-anonymous-default-export */
-export default {
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
   name: 'castingwordsTranscript',
   type: 'object',
   title: 'Castingwords Transcript',
   fields: [
-    {
+    defineField({
       name: 'orderId',
       title: 'Order ID',
       description: 'Used to keep track of the order status on Castingwords',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'audioFileId',
       title: 'Castingwords Audio File ID',
       description:
         'This is used to keep track of the specific transcript in a Castingwords order.',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'transcript',
       title: 'Transcript',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       title: 'SRT',
       name: 'srt',
       type: 'text',
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/divider.tsx
+++ b/packages/create-skill-app/templates/next/schemas/objects/divider.tsx
@@ -1,19 +1,22 @@
 import React from 'react'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'divider',
   type: 'object',
   title: 'Divider',
   fields: [
-    {
+    defineField({
       name: 'image',
       title: 'Image URL',
       type: 'string',
-    },
+    }),
   ],
   preview: {
     select: {image: 'image'},
-    component: ({value}) => {
+  },
+  components: {
+    preview: (value: any) => {
       const {image} = value
       return image ? (
         <div
@@ -30,4 +33,4 @@ export default {
       )
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/externalImage.tsx
+++ b/packages/create-skill-app/templates/next/schemas/objects/externalImage.tsx
@@ -1,24 +1,29 @@
-export default {
+import React from 'react'
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
   name: 'externalImage',
   type: 'object',
   title: 'External Image',
   fields: [
-    {
+    defineField({
       name: 'url',
       type: 'url',
       title: 'Image URL',
-    },
-    {
+    }),
+    defineField({
       name: 'alt',
       type: 'string',
       title: 'Alternative text',
-    },
+    }),
   ],
   preview: {
     select: {url: 'url', alt: 'alt'},
-    prepare(value) {
+  },
+  components: {
+    preview: (value: any) => {
       const {url, alt} = value
-      return {media: <img src={url} alt={alt} />}
+      return <img src={url} alt={alt} />
     },
   },
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/feature.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/feature.ts
@@ -1,12 +1,14 @@
-export default {
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
   name: 'feature',
   type: 'object',
   title: 'Feature',
   fields: [
-    {
+    defineField({
       name: 'value',
       type: 'string',
       title: 'Value',
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/github.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/github.ts
@@ -1,18 +1,19 @@
-export default {
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
   name: 'github',
   type: 'object',
   title: 'GitHub',
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'repo',
       title: 'Repository',
       type: 'string',
-      description: 'without https://github.com/total-typescript/',
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/grid.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/grid.ts
@@ -1,13 +1,15 @@
-export default {
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
   name: 'grid',
   type: 'object',
   title: 'Grid',
   fields: [
-    {
+    defineField({
       name: 'items',
       title: 'Items',
       type: 'array',
       of: [{type: 'gridItem'}],
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/gridItem.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/gridItem.ts
@@ -1,17 +1,19 @@
-export default {
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
   name: 'gridItem',
   type: 'object',
   title: 'Grid Item',
   fields: [
-    {
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/mediaCaption.js
+++ b/packages/create-skill-app/templates/next/schemas/objects/mediaCaption.js
@@ -1,5 +1,0 @@
-export default {
-  name: 'mediaCaption',
-  type: 'array',
-  of: [{type: 'block'}],
-}

--- a/packages/create-skill-app/templates/next/schemas/objects/mediaCaption.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/mediaCaption.ts
@@ -1,0 +1,8 @@
+import {defineArrayMember, defineType} from 'sanity'
+
+export default defineType({
+  title: 'Media Caption',
+  name: 'mediaCaption',
+  type: 'array',
+  of: [defineArrayMember({type: 'block'})],
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/muxAsset.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/muxAsset.ts
@@ -1,22 +1,23 @@
 import {MdLocalMovies} from 'react-icons/md'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'muxAsset',
   type: 'object',
   icon: MdLocalMovies,
   title: 'Mux Asset',
   fields: [
-    {
+    defineField({
       name: 'muxPlaybackId',
       title: 'Mux Playback ID',
       description: 'Hashed ID of a video on mux',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'muxAssetId',
       title: 'Mux Asset ID',
       description: 'ID that references the asset in Mux.',
       type: 'string',
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/resources/muxVideo.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/resources/muxVideo.ts
@@ -1,27 +1,39 @@
 import {MdLocalMovies} from 'react-icons/md'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'muxVideo',
   type: 'object',
   icon: MdLocalMovies,
   title: 'Mux Video',
+  preview: {
+    select: {
+      label: 'label',
+    },
+    prepare({label}) {
+      return {
+        media: MdLocalMovies,
+        title: `${label} (Mux Video)`,
+      }
+    },
+  },
   fields: [
-    {
+    defineField({
       name: 'label',
       title: 'Label',
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'muxPlaybackId',
       title: 'Mux Playback ID',
       description: 'Hashed ID of a video on mux',
       validation: (Rule) => Rule.required(),
       type: 'string',
-    },
-    {
+    }),
+    defineField({
       name: 'transcript',
       title: 'Transcript',
       type: 'body',
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/resources/solution.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/resources/solution.ts
@@ -1,24 +1,36 @@
 import {MdAutoFixHigh} from 'react-icons/md'
+import {defineArrayMember, defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'solution',
   type: 'object',
   title: 'Solution to Exercise',
   icon: MdAutoFixHigh,
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare({title}) {
+      return {
+        media: MdAutoFixHigh,
+        title: `${title} (Solution)`,
+      }
+    },
+  },
   fields: [
-    {
+    defineField({
       name: 'label',
       title: 'Label',
       type: 'string',
       hidden: true,
-    },
-    {
+    }),
+    defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
       validation: (Rule) => Rule.max(90),
-    },
-    {
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
@@ -27,32 +39,32 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-    },
-    {
+    }),
+    defineField({
       name: 'resources',
       title: 'Resources',
       type: 'array',
       of: [
-        {
+        defineArrayMember({
           title: 'Video Resource',
           type: 'reference',
           to: [{type: 'videoResource'}],
-        },
-        {type: 'muxVideo'},
-        {type: 'stackblitz'},
+        }),
+        defineArrayMember({type: 'muxVideo'}),
+        defineArrayMember({type: 'stackblitz'}),
       ],
-    },
-    {
+    }),
+    defineField({
       name: 'body',
       title: 'Body',
       type: 'body',
-    },
-    {
+    }),
+    defineField({
       name: 'description',
       title: 'Summary',
       description: 'Used as a short "SEO" summary on Twitter cards etc.',
       type: 'text',
       validation: (Rule) => Rule.max(160),
-    },
+    }),
   ],
-}
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/stackblitz.tsx
+++ b/packages/create-skill-app/templates/next/schemas/objects/stackblitz.tsx
@@ -1,17 +1,18 @@
+import React from 'react'
 import {MdCode} from 'react-icons/md'
-import * as React from 'react'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'stackblitz',
   type: 'object',
   title: 'Stackblitz',
   icon: MdCode,
   fields: [
-    {
+    defineField({
       name: 'openFile',
       title: 'Open File',
       type: 'string',
-    },
+    }),
   ],
   preview: {
     select: {
@@ -20,8 +21,14 @@ export default {
     prepare(selection) {
       const {file} = selection
       return {
-        title: `StackBlitz ${file}`,
+        title: `StackBlitz: ${file}`,
       }
     },
   },
-}
+  components: {
+    preview: (selection: any) => {
+      const {file} = selection
+      return <div>StackBlitz: {file}</div>
+    },
+  },
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/tweet.tsx
+++ b/packages/create-skill-app/templates/next/schemas/objects/tweet.tsx
@@ -1,18 +1,20 @@
+import React from 'react'
 import {FiTwitter} from 'react-icons/fi'
+import {defineField, defineType} from 'sanity'
 
-export default {
+export default defineType({
   name: 'tweet',
   type: 'object',
   title: 'Tweet',
   icon: FiTwitter,
   fields: [
-    {
+    defineField({
       name: 'tweetId',
       title: 'Tweet ID',
       type: 'string',
       validation: (Rule) => Rule.required(),
-    },
-    {name: 'label', title: 'Label', type: 'string'},
+    }),
+    defineField({name: 'label', title: 'Label', type: 'string'}),
   ],
   preview: {
     select: {
@@ -24,4 +26,9 @@ export default {
       }
     },
   },
-}
+  components: {
+    preview: () => {
+      return <div>Tweet</div>
+    },
+  },
+})

--- a/packages/create-skill-app/templates/next/schemas/objects/videoOptions.ts
+++ b/packages/create-skill-app/templates/next/schemas/objects/videoOptions.ts
@@ -1,25 +1,27 @@
-export default {
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
   name: 'videoOptions',
   type: 'object',
   title: 'Video Options',
   fields: [
-    {
+    defineField({
       name: 'controls',
       title: 'Controls',
       type: 'boolean',
       initialValue: true,
-    },
-    {
+    }),
+    defineField({
       name: 'autoPlay',
       title: 'Autoplay',
       type: 'boolean',
       initialValue: true,
-    },
-    {
+    }),
+    defineField({
       name: 'loop',
       title: 'Loop',
       type: 'boolean',
       initialValue: true,
-    },
+    }),
   ],
-}
+})


### PR DESCRIPTION
- This makes most of the Sanity warnings go away — there are only few more left to tackle, all of which are related to cloudinary plugin. Updating Sanity and its plugins might help with that.
- Document icons didn't work in lists which made it confusing so I fixed that — this was related to migration from v2.
- Custom component previews in PT are now all working again — again related to migration from v2.
- I also made all schemas use TS.

![updates](https://user-images.githubusercontent.com/25487857/225344799-9029276d-8ac9-47fc-aba9-986b0b868303.png)


<img src="https://media.giphy.com/media/xT5LMUJiPu5dRkc6c0/giphy.gif" width="200" alt="gif">