### PR TITLE
jb/clean up pricing logic

### DIFF
--- a/apps/epic-web/src/pages/products/index.tsx
+++ b/apps/epic-web/src/pages/products/index.tsx
@@ -246,7 +246,7 @@ const PriceDisplay = ({status, formattedPrice}: PriceDisplayProps) => {
     (formattedPrice?.unitPrice || 0) * (formattedPrice?.quantity || 0)
 
   const percentOff = appliedMerchantCoupon
-    ? Math.floor(appliedMerchantCoupon.percentageDiscount * 100)
+    ? Math.floor(+appliedMerchantCoupon.percentageDiscount * 100)
     : formattedPrice && isDiscount(formattedPrice)
     ? Math.floor(
         (formattedPrice.calculatedPrice / formattedPrice.unitPrice) * 100,

--- a/apps/scriptkit/src/path-to-purchase-react/pricing.tsx
+++ b/apps/scriptkit/src/path-to-purchase-react/pricing.tsx
@@ -462,7 +462,7 @@ export const PriceDisplay = ({status, formattedPrice}: PriceDisplayProps) => {
     (formattedPrice?.unitPrice || 0) * (formattedPrice?.quantity || 0)
 
   const percentOff = appliedMerchantCoupon
-    ? Math.floor(appliedMerchantCoupon.percentageDiscount * 100)
+    ? Math.floor(+appliedMerchantCoupon.percentageDiscount * 100)
     : formattedPrice && isDiscount(formattedPrice)
     ? Math.floor(
         (formattedPrice.calculatedPrice / formattedPrice.unitPrice) * 100,

--- a/apps/testing-javascript/src/path-to-purchase/pricing.tsx
+++ b/apps/testing-javascript/src/path-to-purchase/pricing.tsx
@@ -112,16 +112,23 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
   //   country: 'UA',
   // }
 
-  // if there is no available coupon, hide the box (it's not a toggle)
-  // only show the box if ppp coupon is available
-  // do not show the box if purchased
-  // do not show the box if it's a downgrade
-  const showPPPBox =
-    Boolean(pppCoupon || merchantCoupon?.type === 'ppp') &&
-    !purchased &&
-    !isDowngrade(formattedPrice) &&
-    (allowPurchase || isSellingLive) &&
-    !isBuyingForTeam
+  const showPPPBox = (() => {
+    // Cannot have already purchased and purchase of this product must be enabled
+    const allowedToPurchase = !purchased && (allowPurchase || isSellingLive)
+
+    // Ensure a valid PPP coupon is present
+    const pppCouponIsPresent = Boolean(
+      pppCoupon || merchantCoupon?.type === 'ppp',
+    )
+
+    // PPP is only valid for individual purchases (not team) and cannot be a downgrade
+    const canBePurchasedWithPPPDiscount =
+      !isDowngrade(formattedPrice) && !isBuyingForTeam
+
+    return (
+      allowedToPurchase && pppCouponIsPresent && canBePurchasedWithPPPDiscount
+    )
+  })()
 
   // const handleOnSuccess = (subscriber: any, email?: string) => {
   //   if (subscriber) {

--- a/apps/testingaccessibility/src/components/pricing.tsx
+++ b/apps/testingaccessibility/src/components/pricing.tsx
@@ -86,7 +86,7 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
     (formattedPrice?.unitPrice || 0) * (formattedPrice?.quantity || 0)
 
   const percentOff = appliedMerchantCoupon
-    ? Math.floor(appliedMerchantCoupon.percentageDiscount * 100)
+    ? Math.floor(+appliedMerchantCoupon.percentageDiscount * 100)
     : formattedPrice && isDiscount(formattedPrice)
     ? Math.floor(
         (formattedPrice.calculatedPrice / formattedPrice.unitPrice) * 100,
@@ -120,9 +120,10 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
         />
       </div>
       <article className="bg-white rounded-md flex flex-col items-center justify-center">
-        {Boolean(appliedMerchantCoupon || isDiscount(formattedPrice)) && (
-          <Ribbon appliedMerchantCoupon={appliedMerchantCoupon} />
-        )}
+        {!!appliedMerchantCoupon ||
+          (isDiscount(formattedPrice) && (
+            <Ribbon appliedMerchantCoupon={appliedMerchantCoupon} />
+          ))}
         <div className={cx('pt-24 flex flex-col items-center')}>
           <h4
             data-pricing-product-name-badge={index}
@@ -375,9 +376,11 @@ const RegionalPricingBox: React.FC<
 }
 
 type RibbonProps = {
-  appliedMerchantCoupon: {
-    type: string
-  }
+  appliedMerchantCoupon:
+    | {
+        type: string | undefined
+      }
+    | undefined
 }
 
 const Ribbon: React.FC<React.PropsWithChildren<RibbonProps>> = ({

--- a/apps/testingaccessibility/src/utils/get-coupon-label.ts
+++ b/apps/testingaccessibility/src/utils/get-coupon-label.ts
@@ -1,4 +1,4 @@
-export const getCouponLabel = (couponType: string) => {
+export const getCouponLabel = (couponType: string | undefined) => {
   switch (couponType) {
     case 'special':
       return 'Special Discount'

--- a/packages/commerce-server/src/@types/index.ts
+++ b/packages/commerce-server/src/@types/index.ts
@@ -1,8 +1,10 @@
-import {Purchase, MerchantCoupon, Coupon} from '@skillrecordings/database'
+import {Purchase, MerchantCoupon} from '@skillrecordings/database'
 import type {PortableTextBlock} from '@portabletext/types'
 
+type MerchantCouponWithCountry = MerchantCoupon & {country?: string | undefined}
+
 type MinimalMerchantCoupon = Omit<
-  MerchantCoupon,
+  MerchantCouponWithCountry,
   'identifier' | 'merchantAccountId'
 >
 
@@ -11,7 +13,9 @@ export type FormattedPrice = {
   quantity: number
   unitPrice: number
   calculatedPrice: number
-  availableCoupons: Array<Omit<MerchantCoupon, 'identifier'> | undefined>
+  availableCoupons: Array<
+    Omit<MerchantCouponWithCountry, 'identifier'> | undefined
+  >
   appliedMerchantCoupon?: MinimalMerchantCoupon
   upgradeFromPurchaseId?: string
   defaultCoupon?: {

--- a/packages/commerce-server/src/@types/index.ts
+++ b/packages/commerce-server/src/@types/index.ts
@@ -1,13 +1,18 @@
-import {Purchase} from '@skillrecordings/database'
+import {Purchase, MerchantCoupon, Coupon} from '@skillrecordings/database'
 import type {PortableTextBlock} from '@portabletext/types'
+
+type MinimalMerchantCoupon = Omit<
+  MerchantCoupon,
+  'identifier' | 'merchantAccountId'
+>
 
 export type FormattedPrice = {
   id: string
   quantity: number
   unitPrice: number
   calculatedPrice: number
-  availableCoupons: any[]
-  appliedMerchantCoupon?: any
+  availableCoupons: Array<Omit<MerchantCoupon, 'identifier'> | undefined>
+  appliedMerchantCoupon?: MinimalMerchantCoupon
   upgradeFromPurchaseId?: string
   defaultCoupon?: {
     expires?: string

--- a/packages/commerce-server/src/format-prices-for-product.test.ts
+++ b/packages/commerce-server/src/format-prices-for-product.test.ts
@@ -212,7 +212,7 @@ test('available ppp coupons should have country "IN" set', async () => {
     ctx,
   })
 
-  expect(first(product?.availableCoupons).country).toBe('IN')
+  expect(first(product?.availableCoupons)?.country).toBe('IN')
 })
 
 test('available ppp coupons should have country "IN" set with active sale', async () => {
@@ -227,7 +227,7 @@ test('available ppp coupons should have country "IN" set with active sale', asyn
     ctx,
   })
 
-  expect(first(product?.availableCoupons).country).toBe('IN')
+  expect(first(product?.availableCoupons)?.country).toBe('IN')
 })
 
 test('sale coupon should have id property when ppp available', async () => {
@@ -243,7 +243,7 @@ test('sale coupon should have id property when ppp available', async () => {
     ctx,
   })
 
-  expect(product.appliedMerchantCoupon.id).toBeDefined()
+  expect(product.appliedMerchantCoupon?.id).toBeDefined()
 })
 
 test('product should have applied coupon present if "IN" and valid couponId', async () => {
@@ -285,7 +285,7 @@ test('applied ppp coupon should have id property', async () => {
     ctx,
   })
 
-  expect(product.appliedMerchantCoupon.id).toBeDefined()
+  expect(product.appliedMerchantCoupon?.id).toBeDefined()
 })
 
 test('applies fixed discount for previous purchase', async () => {

--- a/packages/commerce-server/src/get-active-merchant-coupon.ts
+++ b/packages/commerce-server/src/get-active-merchant-coupon.ts
@@ -33,6 +33,7 @@ export async function getActiveMerchantCoupon({
     couponIsValid(incomingCoupon) &&
     defaultMerchantCoupon
   ) {
+    // use whichever coupon provides the bigger discount
     const {merchantCoupon: incomingMerchantCoupon} = incomingCoupon
     if (
       incomingMerchantCoupon.percentageDiscount >

--- a/packages/skill-lesson/path-to-purchase/pricing-check-context.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing-check-context.tsx
@@ -1,15 +1,21 @@
 import * as React from 'react'
 import {Dispatch, SetStateAction} from 'react'
 import type {FormattedPrice} from '@skillrecordings/commerce-server/dist/@types'
+import type {MerchantCoupon} from '@skillrecordings/database'
+
+type MinimalMerchantCoupon = Omit<
+  MerchantCoupon & {
+    country?: string
+  },
+  'identifier'
+>
 
 type PricingContextType = {
   addPrice: (price: FormattedPrice, productId: string) => void
   isDowngrade: (price?: FormattedPrice) => boolean
   isDiscount: (price?: FormattedPrice) => boolean
-  merchantCoupon?: {id: string; type: string}
-  setMerchantCoupon: Dispatch<
-    SetStateAction<{id: string; type: string} | undefined>
-  >
+  merchantCoupon?: MinimalMerchantCoupon | undefined
+  setMerchantCoupon: Dispatch<SetStateAction<MinimalMerchantCoupon | undefined>>
 }
 
 const defaultPriceCheckContext: PricingContextType = {
@@ -72,10 +78,9 @@ export const PriceCheckProvider: React.FC<React.PropsWithChildren<any>> = ({
     return price.unitPrice > price.calculatedPrice
   }, [])
 
-  const [merchantCoupon, setMerchantCoupon] = React.useState<{
-    id: string
-    type: string
-  }>()
+  const [merchantCoupon, setMerchantCoupon] = React.useState<
+    MinimalMerchantCoupon | undefined
+  >()
 
   return (
     <PriceCheckContext.Provider

--- a/packages/skill-lesson/path-to-purchase/pricing.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing.tsx
@@ -531,7 +531,7 @@ export const PriceDisplay = ({status, formattedPrice}: PriceDisplayProps) => {
     (formattedPrice?.unitPrice || 0) * (formattedPrice?.quantity || 0)
 
   const percentOff = appliedMerchantCoupon
-    ? Math.floor(appliedMerchantCoupon.percentageDiscount * 100)
+    ? Math.floor(+appliedMerchantCoupon.percentageDiscount * 100)
     : formattedPrice && isDiscount(formattedPrice)
     ? Math.floor(
         (formattedPrice.calculatedPrice / formattedPrice.unitPrice) * 100,

--- a/packages/skill-lesson/trpc/routers/pricing.ts
+++ b/packages/skill-lesson/trpc/routers/pricing.ts
@@ -12,7 +12,7 @@ import {getToken} from 'next-auth/jwt'
 
 const merchantCouponSchema = z.object({
   id: z.string(),
-  type: z.string(),
+  type: z.string().nullable(),
 })
 
 const PricingFormattedInputSchema = z.object({


### PR DESCRIPTION
WIP: looks like I have to do a little type-massaging in a couple of the other apps

While looking into bulk pricing functionality on TJS, I was having trouble tracing some of the behavior through the app and the imported packages. By replacing some of the `any`s with appropriate types, I was able to better understand what was happening and clean up a few discrepancies.

- refactor(tjs): make PPP logic more readable
- types: replace several `any`s in pricing logic

![types](https://media2.giphy.com/media/xUA7b8wrPKmCltD89W/giphy.gif?cid=d1fd59ab56006637kpv4t9e11z2tuqq54pfdls6z4qcy7fg1&ep=v1_gifs_search&rid=giphy.gif&ct=g)
