### PR TITLE
feat(commerce): PPP coupon not available for non-ppp purchasers

### DIFF
--- a/packages/commerce-server/src/format-prices-for-product.test.ts
+++ b/packages/commerce-server/src/format-prices-for-product.test.ts
@@ -311,6 +311,36 @@ test('applies fixed discount for previous purchase', async () => {
   expect(expectedPrice).toBe(product?.calculatedPrice)
 })
 
+test('PPP coupon not available for non-ppp purchasers', async () => {
+  const mockPurchases = [
+    {
+      status: 'Valid',
+    },
+    {
+      status: 'Valid',
+    },
+  ]
+
+  mockCtx.prisma.merchantCoupon.findMany.mockResolvedValue([MOCK_INDIA_COUPON])
+
+  // @ts-ignore
+  mockCtx.prisma.purchase.findMany.mockResolvedValue(mockPurchases)
+
+  // @ts-ignore
+  mockCtx.prisma.user.findFirst.mockResolvedValue({
+    id: 'default-user',
+  })
+
+  const product = await formatPricesForProduct({
+    productId: DEFAULT_PRODUCT_ID,
+    userId: 'default-user',
+    country: 'IN',
+    ctx,
+  })
+
+  expect(product.availableCoupons.length).toBe(0)
+})
+
 const UPGRADE_PURCHASE_ID = 'upgrade-product-id'
 const DEFAULT_PRODUCT_ID = 'default-product-id'
 const UPGRADE_PRODUCT_ID = 'upgrade-product-id'


### PR DESCRIPTION
if regional pricing criteria are met, then PPP coupon is available for users:
- with no purchase
- that previously made a purchase using PPP coupon

I also tested a different solution which only disabled PPP for upgradeProduct (in this case a react bundle), but then the standalone product would be less expensive with PPP then the upgrade itself. So I decided to turn it off on all tiers.

![screenshots](https://github.com/skillrecordings/products/assets/25487857/e28434dc-89b9-4958-851a-2895a77bb888)

<img src="https://media.giphy.com/media/l7GBQWmAdtLzkjGEiF/giphy.gif" width="200" alt="gif">