### PR TITLE
chore: stop writing transcript as PT

### DIFF
--- a/packages/skill-lesson/lib/castingwords.ts
+++ b/packages/skill-lesson/lib/castingwords.ts
@@ -98,7 +98,7 @@ export const castingwordsWebhookReceiver = async (
     if (req.body.event === 'TRANSCRIPT_COMPLETE') {
       try {
         const {audiofile, order} = CastingwordsWebhookBody.parse(req.body)
-        await writeTranscriptToVideoResource(audiofile, order, true)
+        await writeTranscriptToVideoResource(audiofile, order)
         res.status(200).json({message: 'video resource updated'})
       } catch (e) {
         Sentry.captureException(e)


### PR DESCRIPTION
all transcripts are being stored as `text` so we can do this now :)

<img src="https://media.giphy.com/media/NytMLKyiaIh6VH9SPm/giphy.gif" width="250" alt="gif">