### PR TITLE
fix(build): move json generation from prebuild to build

### DIFF
--- a/apps/scriptkit/package.json
+++ b/apps/scriptkit/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "dev": "next dev -p 3035",
     "dev:sanity": "sanity dev",
-    "prebuild": "pnpm docs-data && pnpm share-data && pnpm guide-data && pnpm announcements-data && pnpm hot-data && pnpm course-data",
-    "build": "NODE_ENV=production next build",
+    "prebuild": "",
+    "build": "NODE_ENV=production next build && pnpm docs-data && pnpm share-data && pnpm guide-data && pnpm announcements-data && pnpm hot-data && pnpm course-data",
     "postbuild": "NODE_ENV=production next-sitemap",
     "start": "next start -p 3035",
     "repos": "kit ./scripts/repos.js",
@@ -66,7 +66,6 @@
     "@slack/web-api": "^6.7.2",
     "@supabase/supabase-js": "^2.0.5",
     "@tailwindcss/forms": "^0.5.3",
-
     "@tailwindcss/typography": "^0.5.7",
     "@tanstack/react-query": "^4.20.4",
     "@trpc/client": "=10.7.0",


### PR DESCRIPTION
![data star trek](https://media2.giphy.com/media/Kr56AzGm7781G/giphy.gif?cid=0b9ef2f4dolckid2kd68a9hze4qqommwz5y0vmgb4ee3dmyx&ep=v1_gifs_search&rid=giphy.gif&ct=g)

I don't fully understand turbo/caching/steps, but "prebuild" wasn't generating the static .json assets that Kit.app pulls down (docs/guide/community), so I moved the static .json generation to the "build" step.