### PR TITLE
badass.dev: fetch published case studies only

### DIFF
--- a/apps/badass/src/lib/case-studies.ts
+++ b/apps/badass/src/lib/case-studies.ts
@@ -25,7 +25,7 @@ export type CaseStudy = z.infer<typeof CaseStudySchema>
 
 export const getAllCaseStudies = async (): Promise<CaseStudy[]> => {
   const caseStudies =
-    await sanityClient.fetch(groq`*[_type == "caseStudy"] | order(_createdAt desc) {
+    await sanityClient.fetch(groq`*[_type == "caseStudy" && state == "published"] | order(_createdAt desc) {
         _id,
         _type,
         _updatedAt,
@@ -45,7 +45,7 @@ export const getAllCaseStudies = async (): Promise<CaseStudy[]> => {
 
 export const getCaseStudy = async (slug: string): Promise<CaseStudy> => {
   const caseStudy = await sanityClient.fetch(
-    groq`*[_type == "caseStudy" && slug.current == $slug][0] {
+    groq`*[_type == "caseStudy" && state == "published" && slug.current == $slug][0] {
         _id,
         _type,
         _updatedAt,


### PR DESCRIPTION
Adjusted query so that only published case studies get fetched.

![giphy](https://github.com/skillrecordings/products/assets/1519448/3c77095c-e003-4440-9988-37c77e0cf227)
