### PR TITLE
config: add 'rfc' tag to Kodiak no-merge list

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -5,7 +5,7 @@ version = 1
 
 [merge]
 require_automerge_label = false
-blacklist_labels = ["NO MERGE", "wip"] # default: []
+blacklist_labels = ["NO MERGE", "wip", "rfc"] # default: []
 method = "rebase" # default: "merge", options: "merge", "squash", "rebase"
 delete_branch_on_merge = true # default: false
 


### PR DESCRIPTION
We've had the convention of 'rfc' being a no-merge tag in other
repositories. I was surprised that a recent 'rfc' PR got merged. If
your PR is a 'request for comment', then you are likely not looking to
merge yet, so I'd like to preserve that convention.

![cousin greg succession](https://media2.giphy.com/media/BBFaJs6LYM3SMhEIRz/giphy.gif?cid=d1fd59abnxcnljbysvt7lg4qio81ho3bdh947oj7z0k169bl&rid=giphy.gif&ct=g)
