### PR TITLE
chore(pt): standardise page headline, subheadline and button links

### DIFF
--- a/apps/protailwind/src/components/page-headline.tsx
+++ b/apps/protailwind/src/components/page-headline.tsx
@@ -1,0 +1,24 @@
+import cx from 'classnames'
+
+type Props = {
+  className?: string
+  children: React.ReactNode
+} & React.ComponentProps<'h1'>
+
+export default function PageHeadline({
+  className,
+  children,
+  ...restProps
+}: Props) {
+  return (
+    <h1
+      className={cx(
+        'text-center font-heading text-4xl font-black sm:text-5xl lg:text-6xl',
+        className,
+      )}
+      {...restProps}
+    >
+      {children}
+    </h1>
+  )
+}

--- a/apps/protailwind/src/components/page-subheadline.tsx
+++ b/apps/protailwind/src/components/page-subheadline.tsx
@@ -1,0 +1,24 @@
+import cx from 'classnames'
+
+type Props = {
+  className?: string
+  children: React.ReactNode
+} & React.ComponentProps<'p'>
+
+export default function PageSubheadline({
+  className,
+  children,
+  ...restProps
+}: Props) {
+  return (
+    <p
+      className={cx(
+        'max-w-md pt-8 text-center text-lg text-brand-red lg:text-xl',
+        className,
+      )}
+      {...restProps}
+    >
+      {children}
+    </p>
+  )
+}

--- a/apps/protailwind/src/pages/articles.tsx
+++ b/apps/protailwind/src/pages/articles.tsx
@@ -6,6 +6,7 @@ import Markdown from 'react-markdown'
 import {GetStaticProps} from 'next'
 import {Article, getAllArticles} from '../lib/articles'
 import {toPlainText} from '@portabletext/react'
+import PageHeadline from 'components/page-headline'
 
 const meta = {
   title: 'Tailwind Articles',
@@ -18,10 +19,8 @@ type ArticlesProps = {
 const Articles: React.FC<ArticlesProps> = ({articles}) => {
   return (
     <Layout meta={meta} className="overflow-hidden">
-      <header className="relative overflow-hidden px-5 pt-16 pb-10 sm:pb-20 sm:pt-24">
-        <h1 className="mx-auto max-w-screen-md text-center font-heading text-3xl font-black leading-none sm:text-4xl lg:text-5xl">
-          {meta.title}
-        </h1>
+      <header className="relative overflow-hidden px-5 pb-10 pt-16 sm:pb-20 sm:pt-20">
+        <PageHeadline>{meta.title}</PageHeadline>
       </header>
       <main className="flex-grow px-5">
         <div className="mx-auto w-full max-w-screen-lg pb-16">
@@ -78,9 +77,15 @@ const Articles: React.FC<ArticlesProps> = ({articles}) => {
                             <Link
                               href={`/${slug}`}
                               passHref
-                              className="rounded-full bg-sky-500 px-5 py-3 text-white transition hover:bg-sky-600"
+                              className="group my-4 inline-block gap-2 rounded-full bg-brand-red px-4 py-2 font-medium text-white transition hover:brightness-110"
                             >
-                              View article
+                              Read article{' '}
+                              <span
+                                aria-hidden="true"
+                                className="text-white/90 transition group-hover:text-white"
+                              >
+                                →
+                              </span>
                             </Link>
                             <div className="text-sm text-gray-700">
                               Time to read: ~{estimatedReadingTime}m

--- a/apps/protailwind/src/pages/buy.tsx
+++ b/apps/protailwind/src/pages/buy.tsx
@@ -9,6 +9,7 @@ import type {CommerceProps} from '@skillrecordings/commerce-server/dist/@types'
 import {useCoupon} from '@skillrecordings/skill-lesson/path-to-purchase/use-coupon'
 import {PriceCheckProvider} from '@skillrecordings/skill-lesson/path-to-purchase/pricing-check-context'
 import Image from 'next/image'
+import PageHeadline from 'components/page-headline'
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const {req, query} = context
@@ -46,18 +47,16 @@ const Buy: React.FC<CommerceProps> = ({
       className="py-16"
     >
       <header>
-        <h1 className="px-5 pb-10 text-center font-heading text-4xl font-black tracking-tight sm:text-5xl">
-          Level Up at Tailwind CSS
-        </h1>
+        <PageHeadline>Level Up at Tailwind CSS</PageHeadline>
       </header>
-      <main>
+      <main className="mt-8">
         <PriceCheckProvider purchasedProductIds={purchasedProductIds}>
           {redeemableCoupon ? <RedeemDialogForCoupon /> : null}
           <div data-pricing-container="">
             {products.map((product, i) => {
               return (
                 <Pricing
-                  key={product.name}
+                  key={product.title}
                   userId={userId}
                   product={product}
                   purchased={purchasedProductIds.includes(product.productId)}

--- a/apps/protailwind/src/pages/confirm.tsx
+++ b/apps/protailwind/src/pages/confirm.tsx
@@ -34,7 +34,7 @@ export const Signature = () => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      className="mx-auto w-24"
+      className="mx-auto w-36"
       fill="none"
       viewBox="0 0 88 54"
     >

--- a/apps/protailwind/src/pages/tips/index.tsx
+++ b/apps/protailwind/src/pages/tips/index.tsx
@@ -7,6 +7,8 @@ import {useRouter} from 'next/router'
 import {useTipComplete} from '../../hooks/use-tip-complete'
 import {Icon} from '@skillrecordings/skill-lesson/icons'
 import {getBaseUrl} from '@skillrecordings/skill-lesson/utils/get-base-url'
+import PageHeadline from 'components/page-headline'
+import PageSubheadline from 'components/page-subheadline'
 
 export async function getStaticProps() {
   const tips = await getAllTips()
@@ -38,12 +40,8 @@ const TipsIndex: React.FC<TipsIndex> = ({tips}) => {
       className="sm:pt-18 flex flex-col items-center pb-16 pt-16 lg:pb-24 lg:pt-20"
     >
       <header className="relative z-10 flex flex-col items-center px-5 pb-16 text-center">
-        <h1 className="text-center font-heading text-4xl font-black sm:text-5xl lg:text-6xl">
-          Tailwind Tips
-        </h1>
-        <p className="max-w-md pt-8 text-center text-lg text-gray-600 lg:text-xl">
-          {pageDescription}
-        </p>
+        <PageHeadline>Tailwind Tips</PageHeadline>
+        <PageSubheadline>{pageDescription}</PageSubheadline>
       </header>
       <main className="relative z-10 mx-auto grid w-full max-w-screen-lg grid-cols-1 gap-5 px-5 md:grid-cols-2">
         {tips.map((tip) => {

--- a/apps/protailwind/src/pages/tutorials/index.tsx
+++ b/apps/protailwind/src/pages/tutorials/index.tsx
@@ -4,6 +4,8 @@ import {SanityDocument} from '@sanity/client'
 import {getAllTutorials} from 'lib/tutorials'
 import Link from 'next/link'
 import Image from 'next/legacy/image'
+import PageSubheadline from 'components/page-subheadline'
+import PageHeadline from 'components/page-headline'
 
 export async function getStaticProps() {
   const tutorials = await getAllTutorials()
@@ -30,13 +32,11 @@ const TutorialsPage: React.FC<{tutorials: SanityDocument[]}> = ({
       }
     >
       <main className="relative z-10 flex flex-col items-center justify-center py-20">
-        <h1 className="text-center font-heading text-4xl font-black sm:text-5xl lg:text-6xl">
-          Free Tailwind Tutorials
-        </h1>
-        <p className="max-w-sm pt-8 text-center text-lg text-brand-red">
+        <PageHeadline>Free Tailwind Tutorials</PageHeadline>
+        <PageSubheadline>
           A collection of free, exercise-driven, in-depth Tailwind tutorials for
           you to use on your journey to Tailwind wizardry.
-        </p>
+        </PageSubheadline>
         {tutorials && (
           <ul className="flex max-w-screen-md flex-col gap-8 px-3 pt-20">
             {tutorials.map(({title, slug, image, description, sections}, i) => {
@@ -57,7 +57,7 @@ const TutorialsPage: React.FC<{tutorials: SanityDocument[]}> = ({
                     )}
                   </div>
                   <div className="pr:0 m-10 md:m-0 md:pr-10">
-                    <div className="pt-4 pb-3 font-mono text-xs font-semibold uppercase text-gray-600 ">
+                    <div className="pb-3 pt-4 font-mono text-xs font-semibold uppercase text-gray-600 ">
                       {i === 0 && (
                         <span className="mr-3 rounded-full bg-gray-100 px-2 py-0.5 font-sans font-semibold uppercase text-gray-700">
                           New
@@ -92,7 +92,7 @@ const TutorialsPage: React.FC<{tutorials: SanityDocument[]}> = ({
                           module: slug.current,
                         },
                       }}
-                      className="group my-4 inline-block gap-2 rounded-full bg-brand-red px-4 py-2 font-medium text-white transition"
+                      className="group my-4 inline-block gap-2 rounded-full bg-brand-red px-4 py-2 font-medium text-white transition hover:brightness-110"
                     >
                       View{' '}
                       <span

--- a/apps/protailwind/src/pages/workshops/index.tsx
+++ b/apps/protailwind/src/pages/workshops/index.tsx
@@ -4,6 +4,8 @@ import {SanityDocument} from '@sanity/client'
 import Link from 'next/link'
 import Image from 'next/legacy/image'
 import {getAllWorkshops} from '../../lib/workshops'
+import PageHeadline from 'components/page-headline'
+import PageSubheadline from 'components/page-subheadline'
 
 export async function getStaticProps() {
   const workshops = await getAllWorkshops()
@@ -30,14 +32,12 @@ const WorkshopsPage: React.FC<{workshops: SanityDocument[]}> = ({
       }
     >
       <main className="relative z-10 flex flex-col items-center justify-center py-20">
-        <h1 className="text-center font-heading text-4xl font-black sm:text-5xl lg:text-6xl">
-          Professional Tailwind Workshops
-        </h1>
-        <p className="max-w-md pt-8 text-center text-lg text-brand-red">
+        <PageHeadline>Professional Tailwind Workshops</PageHeadline>
+        <PageSubheadline>
           A collection of professional, exercise-driven, in-depth, self-paced
           Tailwind workshops to help you learn how to use Tailwind as a
           professional web developer.
-        </p>
+        </PageSubheadline>
         {workshops && (
           <ul className="flex max-w-screen-md flex-col gap-8 px-3 pt-20">
             {workshops.map(
@@ -118,7 +118,7 @@ const WorkshopsPage: React.FC<{workshops: SanityDocument[]}> = ({
                               module: slug.current,
                             },
                           }}
-                          className="group my-4 inline-block gap-2 rounded-full bg-brand-red px-4 py-2 font-medium text-white transition"
+                          className="group my-4 inline-block gap-2 rounded-full bg-brand-red px-4 py-2 font-medium text-white transition hover:brightness-110"
                         >
                           View{' '}
                           <span

--- a/apps/protailwind/src/purchase-details/purchases-index-template.tsx
+++ b/apps/protailwind/src/purchase-details/purchases-index-template.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link'
 import {DatePurchased, Price} from 'purchase-details/purchase-details-template'
 import Balancer from 'react-wrap-balancer'
 import Image from 'next/image'
+import PageHeadline from 'components/page-headline'
+import PageSubheadline from 'components/page-subheadline'
 
 export type PurchasesIndexProps = {
   purchases: Purchase &
@@ -21,23 +23,19 @@ export type PurchasesIndexProps = {
 const PurchasesIndexTemplate: React.FC<PurchasesIndexProps> = ({purchases}) => {
   return (
     <Layout meta={{title: 'Your Purchases'}}>
-      <header className="px-5 pt-16 text-center sm:pt-20">
-        <h1 className="font-heading text-4xl font-black sm:text-5xl">
-          Your Purchases
-        </h1>
-        <h2 className="mx-auto w-full max-w-lg pt-3 text-lg font-medium text-brand-red">
-          <Balancer>
-            View details about your purchases. Get your invoice, buy more seats,
-            or invite your team members.
-          </Balancer>
-        </h2>
+      <header className="mx-auto px-5 pt-16 text-center sm:pt-20">
+        <PageHeadline>Your Purchases</PageHeadline>
+        <PageSubheadline>
+          View details about your purchases. Get your invoice, buy more seats,
+          or invite your team members.
+        </PageSubheadline>
       </header>
-      <main className="mx-auto flex w-full max-w-2xl flex-col gap-8 py-16 px-5">
+      <main className="mx-auto flex w-full max-w-2xl flex-col gap-8 px-5 py-16">
         {purchases
           ?.filter((p) => !p.redeemedBulkCouponId)
           .map((purchase) => {
             return (
-              <article className="rounded-lg border border-gray-200/50 bg-white px-8 pt-10 pb-5 shadow-2xl shadow-gray-500/10">
+              <article className="rounded-lg border border-gray-200/50 bg-white px-8 pb-5 pt-10 shadow-2xl shadow-gray-500/10">
                 <h2 className="font-heading text-2xl font-black sm:text-2xl">
                   <Balancer>
                     <Link

--- a/apps/protailwind/src/templates/article-template.tsx
+++ b/apps/protailwind/src/templates/article-template.tsx
@@ -17,6 +17,8 @@ import {type Article} from 'lib/articles'
 import {format} from 'date-fns'
 import {useConvertkit} from '@skillrecordings/skill-lesson/hooks/use-convertkit'
 import Spinner from 'components/spinner'
+import PageHeadline from 'components/page-headline'
+import PageSubheadline from 'components/page-subheadline'
 
 type ArticleTemplateProps = {
   article: Article
@@ -125,14 +127,8 @@ const Header: React.FC<Article> = ({
           </a>
         </Link> */}
         <div className="flex flex-col items-center justify-center pb-24 pt-10 text-center">
-          <h1 className="mx-auto py-4 font-heading text-3xl font-black leading-none sm:text-4xl lg:text-5xl">
-            {title}
-          </h1>
-          {subtitle && (
-            <h2 className="mx-auto max-w-md pt-5 text-lg font-medium leading-tight text-brand-red sm:text-xl">
-              {subtitle}
-            </h2>
-          )}
+          <PageHeadline>{title}</PageHeadline>
+          {subtitle && <PageSubheadline>{subtitle}</PageSubheadline>}
         </div>
         <div className="flex w-full max-w-screen-md flex-wrap items-center justify-center gap-10 leading-none sm:justify-between sm:text-lg">
           <Author />
@@ -187,7 +183,7 @@ const Signature = () => {
   return (
     <svg
       aria-hidden="true"
-      className="mt-8 w-28 text-gray-800"
+      className="group mt-8 w-40 text-gray-800"
       viewBox="0 0 102 55"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -197,6 +193,7 @@ const Signature = () => {
         fill="currentColor"
       />
       <path
+        className="origin-right transition group-hover:scale-110 group-hover:text-brand-red"
         d="M92.3631 19.5639L93.1941 19.499C93.6629 17.986 94.1201 17.0076 96.0775 13.8308C97.4038 11.6817 97.7532 10.4627 97.6552 9.20743C97.5336 7.65164 96.0552 6.48645 94.5348 6.60522C93.421 6.69223 92.4574 7.33669 91.9107 8.53557C91.2022 7.43475 90.1503 6.94773 89.0542 7.03335C87.4984 7.15489 86.2542 8.53276 86.3757 10.0885C86.4765 11.3791 87.105 12.5929 88.6508 14.3932C91.0588 17.2112 91.6228 18.0565 92.3631 19.5639ZM92.6496 17.994C92.0745 17.0073 91.219 15.8468 90.0859 14.5479C88.9514 13.2313 88.2185 12.2747 87.905 11.6767C87.5914 11.0786 87.4058 10.5239 87.3658 10.0112C87.287 9.00348 88.1238 8.10212 89.1315 8.0234C90.1039 7.94744 91.0295 8.63998 91.5958 10.1966L92.4975 10.1262C92.7895 8.62701 93.5867 7.67537 94.6121 7.59527C95.6375 7.51516 96.5864 8.27704 96.6651 9.28477C96.7065 9.81515 96.6107 10.4096 96.3761 11.0505C96.1416 11.6914 95.569 12.7855 94.6377 14.2991C93.7065 15.8126 93.0212 17.0579 92.6496 17.994Z"
         fill="currentColor"
       />


### PR DESCRIPTION
This PR also fixes a duplicated `key` on the `/buy` page since both products had the same `product.name`.

Oh, and adds the little love heart hover effect on the signature in the article pages!

![Running puppy](https://media.giphy.com/media/rcw4NNFE6JioM/giphy.gif)