### PR TITLE
jb/improvements to playlists page

### DIFF
--- a/apps/testing-javascript/src/pages/playlists/index.tsx
+++ b/apps/testing-javascript/src/pages/playlists/index.tsx
@@ -9,7 +9,7 @@ export async function getStaticProps() {
   const playlists = await getAllPlaylists()
 
   return {
-    props: {modules: playlists.reverse()},
+    props: {modules: playlists},
     revalidate: 10,
   }
 }

--- a/apps/testing-javascript/src/pages/playlists/index.tsx
+++ b/apps/testing-javascript/src/pages/playlists/index.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import Layout from 'components/layout'
 import {type SanityDocument} from '@sanity/client'
 import {getAllPlaylists} from 'lib/playlists'
-import Link from 'next/link'
-import {track} from '@skillrecordings/skill-lesson/utils/analytics'
 import Playlist from 'components/playlist'
 
 export async function getStaticProps() {

--- a/apps/testing-javascript/src/pages/playlists/index.tsx
+++ b/apps/testing-javascript/src/pages/playlists/index.tsx
@@ -4,6 +4,7 @@ import {type SanityDocument} from '@sanity/client'
 import {getAllPlaylists} from 'lib/playlists'
 import Link from 'next/link'
 import {track} from '@skillrecordings/skill-lesson/utils/analytics'
+import Playlist from 'components/playlist'
 
 export async function getStaticProps() {
   const playlists = await getAllPlaylists()
@@ -18,103 +19,25 @@ const WorkshopsPage: React.FC<{modules: SanityDocument[]}> = ({modules}) => {
   return (
     <Layout
       meta={{
-        title: `Professional TypeScript Workshops from Matt Pocock`,
-        description: `Professional TypeScript workshops by Matt Pocock that will help you learn TypeScript as a professional web developer through exercise driven examples.`,
+        title: `Testing JavaScript with Kent C. Dodds`,
+        description: `This course will teach you the fundamentals of testing your JavaScript applications using ESlint, TypeScript, Jest, and Cypress.`,
       }}
     >
       <main className="relative z-10 flex flex-col items-center justify-center py-32 sm:py-40">
         <h1 className="px-5 text-center font-heading text-5xl font-bold sm:text-5xl">
-          Professional TypeScript Workshops
+          Testing JavaScript with Kent C. Dodds
         </h1>
         {modules && (
-          <ul className="flex max-w-screen-md flex-col gap-5 px-5 pt-10 sm:gap-8 sm:pt-20">
-            {modules.map(
-              ({title, slug, image, description, sections, state}, i) => {
-                return (
-                  <li
-                    key={slug.current}
-                    className="relative flex flex-col items-center gap-10 overflow-hidden rounded-lg border border-gray-700/50 bg-black/20 p-8 shadow-2xl md:flex-row"
-                  >
-                    <div className="w-full">
-                      {state === 'draft' ? (
-                        <h2 className="text-3xl font-semibold sm:text-4xl">
-                          {title}
-                        </h2>
-                      ) : (
-                        <Link
-                          href={{
-                            pathname: '/playlists/[module]',
-                            query: {
-                              module: slug.current,
-                            },
-                          }}
-                        >
-                          <h2 className="text-3xl font-semibold hover:underline sm:text-4xl">
-                            {title}
-                          </h2>
-                        </Link>
-                      )}
-                      <div className="pt-4 pb-3 font-mono text-xs font-semibold uppercase text-cyan-300">
-                        {state === 'draft' ? (
-                          <span className="mr-3 rounded-full bg-gray-700 px-2 py-0.5 font-sans font-semibold uppercase text-gray-200">
-                            Coming Soon
-                          </span>
-                        ) : (
-                          i === 0 && (
-                            <span className="mr-3 rounded-full bg-cyan-300 px-2 py-0.5 font-sans font-semibold uppercase text-black">
-                              New
-                            </span>
-                          )
-                        )}
-                        {sections && state !== 'draft' ? (
-                          <>
-                            {sections.length} sections,{' '}
-                            {sections.reduce(
-                              (acc: number, section: {lessons?: any[]}) =>
-                                section.lessons?.length
-                                  ? section.lessons?.length + acc
-                                  : acc,
-                              0,
-                            )}{' '}
-                            exercises
-                          </>
-                        ) : (
-                          <br />
-                        )}
-                      </div>
-
-                      {description && (
-                        <p className="text-gray-300">{description}</p>
-                      )}
-                      {state !== 'draft' && (
-                        <Link
-                          href={{
-                            pathname: '/playlists/[module]',
-                            query: {
-                              module: slug.current,
-                            },
-                          }}
-                          className="group mt-5 inline-block gap-2 rounded bg-gray-800 py-2 pl-4 pr-6 font-medium transition hover:bg-gray-700"
-                          onClick={() => {
-                            track('clicked view workshop module', {
-                              module: slug.current,
-                            })
-                          }}
-                        >
-                          <span className="pr-2">View</span>
-                          <span
-                            aria-hidden="true"
-                            className="absolute text-gray-300 transition group-hover:translate-x-1 group-hover:text-white"
-                          >
-                            →
-                          </span>
-                        </Link>
-                      )}
-                    </div>
-                  </li>
-                )
-              },
-            )}
+          <ul className="flex max-w-screen-lg flex-col gap-5 px-5 pt-10 sm:gap-8 sm:pt-20">
+            {modules.map((playlist) => {
+              return (
+                <Playlist
+                  key={playlist._id}
+                  playlist={playlist}
+                  purchased={true}
+                />
+              )
+            })}
           </ul>
         )}
       </main>


### PR DESCRIPTION
- fix(tjs): display modules in correct order
- feat(tjs): use styled PlaylistItem on /playlists

TODO: going to follow up with a PR to add `track` calls to the "Start Watching" and "Continue Watching" buttons in `PlaylistItem`.

### Before

<img width="1195" alt="CleanShot 2023-07-14 at 10 19 06@2x" src="https://github.com/skillrecordings/products/assets/694063/030796ec-ce6f-4145-842b-e702fb9af925">

### After

<img width="1180" alt="CleanShot 2023-07-14 at 12 28 22@2x" src="https://github.com/skillrecordings/products/assets/694063/35531757-8f5c-456f-b75e-131b5277a7c4">

![playlist](https://media4.giphy.com/media/zJNMxcHO7p3Ak/giphy.gif?cid=d1fd59abvgcfbrnd1tj1fiuvxqzvwxbr7wwic86l14tqxz4d&ep=v1_gifs_search&rid=giphy.gif&ct=g)
