### PR TITLE
Jb/fix bundled pricing display

### DIFF
--- a/packages/commerce-server/src/@types/index.ts
+++ b/packages/commerce-server/src/@types/index.ts
@@ -19,6 +19,7 @@ export type FormattedPrice = {
   id: string
   quantity: number
   unitPrice: number
+  fullPrice: number
   calculatedPrice: number
   availableCoupons: Array<
     Omit<MerchantCouponWithCountry, 'identifier'> | undefined

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -198,10 +198,14 @@ export async function formatPricesForProduct(
   const bulkDiscountAvailable =
     bulkCouponPercent > 0 && appliedMerchantCouponLessThanBulk && !pppApplied
 
+  const unitPrice: number = price.unitAmount.toNumber()
+  const fullPrice: number = unitPrice * quantity - fixedDiscountForUpgrade
+
   let defaultPriceProduct: FormattedPrice = {
     ...product,
     quantity,
-    unitPrice: price.unitAmount.toNumber(),
+    unitPrice,
+    fullPrice,
     calculatedPrice: getCalculatedPriced({
       unitPrice: price.unitAmount.toNumber(),
       ...(upgradeFromPurchase && {

--- a/packages/skill-lesson/path-to-purchase/pricing-check-context.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing-check-context.tsx
@@ -75,7 +75,7 @@ export const PriceCheckProvider: React.FC<React.PropsWithChildren<any>> = ({
     if (!price) {
       return false
     }
-    return price.unitPrice > price.calculatedPrice
+    return price.fullPrice > price.calculatedPrice
   }, [])
 
   const [merchantCoupon, setMerchantCoupon] = React.useState<

--- a/packages/skill-lesson/path-to-purchase/pricing.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing.tsx
@@ -193,11 +193,7 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
                   <Balancer>{title}</Balancer>
                 </h2>
               )}
-              <PriceDisplay
-                status={status}
-                formattedPrice={formattedPrice}
-                upgradedProductPrice={upgradedProductPrice}
-              />
+              <PriceDisplay status={status} formattedPrice={formattedPrice} />
               {isRestrictedUpgrade ? (
                 <div data-byline="">All region access</div>
               ) : (
@@ -572,21 +568,14 @@ const WorkshopListItem: React.FC<{module: SanityProductModule}> = ({
 export type PriceDisplayProps = {
   status: QueryStatus
   formattedPrice?: FormattedPrice
-  upgradedProductPrice?: number
 }
 
-export const PriceDisplay = ({
-  status,
-  formattedPrice,
-  upgradedProductPrice = 0,
-}: PriceDisplayProps) => {
+export const PriceDisplay = ({status, formattedPrice}: PriceDisplayProps) => {
   const {isDiscount} = usePriceCheck()
 
   const appliedMerchantCoupon = formattedPrice?.appliedMerchantCoupon
 
-  const fullPrice =
-    (formattedPrice?.unitPrice || 0) * (formattedPrice?.quantity || 0) -
-    upgradedProductPrice
+  const fullPrice = formattedPrice?.fullPrice
 
   const percentOff = appliedMerchantCoupon
     ? Math.floor(+appliedMerchantCoupon.percentageDiscount * 100)
@@ -638,6 +627,7 @@ export const PriceDisplay = ({
     </div>
   )
 }
+
 type RegionalPricingBoxProps = {
   pppCoupon: {
     country: string


### PR DESCRIPTION
There is a pricing display bug where without a site-wide coupon, we show the upgrade price along with the discount banner slashing out that same upgrade price. This is because of the logic that determines when certain pricing is a discount. It wasn't accounting for this kind of upgrade pricing.

This PR introduces a `fullPrice` concept in the `FormattedPrice` object which simplifies logic and removes the need to recompute values that were already determined in the commerce-server.

_Note: this doesn't eliminate all the edges in the pricing display logic. For instance, things are still displaying weird when you toggle over to a bulk discounted upgrade._

## Before

![CleanShot 2023-07-26 at 13 52 06@2x](https://github.com/skillrecordings/products/assets/694063/238198b5-9d8e-4b3f-9267-299ccb75808e)

## After

![CleanShot 2023-07-26 at 15 53 41@2x](https://github.com/skillrecordings/products/assets/694063/1cf6582b-1490-4d27-aec9-ebb65a4e95a5)

![upgrade](https://media3.giphy.com/media/xT5LMDbOyltcADw1r2/giphy.gif?cid=d1fd59ab1tcow8ulah9y37w5tm0sqym59ff5yhroo24a7q6p&ep=v1_gifs_search&rid=giphy.gif&ct=g)