### PR TITLE
Remove duplicate Workshops from Testing JavaScript Sanity Import

### DIFF
--- a/apps/testing-javascript/src/data/sanity-import.ts
+++ b/apps/testing-javascript/src/data/sanity-import.ts
@@ -283,16 +283,39 @@ const importCourseData = async () => {
   const uniqueLessons: {[lessonSlug: string]: LessonData} = {}
 
   for (const product of products) {
+    // they have already been parsed, no reason to re-parse them individually
+    // here
     const parsedProduct = productSchema.parse(product)
 
     const {slug: productSlug} = parsedProduct
 
+    // ignore courses with the following slugs because they are the Series
+    // duplicates. The up-to-date courses are Playlist records with the other
+    // slugs.
+    // Series.where(id: [214, 406, 223, 407, 409, 408, 246, 410]).pluck(:slug)
+    const ignoredCourseSlugs = [
+      'static-analysis-testing-javascript-applications-71c1',
+      'test-node-js-backends',
+      'use-dom-testing-library-to-test-any-js-framework',
+      'install-configure-and-script-cypress-for-javascript-web-applications-8184',
+      'test-react-components-with-jest-and-react-testing-library-30af',
+      'configure-jest-for-testing-javascript-applications-b3674a',
+      'javascript-mocking-fundamentals',
+      'fundamentals-of-testing-in-javascript',
+    ]
+
+    const allowedCourses = product.courses.filter((course) => {
+      return !ignoredCourseSlugs.includes(course.slug)
+    })
+
+    const courseSlugs = allowedCourses.map((course) => course.slug)
+
     uniqueProducts[productSlug] = {
-      courseSlugs: product.courses.map((course) => course.slug),
+      courseSlugs,
       ...parsedProduct,
     }
 
-    for (const course of product.courses) {
+    for (const course of allowedCourses) {
       const courseSlug = course.slug as string
 
       if (uniqueCourses[courseSlug] === undefined) {

--- a/apps/testing-javascript/src/data/sanity-import.ts
+++ b/apps/testing-javascript/src/data/sanity-import.ts
@@ -71,6 +71,25 @@ const CastingWordsSchema = z
     srt: z.string(),
   })
   .nullish()
+  .transform((data) => {
+    if (data === null || data === undefined) {
+      return data
+    }
+
+    const {srt, ...rest} = data
+
+    if (srt.startsWith('WEBVTT\n\n')) {
+      const updatedSrt = srt.replace(/^WEBVTT\n\n/, '')
+
+      return {
+        ...rest,
+        srt: updatedSrt,
+      }
+    } else {
+      return data
+    }
+  })
+
 const VideoResourceSchema = z.object({
   _id: z.string(),
   _type: z.literal('videoResource'),


### PR DESCRIPTION
I already used this updated script to re-import the production Sanity data. This PR is to get those changes under version control.

- feat(kcd): ignore specific duplicate TJS courses
- feat(kcd): scrub WEBVTT from top of SRT text

![workshop](https://media1.giphy.com/media/PjltrbWBuDdZ5PigyJ/giphy.gif?cid=d1fd59abky5jl5uhbzq896j5ygrte3l19kulk6xrt6jfx8m0&rid=giphy.gif&ct=g)