### PR TITLE
jb/refactor coupon application in pricing logic

### DIFF
--- a/packages/commerce-server/src/@types/index.ts
+++ b/packages/commerce-server/src/@types/index.ts
@@ -8,7 +8,7 @@ import type {PortableTextBlock} from '@portabletext/types'
 
 type MerchantCouponWithCountry = MerchantCoupon & {country?: string | undefined}
 
-type MinimalMerchantCoupon = Omit<
+export type MinimalMerchantCoupon = Omit<
   MerchantCouponWithCountry,
   'identifier' | 'merchantAccountId'
 >

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -65,7 +65,7 @@ export const determineCouponToApply = async (
     prismaCtx,
   })
 
-  const bulkDiscountDetails = await getBulkCouponDetails({
+  const bulkCouponToBeApplied = await getBulkCouponDetails({
     prismaCtx,
     userId,
     productId,
@@ -77,8 +77,8 @@ export const determineCouponToApply = async (
   let couponToApply: MinimalMerchantCoupon | null = null
   if (pppDetails.status === VALID_PPP) {
     couponToApply = pppDetails.pppCouponToBeApplied
-  } else if (bulkDiscountDetails.bulkDiscountAvailable) {
-    couponToApply = bulkDiscountDetails.bulkCouponToBeApplied
+  } else if (bulkCouponToBeApplied) {
+    couponToApply = bulkCouponToBeApplied
   } else {
     couponToApply = candidateMerchantCoupon
   }
@@ -107,7 +107,6 @@ export const determineCouponToApply = async (
 
   return {
     pppDetails,
-    bulkDiscountDetails,
     appliedMerchantCoupon: couponToApply || undefined,
     appliedCouponType,
     availableCoupons,
@@ -307,17 +306,17 @@ const getBulkCouponDetails = async (params: GetBulkCouponDetailsParams) => {
   const bulkDiscountAvailable =
     bulkCouponPercent > 0 && bulkDiscountIsBetter && !pppApplied // this condition seems irrelevant, if quantity > 1 OR seatCount > 1
 
-  const bulkCoupons = await couponForType(
-    BULK_TYPE,
-    bulkCouponPercent,
-    prismaCtx,
-  )
-  const bulkCoupon = bulkCoupons[0]
+  if (bulkDiscountAvailable) {
+    const bulkCoupons = await couponForType(
+      BULK_TYPE,
+      bulkCouponPercent,
+      prismaCtx,
+    )
+    const bulkCoupon = bulkCoupons[0]
 
-  return {
-    bulkDiscountAvailable,
-    bulkCouponPercent,
-    bulkCouponToBeApplied: bulkCoupon,
+    return bulkCoupon
+  } else {
+    return null
   }
 }
 

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -67,7 +67,7 @@ export const determineCouponToApply = async (
 
   const {getMerchantCoupon, getPurchasesForUser} = getSdk({ctx: prismaCtx})
 
-  const appliedMerchantCoupon = await getMerchantCoupon({
+  const candidateMerchantCoupon = await getMerchantCoupon({
     where: {id: merchantCouponId},
   })
 
@@ -78,7 +78,7 @@ export const determineCouponToApply = async (
   // the quantity, then we remove PPP Coupon from both the `applied` and
   // `available` coupon result.
   const pppDetails = await getPPPDetails({
-    appliedMerchantCoupon,
+    appliedMerchantCoupon: candidateMerchantCoupon,
     country,
     quantity,
     purchaseToBeUpgraded,
@@ -91,7 +91,7 @@ export const determineCouponToApply = async (
     userId,
     productId,
     quantity,
-    appliedMerchantCoupon,
+    appliedMerchantCoupon: candidateMerchantCoupon,
     pppApplied: pppDetails.pppApplied,
   })
 
@@ -105,7 +105,7 @@ export const determineCouponToApply = async (
   if (pppDetails.status === VALID_PPP) {
     couponToApply = pppDetails.pppCouponToBeApplied
   } else {
-    couponToApply = appliedMerchantCoupon
+    couponToApply = candidateMerchantCoupon
   }
 
   // Narrow appliedCouponType to a union of consts

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -3,12 +3,12 @@ import {Context, getSdk} from '@skillrecordings/database'
 import type {MerchantCoupon, Purchase} from '@skillrecordings/database'
 import {getPPPDiscountPercent} from './parity-coupon'
 
-export class MerchantCouponError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'PriceFormattingError'
-  }
-}
+// export class MerchantCouponError extends Error {
+//   constructor(message: string) {
+//     super(message)
+//     this.name = 'PriceFormattingError'
+//   }
+// }
 
 const PrismaCtxSchema: z.ZodType<Context> = z.any()
 const PurchaseSchema: z.ZodType<Purchase> = z.any()
@@ -95,10 +95,10 @@ export const determineCouponToApply = async (
   })
 
   // NOTE: maybe return an 'error' result instead of throwing?
-  if (pppDetails.status === INVALID_PPP) {
-    // Throw coupon error and then repackage in caller as a PriceFormattingError
-    throw new MerchantCouponError('coupon-not-valid-for-ppp')
-  }
+  //   if (pppDetails.status === INVALID_PPP) {
+  //     // Throw coupon error and then repackage in caller as a PriceFormattingError
+  //     throw new MerchantCouponError('coupon-not-valid-for-ppp')
+  //   }
 
   return {pppDetails}
 }

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -263,9 +263,8 @@ type LookupApplicablePPPMerchantCouponParams = z.infer<
   typeof LookupApplicablePPPMerchantCouponParamsSchema
 >
 
-// TODO: Should we pass in the `country` and verify that the PPP
-// discount percentage for that country matches the discount we
-// are about to apply?
+// TODO: Should we cross-check the incoming `pppDiscountPercent` with
+// the `discountPercentage` that was applied to the original purchase?
 const lookupApplicablePPPMerchantCoupon = async (
   params: LookupApplicablePPPMerchantCouponParams,
 ) => {
@@ -281,12 +280,6 @@ const lookupApplicablePPPMerchantCoupon = async (
   // report this to Sentry? Seems like a bug if we aren't able to find one.
   if (pppMerchantCoupon === null) return null
 
-  // Going to skip trimming down the coupon attributes for the time being.
-  //   const {identifier, merchantAccountId, ...minimalPPPMerchantCoupon} =
-  //     pppMerchantCoupon
-
-  // TODO: Mix in the `country`, seems like downstream wants the
-  // `country` bundled in with the rest of the PPP coupon
   return pppMerchantCoupon
 }
 

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -106,7 +106,6 @@ export const determineCouponToApply = async (
     .parse(couponToApply?.type)
 
   return {
-    pppDetails,
     appliedMerchantCoupon: couponToApply || undefined,
     appliedCouponType,
     availableCoupons,
@@ -201,7 +200,6 @@ const getPPPDetails = async ({
   const baseDetails = {
     pppApplied: false,
     pppCouponToBeApplied: null,
-    pppAvailable: pppConditionsMet,
     availableCoupons,
   }
   if (pppCouponToBeApplied === null) {

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -5,13 +5,6 @@ import {getPPPDiscountPercent} from './parity-coupon'
 import {getBulkDiscountPercent} from './bulk-coupon'
 import type {MinimalMerchantCoupon} from './@types'
 
-// export class MerchantCouponError extends Error {
-//   constructor(message: string) {
-//     super(message)
-//     this.name = 'PriceFormattingError'
-//   }
-// }
-
 const PrismaCtxSchema: z.ZodType<Context> = z.any()
 const PurchaseSchema: z.ZodType<Purchase> = z.any()
 
@@ -101,12 +94,6 @@ export const determineCouponToApply = async (
     appliedMerchantCoupon: candidateMerchantCoupon,
     pppApplied: pppDetails.pppApplied,
   })
-
-  // NOTE: maybe return an 'error' result instead of throwing?
-  //   if (pppDetails.status === INVALID_PPP) {
-  //     // Throw coupon error and then repackage in caller as a PriceFormattingError
-  //     throw new MerchantCouponError('coupon-not-valid-for-ppp')
-  //   }
 
   let couponToApply: MinimalMerchantCoupon | null = null
   if (pppDetails.status === VALID_PPP) {

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -142,7 +142,7 @@ export const determineCouponToApply = async (
   return {
     pppDetails,
     bulkDiscountDetails,
-    appliedMerchantCoupon: couponToApply,
+    appliedMerchantCoupon: couponToApply || undefined,
     appliedCouponType,
     availableCoupons,
   }

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -72,7 +72,7 @@ export const determineCouponToApply = async (
     userId,
     productId,
     quantity,
-    appliedMerchantCoupon: candidateMerchantCoupon,
+    appliedMerchantCoupon: specialMerchantCouponToApply,
     pppApplied: pppDetails.pppApplied,
   })
 
@@ -82,7 +82,7 @@ export const determineCouponToApply = async (
   } else if (bulkCouponToBeApplied) {
     couponToApply = bulkCouponToBeApplied
   } else {
-    couponToApply = candidateMerchantCoupon
+    couponToApply = specialMerchantCouponToApply
   }
 
   // It is only every PPP that ends up in the Available Coupons
@@ -164,8 +164,9 @@ const getPPPDetails = async ({
   }
 
   const pppCouponToBeApplied =
-    (appliedMerchantCoupon?.type === PPP_TYPE && appliedMerchantCoupon) ||
-    pppMerchantCouponForUpgrade
+    appliedMerchantCoupon?.type === PPP_TYPE
+      ? appliedMerchantCoupon
+      : pppMerchantCouponForUpgrade
 
   // TODO: Move this sort of price comparison to the parent method, for the
   // purposes of this method we'll just assume that if the PPP looks
@@ -214,7 +215,7 @@ const getPPPDetails = async ({
   // Check *applied* PPP coupon validity
   const couponPercentDoesNotMatchCountry =
     expectedPPPDiscountPercent !==
-    pppCouponToBeApplied.percentageDiscount.toNumber()
+    pppCouponToBeApplied?.percentageDiscount.toNumber()
   const couponPercentOutOfRange =
     expectedPPPDiscountPercent <= 0 || expectedPPPDiscountPercent >= 1
   const pppAppliedToBulkPurchase = quantity > 1

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -129,9 +129,10 @@ const getPPPDetails = ({
 
   const expectedPPPDiscountPercent = getPPPDiscountPercent(country)
 
-  const hasNonPPPPurchases = userPurchases.some(
+  const hasMadeNonPPPDiscountedPurchase = userPurchases.some(
     (purchase) => purchase.status === 'Valid',
   )
+  const hasOnlyPPPDiscountedPurchases = !hasMadeNonPPPDiscountedPurchase
 
   const appliedMerchantCouponLessThanPPP = appliedMerchantCoupon
     ? appliedMerchantCoupon.percentageDiscount.toNumber() <
@@ -141,14 +142,11 @@ const getPPPDetails = ({
   const pppConditionsMet =
     expectedPPPDiscountPercent > 0 &&
     quantity === 1 &&
-    !hasNonPPPPurchases &&
+    hasOnlyPPPDiscountedPurchases &&
     appliedMerchantCouponLessThanPPP
 
-  // if they have a purchase then verify they've used a PPP coupon
-  // otherwise proceed with default conditions
-  const pppAvailable = purchaseToBeUpgraded
-    ? hasPurchaseWithPPP && pppConditionsMet
-    : pppConditionsMet
+  // TODO: Does there actually have to be a PPP coupon available for this condition to be satisfied?
+  const pppAvailable = pppConditionsMet
 
   // Build `details` with all kinds of intermediate stuff as part of this refactoring
   const pppApplied =

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -44,9 +44,11 @@ export const determineCouponToApply = async (
 
   const {getMerchantCoupon, getPurchasesForUser} = getSdk({ctx: prismaCtx})
 
-  const candidateMerchantCoupon = await getMerchantCoupon({
-    where: {id: merchantCouponId},
-  })
+  const candidateMerchantCoupon = merchantCouponId
+    ? await getMerchantCoupon({
+        where: {id: merchantCouponId},
+      })
+    : null
 
   const specialMerchantCouponToApply =
     candidateMerchantCoupon?.type === SPECIAL_TYPE

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -357,9 +357,17 @@ const getBulkCouponDetails = async (params: GetBulkCouponDetailsParams) => {
   const bulkDiscountAvailable =
     bulkCouponPercent > 0 && appliedMerchantCouponLessThanBulk && !pppApplied // this condition seems irrelevant, if quantity > 1 OR seatCount > 1
 
+  const bulkCoupons = await couponForType(
+    BULK_TYPE,
+    bulkCouponPercent,
+    prismaCtx,
+  )
+  const bulkCoupon = bulkCoupons[0]
+
   return {
     bulkDiscountAvailable,
     bulkCouponPercent,
+    bulkCoupon,
   }
 }
 

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -189,9 +189,6 @@ const getPPPDetails = async ({
     hasOnlyPPPDiscountedPurchases &&
     pppDiscountIsBetter
 
-  // TODO: Does there actually have to be a PPP coupon available for this condition to be satisfied?
-  const pppAvailable = pppConditionsMet
-
   // Build `details` with all kinds of intermediate stuff as part of this refactoring
   const pppApplied =
     quantity === 1 &&
@@ -213,7 +210,8 @@ const getPPPDetails = async ({
 
   const baseDetails = {
     pppApplied: false,
-    pppAvailable,
+    pppCouponToBeApplied: null,
+    pppAvailable: pppConditionsMet,
     hasPurchaseWithPPP,
     availableCoupons,
   }
@@ -236,21 +234,18 @@ const getPPPDetails = async ({
     couponPercentOutOfRange ||
     pppAppliedToBulkPurchase
 
-  const details = {...baseDetails, pppApplied, pppAvailable}
-
   if (invalidCoupon) {
     return {
+      ...baseDetails,
       status: INVALID_PPP,
-      ...details,
-      pppApplied: false,
-      pppCouponToBeApplied: null,
       availableCoupons: [],
     }
   }
 
   return {
+    ...baseDetails,
     status: VALID_PPP,
-    ...details,
+    pppApplied,
     pppCouponToBeApplied,
   }
 }

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -143,15 +143,6 @@ const getPPPDetails = async ({
   userPurchases,
   prismaCtx,
 }: GetPPPDetailsParams) => {
-  // TODO: Revisit exactly what this condition means, it may be
-  // the case that it can be replaced with the `hasNonPPPPurchases` condition
-  const hasPurchaseWithPPP = userPurchases.some(
-    (purchase) =>
-      purchase.status === 'Restricted' &&
-      purchaseToBeUpgraded &&
-      purchase.productId === purchaseToBeUpgraded?.productId,
-  )
-
   const hasMadeNonPPPDiscountedPurchase = userPurchases.some(
     (purchase) => purchase.status === 'Valid',
   )
@@ -212,7 +203,6 @@ const getPPPDetails = async ({
     pppApplied: false,
     pppCouponToBeApplied: null,
     pppAvailable: pppConditionsMet,
-    hasPurchaseWithPPP,
     availableCoupons,
   }
   if (pppCouponToBeApplied === null) {

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -1,0 +1,141 @@
+import {z} from 'zod'
+import {Context, getSdk} from '@skillrecordings/database'
+import type {MerchantCoupon} from '@skillrecordings/database'
+import {getPPPDiscountPercent} from './parity-coupon'
+
+export class MerchantCouponError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PriceFormattingError'
+  }
+}
+
+const PrismaCtxSchema: z.ZodType<Context> = z.any()
+
+const DetermineCouponToApplyParamsSchema = z.object({
+  prismaCtx: PrismaCtxSchema,
+  merchantCouponId: z.string().optional(),
+  country: z.string(),
+  quantity: z.number(),
+  userId: z.string().optional(),
+})
+
+type DetermineCouponToApplyParams = z.infer<
+  typeof DetermineCouponToApplyParamsSchema
+>
+
+const SPECIAL_TYPE = 'special' as const
+const PPP_TYPE = 'ppp' as const
+const BULK_TYPE = 'bulk' as const
+const NONE_TYPE = 'none' as const
+
+// We are trying to determine:
+// - what coupon is validly applied
+//   - type
+//   - merchantCoupon object
+// - what other coupons are available
+//   e.g. site-wide defaults, but PPP is available
+// -
+
+// If the coupon to be applied is PPP, but PPP is invalid, then
+// return `NONE_TYPE` and `undefined` for the `appliedMerchantCoupon`
+
+// If the applied coupon (e.g. site-wide discount) provides a greater
+// discount than PPP would be able to, then we don't even offer PPP.
+
+// If the applied coupon (e.g. site-wide discount) provides a greater
+// discount than BULK would be able to, then we don't apply bulk discount.
+
+export const determineCouponToApply = async (
+  params: DetermineCouponToApplyParams,
+) => {
+  const {prismaCtx, merchantCouponId, country, quantity, userId} =
+    DetermineCouponToApplyParamsSchema.parse(params)
+
+  if (merchantCouponId === undefined) {
+    return undefined
+  }
+
+  const {getMerchantCoupon, getPurchasesForUser} = getSdk({ctx: prismaCtx})
+
+  const appliedMerchantCoupon = await getMerchantCoupon({
+    where: {id: merchantCouponId},
+  })
+
+  const userPurchases = await getPurchasesForUser(userId)
+
+  // NOTE: `pppApplied` vs `pppAvailable`
+
+  // QUESTION: Should this include `applied` and `available`?
+  // Then, for example, if we determine that PPP isn't valid because of
+  // the quantity, then we remove PPP Coupon from both the `applied` and
+  // `available` coupon result.
+  const pppDetails = getPPPDetails({appliedMerchantCoupon, country, quantity})
+
+  // NOTE: maybe return an 'error' result instead of throwing?
+  if (pppDetails.status === INVALID_PPP) {
+    // Throw coupon error and then repackage in caller as a PriceFormattingError
+    throw new MerchantCouponError('coupon-not-valid-for-ppp')
+  }
+
+  return {pppDetails}
+}
+
+const MerchantCouponSchema: z.ZodType<MerchantCoupon> = z.any()
+const GetPPPDetailsParamsSchema = z.object({
+  appliedMerchantCoupon: MerchantCouponSchema.nullable(),
+  quantity: z.number(),
+  country: z.string(),
+})
+type GetPPPDetailsParams = z.infer<typeof GetPPPDetailsParamsSchema>
+
+const NO_PPP = 'NO_PPP' as const
+const INVALID_PPP = 'INVALID_PPP' as const
+const VALID_PPP = 'VALID_PPP' as const
+
+const getPPPDetails = ({
+  appliedMerchantCoupon,
+  country,
+  quantity,
+}: GetPPPDetailsParams) => {
+  if (appliedMerchantCoupon?.type !== 'ppp') {
+    return {
+      status: NO_PPP,
+      pppApplied: false,
+    }
+  }
+
+  const expectedPPPDiscountPercent = getPPPDiscountPercent(country)
+
+  // Check PPP coupon validity
+  const couponPercentDoesNotMatchCountry =
+    expectedPPPDiscountPercent !==
+    appliedMerchantCoupon.percentageDiscount.toNumber()
+  const couponPercentOutOfRange =
+    expectedPPPDiscountPercent <= 0 || expectedPPPDiscountPercent >= 1
+  const pppAppliedToBulkPurchase = quantity > 1
+  const invalidCoupon =
+    couponPercentDoesNotMatchCountry ||
+    couponPercentOutOfRange ||
+    pppAppliedToBulkPurchase
+
+  // Build `details` with all kinds of intermediate stuff as part of this refactoring
+  const pppApplied =
+    quantity === 1 &&
+    appliedMerchantCoupon?.type === 'ppp' &&
+    expectedPPPDiscountPercent > 0
+
+  const details = {pppApplied}
+
+  if (invalidCoupon) {
+    return {
+      status: INVALID_PPP,
+      ...details,
+    }
+  }
+
+  return {
+    status: VALID_PPP,
+    ...details,
+  }
+}

--- a/packages/commerce-server/src/format-prices-for-product.test.ts
+++ b/packages/commerce-server/src/format-prices-for-product.test.ts
@@ -275,6 +275,25 @@ test('product should calculate discount if country is "IN" and couponId', async 
   expect(expectedPrice).toBe(product?.calculatedPrice)
 })
 
+test('PPP should be un-applied if quantity is over 1', async () => {
+  mockDefaultProduct()
+  mockCtx.prisma.merchantCoupon.findFirst.mockResolvedValue(MOCK_INDIA_COUPON)
+
+  const quantity = 3
+
+  const product = await formatPricesForProduct({
+    productId: DEFAULT_PRODUCT_ID,
+    merchantCouponId: VALID_INDIA_COUPON_ID,
+    country: 'IN',
+    quantity,
+    ctx,
+  })
+
+  const expectedPrice = 100 * quantity
+
+  expect(expectedPrice).toBe(product?.calculatedPrice)
+})
+
 test('applied ppp coupon should have id property', async () => {
   mockDefaultProduct()
   mockCtx.prisma.merchantCoupon.findFirst.mockResolvedValue(MOCK_INDIA_COUPON)

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -195,6 +195,7 @@ export async function formatPricesForProduct(
       country,
       quantity,
       userId,
+      purchaseToBeUpgraded: upgradeFromPurchase,
     })
   } catch (error) {
     if (error instanceof MerchantCouponError) {
@@ -228,17 +229,10 @@ export async function formatPricesForProduct(
     !hasNonPPPPurchases &&
     appliedMerchantCouponLessThanPPP
 
-  const hasPurchaseWithPPP = userPurchases.some(
-    (purchase) =>
-      purchase.status === 'Restricted' &&
-      upgradeFromPurchase &&
-      purchase.productId === upgradeFromPurchase?.productId,
-  )
-
   // if they have a purchase then verify they've used a PPP coupon
   // otherwise proceed with default conditions
   const pppAvailable = upgradeFromPurchase
-    ? hasPurchaseWithPPP && pppConditionsMet
+    ? result?.pppDetails.hasPurchaseWithPPP && pppConditionsMet
     : pppConditionsMet
 
   const bulkDiscountAvailable =
@@ -354,7 +348,7 @@ export async function formatPricesForProduct(
         upgradedProduct,
       }),
     }
-  } else if (hasPurchaseWithPPP && upgradeFromPurchase) {
+  } else if (result?.pppDetails.hasPurchaseWithPPP && upgradeFromPurchase) {
     const {getMerchantCoupons} = getSdk({ctx})
     const merchantCoupons =
       (await getMerchantCoupons({

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -190,9 +190,7 @@ export async function formatPricesForProduct(
     fullPrice,
     calculatedPrice: getCalculatedPriced({
       unitPrice: price.unitAmount.toNumber(),
-      ...(upgradeFromPurchase && {
-        fixedDiscount: fixedDiscountForUpgrade,
-      }),
+      fixedDiscount: fixedDiscountForUpgrade,
       quantity,
     }),
     availableCoupons: result.availableCoupons,
@@ -209,9 +207,7 @@ export async function formatPricesForProduct(
       calculatedPrice: getCalculatedPriced({
         unitPrice: defaultPriceProduct.unitPrice,
         percentOfDiscount: appliedMerchantCoupon.percentageDiscount.toNumber(),
-        ...(upgradeFromPurchase && {
-          fixedDiscount: fixedDiscountForUpgrade,
-        }),
+        fixedDiscount: fixedDiscountForUpgrade,
         quantity,
       }),
       appliedMerchantCoupon: appliedMerchantCoupon,
@@ -243,9 +239,7 @@ export async function formatPricesForProduct(
       const calculatedPrice = getCalculatedPriced({
         unitPrice: defaultPriceProduct.unitPrice,
         percentOfDiscount: merchantCoupon.percentageDiscount.toNumber(),
-        ...(upgradeFromPurchase && {
-          fixedDiscount: fixedDiscountForUpgrade,
-        }),
+        fixedDiscount: fixedDiscountForUpgrade,
       })
 
       return {
@@ -263,14 +257,15 @@ export async function formatPricesForProduct(
     appliedMerchantCoupon &&
     (appliedCouponType === 'ppp' || appliedCouponType === 'special')
   ) {
+    const percentOfDiscount =
+      appliedMerchantCoupon?.percentageDiscount.toNumber()
+
     return {
       ...defaultPriceProduct,
       calculatedPrice: getCalculatedPriced({
         unitPrice: defaultPriceProduct.unitPrice,
-        percentOfDiscount: appliedMerchantCoupon.percentageDiscount.toNumber(),
-        ...(upgradeFromPurchase && {
-          fixedDiscount: fixedDiscountForUpgrade,
-        }),
+        percentOfDiscount,
+        fixedDiscount: fixedDiscountForUpgrade,
         quantity, // if PPP is applied, we know this will be 1
       }),
       appliedMerchantCoupon,

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -5,10 +5,7 @@ import {Context, defaultContext, getSdk} from '@skillrecordings/database'
 import type {Purchase, Product} from '@skillrecordings/database'
 import {FormattedPrice} from './@types'
 import isEmpty from 'lodash/isEmpty'
-import {
-  determineCouponToApply,
-  MerchantCouponError,
-} from './determine-coupon-to-apply'
+import {determineCouponToApply} from './determine-coupon-to-apply'
 
 // 10% premium for an upgrade
 // TODO: Display Coupon Errors
@@ -186,25 +183,14 @@ export async function formatPricesForProduct(
   const pppDiscountPercent = getPPPDiscountPercent(country)
   const bulkCouponPercent = getBulkDiscountPercent(seatCount)
 
-  let result: Awaited<ReturnType<typeof determineCouponToApply>> = undefined
-
-  try {
-    result = await determineCouponToApply({
-      prismaCtx: ctx,
-      merchantCouponId,
-      country,
-      quantity,
-      userId,
-      purchaseToBeUpgraded: upgradeFromPurchase,
-    })
-  } catch (error) {
-    if (error instanceof MerchantCouponError) {
-      throw new PriceFormattingError(error.message, noContextOptions)
-    } else {
-      // otherwise, re-throw this same error
-      throw error
-    }
-  }
+  const result = await determineCouponToApply({
+    prismaCtx: ctx,
+    merchantCouponId,
+    country,
+    quantity,
+    userId,
+    purchaseToBeUpgraded: upgradeFromPurchase,
+  })
 
   // if there's a coupon implied because an id is passed in, load it to verify
   const appliedMerchantCoupon = merchantCouponId

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -259,34 +259,10 @@ export async function formatPricesForProduct(
         }),
       }
     }
-  } else if (appliedCouponType === 'ppp' && appliedMerchantCoupon) {
-    const {identifier, merchantAccountId, ...merchantCouponWithoutIdentifier} =
-      appliedMerchantCoupon
-
-    return {
-      ...defaultPriceProduct,
-      calculatedPrice: getCalculatedPriced({
-        unitPrice: defaultPriceProduct.unitPrice,
-        percentOfDiscount: appliedMerchantCoupon.percentageDiscount.toNumber(),
-        ...(upgradeFromPurchase && {
-          fixedDiscount: fixedDiscountForUpgrade,
-        }),
-      }),
-      appliedMerchantCoupon: merchantCouponWithoutIdentifier,
-      ...(upgradeFromPurchase && {
-        upgradeFromPurchaseId,
-        upgradeFromPurchase,
-        upgradedProduct,
-      }),
-    }
   } else if (
     appliedMerchantCoupon &&
-    appliedMerchantCoupon.type === 'special' &&
-    result?.pppDetails.pppAvailable
+    (appliedCouponType === 'ppp' || appliedCouponType === 'special')
   ) {
-    const {identifier, merchantAccountId, ...merchantCouponWithoutIdentifier} =
-      appliedMerchantCoupon
-
     return {
       ...defaultPriceProduct,
       calculatedPrice: getCalculatedPriced({
@@ -295,9 +271,9 @@ export async function formatPricesForProduct(
         ...(upgradeFromPurchase && {
           fixedDiscount: fixedDiscountForUpgrade,
         }),
+        quantity, // if PPP is applied, we know this will be 1
       }),
-      appliedMerchantCoupon: merchantCouponWithoutIdentifier,
-      availableCoupons: result.availableCoupons,
+      appliedMerchantCoupon,
       ...(upgradeFromPurchase && {
         upgradeFromPurchaseId,
         upgradeFromPurchase,
@@ -321,7 +297,7 @@ export async function formatPricesForProduct(
       }),
     }
   } else if (result.bulkDiscountDetails.bulkDiscountAvailable) {
-    const bulkCoupon = result.bulkDiscountDetails.bulkCoupon
+    const bulkCoupon = result.bulkDiscountDetails.bulkCouponToBeApplied
 
     return {
       ...defaultPriceProduct,

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -113,7 +113,6 @@ export async function formatPricesForProduct(
     couponForIdOrCode,
     getPrice,
     getPurchase,
-    getPurchasesForUser,
   } = getSdk({ctx})
 
   const upgradeFromPurchase = upgradeFromPurchaseId

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -183,6 +183,7 @@ export async function formatPricesForProduct(
   const unitPrice: number = price.unitAmount.toNumber()
   const fullPrice: number = unitPrice * quantity - fixedDiscountForUpgrade
 
+  // Once the `if(code)` block below is removed, we can collapse this with the else block.
   let defaultPriceProduct: FormattedPrice = {
     ...product,
     quantity,
@@ -202,6 +203,8 @@ export async function formatPricesForProduct(
   }
 
   // no ppp or bulk if you're applying a code
+  // TODO: I believe nowhere in the codebase actually sends in a
+  // `code` to this function, so we can do away with this logic.
   if (code) {
     const coupon = await couponForIdOrCode({code})
 

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -240,7 +240,7 @@ export async function formatPricesForProduct(
       appliedMerchantCoupon?.percentageDiscount.toNumber()
 
     const upgradeDetails =
-      upgradeFromPurchase !== null && appliedCouponType !== 'bulk' // we don't handle bulk with upgrades, so be explicit here
+      upgradeFromPurchase !== null && appliedCouponType !== 'bulk' // we don't handle bulk with upgrades (yet), so be explicit here
         ? {
             upgradeFromPurchaseId,
             upgradeFromPurchase,

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -253,7 +253,7 @@ export async function formatPricesForProduct(
         }),
       }
     }
-  } else if (appliedMerchantCoupon) {
+  } else {
     const percentOfDiscount =
       appliedMerchantCoupon?.percentageDiscount.toNumber()
 
@@ -271,27 +271,12 @@ export async function formatPricesForProduct(
       calculatedPrice: getCalculatedPriced({
         unitPrice: defaultPriceProduct.unitPrice,
         percentOfDiscount,
-        fixedDiscount: fixedDiscountForUpgrade,
+        fixedDiscount: fixedDiscountForUpgrade, // if not upgrade, we know this will be 0
         quantity, // if PPP is applied, we know this will be 1
       }),
+      availableCoupons: result.availableCoupons,
       appliedMerchantCoupon,
       ...upgradeDetails,
-    }
-  } else if (result?.pppDetails.pppAvailable) {
-    return {
-      ...defaultPriceProduct,
-      calculatedPrice: getCalculatedPriced({
-        unitPrice: defaultPriceProduct.unitPrice,
-        ...(upgradeFromPurchase && {
-          fixedDiscount: fixedDiscountForUpgrade,
-        }),
-      }),
-      availableCoupons: result.availableCoupons,
-      ...(upgradeFromPurchase && {
-        upgradeFromPurchaseId,
-        upgradeFromPurchase,
-        upgradedProduct,
-      }),
     }
   }
 

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -198,7 +198,7 @@ export async function formatPricesForProduct(
       }),
       quantity,
     }),
-    availableCoupons: [],
+    availableCoupons: result.availableCoupons,
     ...(upgradeFromPurchase && {
       upgradeFromPurchaseId,
       upgradeFromPurchase,
@@ -287,14 +287,6 @@ export async function formatPricesForProduct(
     appliedMerchantCoupon.type === 'special' &&
     result?.pppDetails.pppAvailable
   ) {
-    // PPP + site coupon
-    const pppCoupons = await couponForType(
-      'ppp',
-      pppDiscountPercent,
-      ctx,
-      country,
-    )
-
     const {identifier, merchantAccountId, ...merchantCouponWithoutIdentifier} =
       appliedMerchantCoupon
 
@@ -308,7 +300,7 @@ export async function formatPricesForProduct(
         }),
       }),
       appliedMerchantCoupon: merchantCouponWithoutIdentifier,
-      availableCoupons: pppCoupons,
+      availableCoupons: result.availableCoupons,
       ...(upgradeFromPurchase && {
         upgradeFromPurchaseId,
         upgradeFromPurchase,
@@ -316,14 +308,6 @@ export async function formatPricesForProduct(
       }),
     }
   } else if (result?.pppDetails.pppAvailable) {
-    // no PPP for bulk
-    const pppCoupons = await couponForType(
-      'ppp',
-      pppDiscountPercent,
-      ctx,
-      country,
-    )
-
     return {
       ...defaultPriceProduct,
       calculatedPrice: getCalculatedPriced({
@@ -332,7 +316,7 @@ export async function formatPricesForProduct(
           fixedDiscount: fixedDiscountForUpgrade,
         }),
       }),
-      availableCoupons: pppCoupons,
+      availableCoupons: result.availableCoupons,
       ...(upgradeFromPurchase && {
         upgradeFromPurchaseId,
         upgradeFromPurchase,

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -324,12 +324,7 @@ export async function formatPricesForProduct(
       }),
     }
   } else if (result.bulkDiscountDetails.bulkDiscountAvailable) {
-    const bulkCoupons = await couponForType(
-      'bulk',
-      result.bulkDiscountDetails.bulkCouponPercent,
-      ctx,
-    )
-    const bulkCoupon = bulkCoupons[0]
+    const bulkCoupon = result.bulkDiscountDetails.bulkCoupon
 
     return {
       ...defaultPriceProduct,
@@ -343,25 +338,4 @@ export async function formatPricesForProduct(
   }
 
   return defaultPriceProduct
-}
-
-async function couponForType(
-  type: string,
-  percentageDiscount: number,
-  ctx: Context,
-  country?: string,
-) {
-  const {getMerchantCoupons} = getSdk({ctx})
-  const merchantCoupons =
-    (await getMerchantCoupons({
-      where: {type, percentageDiscount},
-    })) || []
-
-  type MerchantCoupon = (typeof merchantCoupons)[0]
-
-  return merchantCoupons.map((coupon: MerchantCoupon) => {
-    // for pricing we don't need the identifier so strip it here
-    const {identifier, ...rest} = coupon
-    return {...rest, ...(country && {country})}
-  })
 }

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -198,28 +198,12 @@ export async function formatPricesForProduct(
     : undefined
 
   // pick the bigger discount during a sale
-  const appliedMerchantCouponLessThanPPP = appliedMerchantCoupon
-    ? appliedMerchantCoupon.percentageDiscount.toNumber() < pppDiscountPercent
-    : true
+  // const appliedMerchantCouponLessThanPPP = appliedMerchantCoupon
+  //   ? appliedMerchantCoupon.percentageDiscount.toNumber() < pppDiscountPercent
+  //   : true
   const appliedMerchantCouponLessThanBulk = appliedMerchantCoupon
     ? appliedMerchantCoupon.percentageDiscount.toNumber() < bulkCouponPercent
     : true
-
-  const hasNonPPPPurchases = userPurchases.some(
-    (purchase) => purchase.status === 'Valid',
-  )
-
-  const pppConditionsMet =
-    pppDiscountPercent > 0 &&
-    quantity === 1 &&
-    !hasNonPPPPurchases &&
-    appliedMerchantCouponLessThanPPP
-
-  // if they have a purchase then verify they've used a PPP coupon
-  // otherwise proceed with default conditions
-  const pppAvailable = upgradeFromPurchase
-    ? result?.pppDetails.hasPurchaseWithPPP && pppConditionsMet
-    : pppConditionsMet
 
   const bulkDiscountAvailable =
     bulkCouponPercent > 0 &&
@@ -366,7 +350,7 @@ export async function formatPricesForProduct(
   } else if (
     appliedMerchantCoupon &&
     appliedMerchantCoupon.type === 'special' &&
-    pppAvailable
+    result?.pppDetails.pppAvailable
   ) {
     // PPP + site coupon
     const pppCoupons = await couponForType(
@@ -396,7 +380,7 @@ export async function formatPricesForProduct(
         upgradedProduct,
       }),
     }
-  } else if (pppAvailable) {
+  } else if (result?.pppDetails.pppAvailable) {
     // no PPP for bulk
     const pppCoupons = await couponForType(
       'ppp',

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -201,24 +201,6 @@ export async function formatPricesForProduct(
     }),
   }
 
-  if (appliedMerchantCoupon?.type === 'special') {
-    defaultPriceProduct = {
-      ...defaultPriceProduct,
-      calculatedPrice: getCalculatedPriced({
-        unitPrice: defaultPriceProduct.unitPrice,
-        percentOfDiscount: appliedMerchantCoupon.percentageDiscount.toNumber(),
-        fixedDiscount: fixedDiscountForUpgrade,
-        quantity,
-      }),
-      appliedMerchantCoupon: appliedMerchantCoupon,
-      ...(upgradeFromPurchase && {
-        upgradeFromPurchaseId,
-        upgradeFromPurchase,
-        upgradedProduct,
-      }),
-    }
-  }
-
   // no ppp or bulk if you're applying a code
   if (code) {
     const coupon = await couponForIdOrCode({code})

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -103,13 +103,7 @@ export async function formatPricesForProduct(
     userId,
   } = noContextOptions
 
-  const {
-    getProduct,
-    getMerchantCoupon,
-    couponForIdOrCode,
-    getPrice,
-    getPurchase,
-  } = getSdk({ctx})
+  const {getProduct, getPrice, getPurchase} = getSdk({ctx})
 
   const upgradeFromPurchase = upgradeFromPurchaseId
     ? await getPurchase({
@@ -181,25 +175,6 @@ export async function formatPricesForProduct(
   const unitPrice: number = price.unitAmount.toNumber()
   const fullPrice: number = unitPrice * quantity - fixedDiscountForUpgrade
 
-  // Once the `if(code)` block below is removed, we can collapse this with the else block.
-  let defaultPriceProduct: FormattedPrice = {
-    ...product,
-    quantity,
-    unitPrice,
-    fullPrice,
-    calculatedPrice: getCalculatedPriced({
-      unitPrice: price.unitAmount.toNumber(),
-      fixedDiscount: fixedDiscountForUpgrade,
-      quantity,
-    }),
-    availableCoupons: result.availableCoupons,
-    ...(upgradeFromPurchase && {
-      upgradeFromPurchaseId,
-      upgradeFromPurchase,
-      upgradedProduct,
-    }),
-  }
-
   const percentOfDiscount = appliedMerchantCoupon?.percentageDiscount.toNumber()
 
   const upgradeDetails =
@@ -212,9 +187,12 @@ export async function formatPricesForProduct(
       : {}
 
   return {
-    ...defaultPriceProduct,
+    ...product,
+    quantity,
+    unitPrice,
+    fullPrice,
     calculatedPrice: getCalculatedPriced({
-      unitPrice: defaultPriceProduct.unitPrice,
+      unitPrice,
       percentOfDiscount,
       fixedDiscount: fixedDiscountForUpgrade, // if not upgrade, we know this will be 0
       quantity, // if PPP is applied, we know this will be 1

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -253,15 +253,12 @@ export async function formatPricesForProduct(
         }),
       }
     }
-  } else if (
-    appliedMerchantCoupon &&
-    (appliedCouponType === 'ppp' || appliedCouponType === 'special')
-  ) {
+  } else if (appliedMerchantCoupon) {
     const percentOfDiscount =
       appliedMerchantCoupon?.percentageDiscount.toNumber()
 
     const upgradeDetails =
-      upgradeFromPurchase !== null
+      upgradeFromPurchase !== null && appliedCouponType !== 'bulk' // we don't handle bulk with upgrades, so be explicit here
         ? {
             upgradeFromPurchaseId,
             upgradeFromPurchase,
@@ -295,18 +292,6 @@ export async function formatPricesForProduct(
         upgradeFromPurchase,
         upgradedProduct,
       }),
-    }
-  } else if (result.bulkDiscountDetails.bulkDiscountAvailable) {
-    const bulkCoupon = result.bulkDiscountDetails.bulkCouponToBeApplied
-
-    return {
-      ...defaultPriceProduct,
-      calculatedPrice: getCalculatedPriced({
-        unitPrice: defaultPriceProduct.unitPrice,
-        percentOfDiscount: bulkCoupon.percentageDiscount.toNumber(),
-        quantity,
-      }),
-      ...(bulkCoupon && {appliedMerchantCoupon: bulkCoupon}),
     }
   }
 

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -260,6 +260,15 @@ export async function formatPricesForProduct(
     const percentOfDiscount =
       appliedMerchantCoupon?.percentageDiscount.toNumber()
 
+    const upgradeDetails =
+      upgradeFromPurchase !== null
+        ? {
+            upgradeFromPurchaseId,
+            upgradeFromPurchase,
+            upgradedProduct,
+          }
+        : {}
+
     return {
       ...defaultPriceProduct,
       calculatedPrice: getCalculatedPriced({
@@ -269,11 +278,7 @@ export async function formatPricesForProduct(
         quantity, // if PPP is applied, we know this will be 1
       }),
       appliedMerchantCoupon,
-      ...(upgradeFromPurchase && {
-        upgradeFromPurchaseId,
-        upgradeFromPurchase,
-        upgradedProduct,
-      }),
+      ...upgradeDetails,
     }
   } else if (result?.pppDetails.pppAvailable) {
     return {

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -1,4 +1,3 @@
-import {getPPPDiscountPercent} from './parity-coupon'
 import {getCalculatedPriced} from './get-calculated-price'
 import {Context, defaultContext, getSdk} from '@skillrecordings/database'
 import type {Purchase, Product} from '@skillrecordings/database'
@@ -168,8 +167,6 @@ export async function formatPricesForProduct(
   const price = await getPrice({where: {productId}})
 
   if (!price) throw new PriceFormattingError(`no-price-found`, noContextOptions)
-
-  const pppDiscountPercent = getPPPDiscountPercent(country)
 
   // TODO: give this function a better name like, `determineCouponDetails`
   const {appliedMerchantCoupon, appliedCouponType, ...result} =

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -154,8 +154,6 @@ export async function formatPricesForProduct(
     ctx,
   })
 
-  const userPurchases = await getPurchasesForUser(userId)
-
   const price = await getPrice({where: {productId}})
 
   if (!price) throw new PriceFormattingError(`no-price-found`, noContextOptions)

--- a/packages/skill-api/src/core/services/load-prices.ts
+++ b/packages/skill-api/src/core/services/load-prices.ts
@@ -13,7 +13,6 @@ type OptionsForFormatPrices = {
   userId?: string
   country: string
   quantity: number
-  code?: string
   siteCouponId?: string
   merchantCouponId?: string
   upgradeFromPurchaseId?: string
@@ -26,7 +25,6 @@ export const formatPrices = async (options: OptionsForFormatPrices) => {
     country,
     productId,
     quantity,
-    code,
     siteCouponId,
     merchantCouponId,
     upgradeFromPurchaseId: _upgradeFromPurchaseId,
@@ -60,7 +58,7 @@ export const formatPrices = async (options: OptionsForFormatPrices) => {
       }
     : await getActiveMerchantCoupon({
         siteCouponId,
-        code,
+        code: undefined,
         productId,
       })
 
@@ -70,7 +68,6 @@ export const formatPrices = async (options: OptionsForFormatPrices) => {
     productId,
     country,
     quantity,
-    code,
     merchantCouponId: activeMerchantCoupon?.id,
     ...(upgradeFromPurchaseId && {upgradeFromPurchaseId}),
     userId,
@@ -96,7 +93,6 @@ export async function loadPrices({
       productId: req.body.productId,
       quantity: req.body.quantity,
       purchases: req.body.purchases,
-      code: req.body.code,
       merchantCouponId: req.body.merchantCouponId,
       siteCouponId: req.body.siteCouponId,
       upgradeFromPurchaseId: req.body.upgradeFromPurchaseId,

--- a/packages/skill-api/src/core/services/stripe-checkout.ts
+++ b/packages/skill-api/src/core/services/stripe-checkout.ts
@@ -156,7 +156,7 @@ export async function stripeCheckout({
               id: couponId as string,
             },
           })
-        : false
+        : null
 
       const stripeCoupon =
         merchantCoupon && merchantCoupon.identifier
@@ -183,6 +183,7 @@ export async function stripeCheckout({
         const fixedDiscountForUpgrade = await getFixedDiscountForUpgrade({
           purchaseToBeUpgraded: upgradeFromPurchase,
           productToBePurchased: loadedProduct,
+          purchaseWillBeRestricted: merchantCoupon?.type === 'ppp',
         })
 
         const fullPrice = loadedProduct.prices?.[0].unitAmount.toNumber()

--- a/packages/skill-lesson/trpc/routers/pricing.ts
+++ b/packages/skill-lesson/trpc/routers/pricing.ts
@@ -22,7 +22,6 @@ const PricingFormattedInputSchema = z.object({
   couponId: z.string().optional(),
   merchantCoupon: merchantCouponSchema.optional(),
   upgradeFromPurchaseId: z.string().optional(),
-  code: z.string().optional(),
 })
 
 const checkForAnyAvailableUpgrades = async ({
@@ -65,7 +64,6 @@ type CheckForAvailableCoupons = z.infer<typeof CheckForAvailableCouponsSchema>
 const checkForAvailableCoupons = async ({
   merchantCoupon,
   couponId,
-  code,
   productId,
 }: CheckForAvailableCoupons) => {
   // explicit incoming merchant coupons are honored
@@ -81,8 +79,8 @@ const checkForAvailableCoupons = async ({
     const {activeMerchantCoupon, defaultCoupon} = await getActiveMerchantCoupon(
       {
         siteCouponId: couponId,
-        code,
         productId,
+        code: undefined,
       },
     )
 
@@ -125,7 +123,6 @@ export const pricing = router({
         couponId,
         merchantCoupon,
         upgradeFromPurchaseId: _upgradeFromPurchaseId,
-        code,
       } = input
 
       const token = await getToken({req: ctx.req})
@@ -169,7 +166,6 @@ export const pricing = router({
         await checkForAvailableCoupons({
           merchantCoupon,
           couponId,
-          code,
           productId,
         })
 
@@ -177,7 +173,6 @@ export const pricing = router({
         productId,
         country,
         quantity,
-        code,
         merchantCouponId: activeMerchantCoupon?.id,
         ...(upgradeFromPurchaseId && {upgradeFromPurchaseId}),
         userId: verifiedUserId,


### PR DESCRIPTION
_Update: Loom Walkthrough https://www.loom.com/share/ab73c4acfb0a479eabde80d776926d6c_

This PR represents a refactoring of the Price Formatter logic to make it easier to reason about and easier to make updates as pricing logic, coupon logic, and product offerings continue to evolve.

There was, for instance, lots of redundant logic scattered throughout the price formatter that makes it more error-prone to update because you have to know to update multiple spots.

There were conditional blocks that appear to be added independent of similar logic paths because it was hard to reason about in what ways they overlapped and were different.

This PR took the approach of moving _coupon determining_ logic into a separate module to be called by the price formatter. It separates out the logic for PPP, bulk, and special coupons and then funnels those results back to the price formatter in a way that means there is a single path through the formatter rather than hundreds of lines of `if/else` logic.

It's a little hard to demonstrate with the diff alone, but the core part of the Price Formatter module goes from ~300 lines to about 40.

<img width="881" alt="CleanShot 2023-08-01 at 15 45 05@2x" src="https://github.com/skillrecordings/products/assets/694063/1e8f6bdd-ba87-4fc3-ac57-24b86e0810ad">


The PR is comprised of the following series of commits. I took a very incremental approach, moving logic around primarily, with very little actual changes to the logic. Once these changes are reviewed and approved, these should be squashed before merging to make it trivial to roll this back. That said, I've done extensive manual testing against Total TypeScript locally, through all kinds of scenarios to check the logic and it is sound.

- feat(commerce): move pppApplied into helper
- feat(commerce): move hasPPP check to helper
- feat(commerce): return result instead of throwing
- feat(commerce): move more PPP logic into helper
- feat(commerce): consolidate PPP logic
- cleanup(commerce): remove user purchases lookup
- feat(commerce): combine PPP formatting scenarios
- feat(commerce): move bulk coupon logic into helper
- feat(commerce): try renaming incoming coupon
- feat(commerce): make coupon comparison more explicit
- feat(commerce): find available coupons in helper
- feat(commerce): lookup bulk coupon in helper
- cleanup(commerce): remove unused PPP percent const
- feat(commerce): apply bulk, combine conditions
- feat(commerce): tighten fixed discount logic
- feat(commerce): pull upgradeDetails logic up
- feat(commerce): collapse bulk logic into rest
- feat(skill-api): fix params to get fixed discount
- feat(commerce): collapse available PPP logic
- feat(commerce): collapse extraneous 'special' logic
- feat(commerce): remove commented error-throwing
- cleanup(commerce): clean up some comments
- cleanup(commerce): more coupon comment cleanup
- feat(commerce): reduce PPP details logic
- feat(commerce): remove unused hasPurchaseWithPPP
- feat(commerce): note future refactoring
- feat(commerce): get bulk coupon, instead of details
- feat(commerce): no need to return pppDetails
- feat(commerce): remove coupon `code` logic branch
- feat(commerce): remove last redundant price block
- fix(commerce): don't lookup coupon w/ undefined
- fix(commerce): ensure PPP does not leak through

![simpler](https://media0.giphy.com/media/WRVN3fNc8gkUC4R559/giphy.gif?cid=d1fd59abevb93bawpyelaov7opqwquk9serftqq8ovaluk54&ep=v1_gifs_search&rid=giphy.gif&ct=g)
