### PR TITLE
feat: skip CK tagging in development

### DIFF
--- a/packages/skill-api/src/core/services/convertkit/convertkit-tag-purchase.ts
+++ b/packages/skill-api/src/core/services/convertkit/convertkit-tag-purchase.ts
@@ -41,6 +41,9 @@ async function getSanityProduct(productId: string) {
 }
 
 export async function convertkitTagPurchase(email: string, purchase: Purchase) {
+  // skip CK tagging in development
+  if (process.env.NODE_ENV === 'development') return
+
   try {
     const sanityProduct = await getSanityProduct(purchase.productId)
 

--- a/packages/skill-api/src/core/services/convertkit/convertkit-tag-purchase.ts
+++ b/packages/skill-api/src/core/services/convertkit/convertkit-tag-purchase.ts
@@ -42,7 +42,7 @@ async function getSanityProduct(productId: string) {
 
 export async function convertkitTagPurchase(email: string, purchase: Purchase) {
   // skip CK tagging in development
-  if (process.env.NODE_ENV === 'development') return
+  if (process.env.SKIP_CK_TAGGING === 'true') return
 
   try {
     const sanityProduct = await getSanityProduct(purchase.productId)


### PR DESCRIPTION
I was getting this error about the CK purchase tag ID needing to be set. I don't think we want to be sending tagging events to CK in development, so I'm checking the `NODE_ENV` and exiting this function early if we are in `development`.

<img width="950" alt="CleanShot 2023-07-24 at 11 48 03@2x" src="https://github.com/skillrecordings/products/assets/694063/ca859949-4645-4984-835c-ec1b03a41cb8">
