### PR TITLE
cleanup(tjs): use product ID from env vars

### DIFF
--- a/apps/testing-javascript/process.d.ts
+++ b/apps/testing-javascript/process.d.ts
@@ -27,6 +27,7 @@ const envVariables = z.object({
   POSTMARK_KEY: z.string(),
   NEXT_PUBLIC_PRODUCT_NAME: z.string(),
   STRIPE_SECRET_TOKEN: z.string(),
+  NEXT_PUBLIC_DEFAULT_PRODUCT_ID: z.string(),
 })
 
 envVariables.parse(process.env)

--- a/apps/testing-javascript/src/pages/index.tsx
+++ b/apps/testing-javascript/src/pages/index.tsx
@@ -118,7 +118,7 @@ const Home: React.FC<
     canViewContent &&
     !isEmpty(
       purchases.filter(
-        (item) => item.productId === 'kcd_4f0b26ee-d61d-4245-a204-26f5774355a5',
+        (item) => item.productId === process.env.NEXT_PUBLIC_DEFAULT_PRODUCT_ID,
       ),
     )
 


### PR DESCRIPTION
instead of a hard-coded value

![phoenix](https://media1.giphy.com/media/dKCY50ptJQQpBTLahd/giphy.gif?cid=d1fd59abz373eox8ctvc51ma8cy2mht8d530f0zrkx65uod2&ep=v1_gifs_search&rid=giphy.gif&ct=g)