### PR TITLE
pt(chore): Articles list fields and cards tweaks

### DIFF
--- a/apps/protailwind/src/lib/articles.ts
+++ b/apps/protailwind/src/lib/articles.ts
@@ -7,6 +7,7 @@ export const ArticleSchema = z.object({
   metaTitle: z.string().optional(),
   subtitle: z.string().optional(),
   slug: z.string(),
+  summary: z.string().optional(),
   description: z.nullable(z.string()).optional(),
   body: z.string(),
   date: z.string(),
@@ -26,12 +27,12 @@ export const ArticleSchema = z.object({
 export type Article = z.infer<typeof ArticleSchema>
 
 export async function getAllArticles() {
-  return await sanityClient.fetch(groq`*[_type == "article"] | order(date asc){
+  return await sanityClient.fetch(groq`*[_type == "article"] | order(date desc){
     _updatedAt,
     title,
     subtitle,
     'slug': slug.current,
-    description,
+    summary,
     body,
     state,
     image,

--- a/apps/protailwind/src/pages/articles.tsx
+++ b/apps/protailwind/src/pages/articles.tsx
@@ -6,6 +6,7 @@ import {GetStaticProps} from 'next'
 import {Article, getAllArticles} from '../lib/articles'
 import PageHeadline from 'components/page-headline'
 import readingTime from 'reading-time'
+import {format} from 'date-fns'
 
 const meta = {
   title: 'Tailwind Articles',
@@ -27,9 +28,7 @@ const Articles: React.FC<ArticlesProps> = ({articles}) => {
             {isEmpty(articles) ? (
               <h3>Sorry, there are no articles yet</h3>
             ) : (
-              articles.map(({title, slug, description, body, subtitle}) => {
-                const shortDescription =
-                  description || body.substring(0, 190) + '...'
+              articles.map(({title, slug, summary, body, subtitle, date}) => {
                 const estimatedReadingTime = readingTime(body)
 
                 return (
@@ -48,23 +47,15 @@ const Articles: React.FC<ArticlesProps> = ({articles}) => {
                             {title}
                           </Link>
                         </h2>
+                        <time
+                          dateTime={date}
+                          className="mt-4 block font-semibold text-gray-500"
+                        >
+                          Posted on {format(new Date(date), 'do MMMM, y')}
+                        </time>
                         <h3 className="pt-3 text-xl font-medium text-gray-700">
                           {subtitle}
                         </h3>
-                        <p className="pt-5 font-normal text-gray-600">
-                          {shortDescription}
-                        </p>
-                        {/* <time
-                            dateTime={date}
-                            className="block pt-1 font-semibold pb-5 text-gray-500"
-                          >
-                            {format(new Date(date), 'dd MMMM, y')}
-                          </time> */}
-                        {/* {description && (
-                            <Markdown className="prose pt-3 pb-6">
-                              {description}
-                            </Markdown>
-                          )} */}
                         <div className="mt-6 flex w-full items-center justify-between space-x-5">
                           <Link
                             href={`/${slug}`}


### PR DESCRIPTION
Added post date, removed `shortDescription`, cleared used `summary` instead of `description` since the `description` (SEO meta) might want to be decoupled from what shows on the listing card.

<img width="1496" alt="CleanShot 2023-07-24 at 16 59 40@2x" src="https://github.com/skillrecordings/products/assets/485747/53e7caf2-c679-4629-af19-c7157a72ecf2">

<img width="1135" alt="CleanShot 2023-07-24 at 16 59 04@2x" src="https://github.com/skillrecordings/products/assets/485747/a3e024c1-7a7d-4f35-97b0-0185ae7e07e8">
