### PR TITLE
feat(kcd): add module page, link to it

### DIFF
--- a/apps/epic-react/src/components/lesson-listing.tsx
+++ b/apps/epic-react/src/components/lesson-listing.tsx
@@ -1,0 +1,17 @@
+export const LessonListing = (props: {
+  lesson: {title: string; slug: string}
+  moduleSlug: string
+}) => {
+  const {lesson, moduleSlug} = props
+
+  return (
+    <li>
+      <a
+        href={`${moduleSlug}/${lesson.slug}`}
+        className="font-semibold underline"
+      >
+        {lesson.title}
+      </a>
+    </li>
+  )
+}

--- a/apps/epic-react/src/components/module-listing.tsx
+++ b/apps/epic-react/src/components/module-listing.tsx
@@ -1,0 +1,50 @@
+import {ModuleSchema} from 'lib/modules'
+import {z} from 'zod'
+import {LessonListing} from './lesson-listing'
+
+export const ModuleListing = ({
+  module,
+}: {
+  module: z.infer<typeof ModuleSchema>
+}) => {
+  return (
+    <div className="mb-4 text-lg font-semibold">
+      <a className="font-semibold underline" href={module.slug.current}>
+        {module.title}
+      </a>
+      <ul className="mt-2 list-inside list-disc pl-4">
+        {module.resources.map((resource) => {
+          if (resource._type === 'section') {
+            // asserting that this should be defined in this case
+            const sectionResources = resource.resources as NonNullable<
+              typeof resource.resources
+            >
+
+            return (
+              <li className="mt-1 font-medium">
+                {resource.title}
+                <ul className="mt-1 list-inside list-decimal pl-6">
+                  {sectionResources.map((lesson) => {
+                    return (
+                      <LessonListing
+                        lesson={lesson}
+                        moduleSlug={module.slug.current}
+                      />
+                    )
+                  })}
+                </ul>
+              </li>
+            )
+          } else {
+            return (
+              <LessonListing
+                lesson={resource}
+                moduleSlug={module.slug.current}
+              />
+            )
+          }
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/apps/epic-react/src/lib/modules.ts
+++ b/apps/epic-react/src/lib/modules.ts
@@ -13,6 +13,7 @@ export const ModuleSchema = z.object({
   state: z.string(),
   moduleType: z.string(),
   description: z.string().nullable(),
+  body: z.array(z.any()),
   github: z
     .object({
       repo: z.string(),
@@ -62,8 +63,9 @@ const productModulesQuery = groq`*[_type == "product" && productId == $productId
     _id,
     _type,
     title,
-    description,
     slug,
+    description,
+    body,
     state,
     moduleType,
     github,
@@ -152,6 +154,7 @@ export const getModule = async (slug: string) => {
       moduleType,
       github,
       description,
+      body,
       _updatedAt,
       "square_cover_large_url": image.url,
       "resources": resources[@->._type in ['section', 'exercise', 'explainer', 'interview']]->{

--- a/apps/epic-react/src/pages/learn.tsx
+++ b/apps/epic-react/src/pages/learn.tsx
@@ -3,26 +3,9 @@ import Layout from 'components/layout'
 import {InferGetServerSidePropsType, GetServerSideProps} from 'next'
 import {getProductModules, ProductModulesSchema} from 'lib/modules'
 import {z} from 'zod'
+import {ModuleListing} from 'components/module-listing'
 
 type ProductModules = z.infer<typeof ProductModulesSchema>
-
-const LessonListing = (props: {
-  lesson: {title: string; slug: string}
-  moduleSlug: string
-}) => {
-  const {lesson, moduleSlug} = props
-
-  return (
-    <li>
-      <a
-        href={`${moduleSlug}/${lesson.slug}`}
-        className="font-semibold underline"
-      >
-        {lesson.title}
-      </a>
-    </li>
-  )
-}
 
 export const getServerSideProps: GetServerSideProps<ProductModules> = async ({
   params,
@@ -59,49 +42,9 @@ const Modules = ({
             There are {modules.length} modules in this product.
           </p>
           <div className="flex flex-col items-start justify-start text-left">
-            <ul className="list-none pl-0">
-              {modules.map((module) => {
-                return (
-                  <li className="mb-4 text-lg font-semibold">
-                    {module.title}
-                    <ul className="mt-2 list-inside list-disc pl-4">
-                      {module.resources.map((resource) => {
-                        if (resource._type === 'section') {
-                          // asserting that this should be defined in this case
-                          const sectionResources =
-                            resource.resources as NonNullable<
-                              typeof resource.resources
-                            >
-
-                          return (
-                            <li className="mt-1 font-medium">
-                              {resource.title}
-                              <ul className="mt-1 list-inside list-decimal pl-6">
-                                {sectionResources.map((lesson) => {
-                                  return (
-                                    <LessonListing
-                                      lesson={lesson}
-                                      moduleSlug={module.slug.current}
-                                    />
-                                  )
-                                })}
-                              </ul>
-                            </li>
-                          )
-                        } else {
-                          return (
-                            <LessonListing
-                              lesson={resource}
-                              moduleSlug={module.slug.current}
-                            />
-                          )
-                        }
-                      })}
-                    </ul>
-                  </li>
-                )
-              })}
-            </ul>
+            {modules.map((module) => {
+              return <ModuleListing module={module} />
+            })}
           </div>
         </div>
       </main>


### PR DESCRIPTION
This updates the module page to include a listing of the sections and lessons contained within that module. It also displays the module's body using the Portable Text (for react) component. And the module page is linked to from the learn page.

Like https://github.com/skillrecordings/products/pull/909, I'm just making sure the main/essential pieces are available and in place, fully porting over the look, feel, and behavior will happen in follow up work.

<img width="955" alt="CleanShot 2023-04-26 at 18 20 19@2x" src="https://user-images.githubusercontent.com/694063/234723533-284d9655-9919-40e0-b1fa-c891eedfa2b8.png">

![portable](https://media1.giphy.com/media/H0NkMQE6N8eigkLEgi/giphy.gif?cid=d1fd59abislqrefnslpwkswp0ln0996srfdhvh6ocv73d7pd&ep=v1_gifs_search&rid=giphy.gif&ct=g)