### PR TITLE
feat(tjs): improve currency formatting of cents

### DIFF
--- a/apps/testing-javascript/src/path-to-purchase/pricing.tsx
+++ b/apps/testing-javascript/src/path-to-purchase/pricing.tsx
@@ -53,6 +53,9 @@ const formatUsd = (amount: number = 0) => {
   const formattedPrice = formatter.format(amount).split('.')
 
   let cents: string | undefined = undefined
+  // Only set `cents` if we have a non-zero value. This preserves the existing
+  // behavior where cents only gets displayed if it is something other than
+  // `00`.
   if (Number.parseInt(formattedPrice[1]) !== 0) {
     cents = formattedPrice[1]
   }

--- a/apps/testing-javascript/src/path-to-purchase/pricing.tsx
+++ b/apps/testing-javascript/src/path-to-purchase/pricing.tsx
@@ -48,10 +48,16 @@ function getFirstPPPCoupon(
 const formatUsd = (amount: number = 0) => {
   const formatter = new Intl.NumberFormat('en-US', {
     currency: 'USD',
+    minimumFractionDigits: 2,
   })
   const formattedPrice = formatter.format(amount).split('.')
 
-  return {dollars: formattedPrice[0], cents: formattedPrice[1]}
+  let cents: string | undefined = undefined
+  if (Number.parseInt(formattedPrice[1]) !== 0) {
+    cents = formattedPrice[1]
+  }
+
+  return {dollars: formattedPrice[0], cents}
 }
 
 type PricingProps = {


### PR DESCRIPTION
I added in the `minimalFractionDigits` option for the [currency NumberFormat constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat) set to `2` so that we get `80` instead of `8` when the discounted price has cents involved.

### Before

![CleanShot 2023-07-13 at 12 30 42@2x](https://github.com/skillrecordings/products/assets/694063/ca95cb30-7e6f-429b-8825-7d5b820a3d88)


### After

![CleanShot 2023-07-13 at 13 02 45@2x](https://github.com/skillrecordings/products/assets/694063/27ea8fba-6b9f-4129-962d-920f54cc2ad7)

![cents](https://media4.giphy.com/media/7x90dc0KEjRNC/giphy.gif?cid=d1fd59ab4dkqe6mukx2mkvhmy9wt0jtq8xox1669rmz2tae3&ep=v1_gifs_search&rid=giphy.gif&ct=g)
