### PR TITLE
fix(tt): pass applied bulk coupon to Stripe

### DIFF
--- a/apps/total-typescript/src/templates/purchased-product-template.tsx
+++ b/apps/total-typescript/src/templates/purchased-product-template.tsx
@@ -27,6 +27,7 @@ import {track} from '@skillrecordings/skill-lesson/utils/analytics'
 import {usePriceCheck} from '@skillrecordings/skill-lesson/path-to-purchase/pricing-check-context'
 import {PriceDisplay} from '@skillrecordings/skill-lesson/path-to-purchase/pricing'
 import {QueryStatus} from '@tanstack/react-query'
+import {buildStripeCheckoutPath} from '@skillrecordings/skill-lesson/utils/build-stripe-checkout-path'
 
 const PurchasedProductTemplate: React.FC<ProductPageProps> = ({
   purchases = [],
@@ -195,14 +196,15 @@ const Upgrade: React.FC<{
   purchaseToUpgrade: any
   formattedPrice: FormattedPrice | undefined
   formattedPriceStatus: QueryStatus
-}> = ({
-  purchaseToUpgrade,
-  formattedPrice,
-  product,
-  userId,
-  formattedPriceStatus,
-}) => {
-  const appliedMerchantCoupon = formattedPrice?.appliedMerchantCoupon
+}> = ({formattedPrice, userId, formattedPriceStatus}) => {
+  const formActionPath = buildStripeCheckoutPath({
+    userId,
+    quantity: formattedPrice?.quantity,
+    productId: formattedPrice?.id,
+    bulk: false,
+    couponId: formattedPrice?.appliedMerchantCoupon?.id,
+    upgradeFromPurchaseId: formattedPrice?.upgradeFromPurchaseId,
+  })
 
   return (
     <div>
@@ -211,15 +213,7 @@ const Upgrade: React.FC<{
         get full access to all materials and bonuses from anywhere in the world.
       </p>
       <form
-        action={`/api/skill/checkout/stripe?productId=${
-          formattedPrice?.id
-        }&couponId=${appliedMerchantCoupon?.id}&bulk=false&quantity=1${
-          userId ? `&userId=${userId}` : ``
-        }${
-          formattedPrice?.upgradeFromPurchaseId
-            ? `&upgradeFromPurchaseId=${formattedPrice?.upgradeFromPurchaseId}`
-            : ``
-        }`}
+        action={formActionPath}
         method="POST"
         className="mt-4 flex items-center gap-3"
       >

--- a/packages/skill-lesson/index.tsx
+++ b/packages/skill-lesson/index.tsx
@@ -1,4 +1,5 @@
 export * from './utils/ability'
+export * from './utils/build-stripe-checkout-path'
 export * from './trpc/routers/_skill-lesson-router'
 export * from './trpc/trpc-context'
 export * from './trpc/trpc.server'

--- a/packages/skill-lesson/path-to-purchase/pricing.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing.tsx
@@ -31,6 +31,7 @@ import Balancer from 'react-wrap-balancer'
 import BuyMoreSeats from '../team/buy-more-seats'
 import first from 'lodash/first'
 import {AnimatePresence, motion} from 'framer-motion'
+import {buildStripeCheckoutPath} from '../utils/build-stripe-checkout-path'
 
 type PricingProps = {
   product: SanityProduct
@@ -269,15 +270,16 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
             ) : (
               <div data-purchase-container="">
                 <form
-                  action={`/api/skill/checkout/stripe?productId=${
-                    formattedPrice?.id
-                  }&couponId=${appliedMerchantCoupon?.id}&bulk=${
-                    isBuyingForTeam ? 'true' : 'false'
-                  }&quantity=${quantity}${userId ? `&userId=${userId}` : ``}${
-                    formattedPrice?.upgradeFromPurchaseId
-                      ? `&upgradeFromPurchaseId=${formattedPrice?.upgradeFromPurchaseId}`
-                      : ``
-                  }${cancelUrl ? `&cancelUrl=${cancelUrl}` : ``}`}
+                  action={buildStripeCheckoutPath({
+                    productId: formattedPrice?.id,
+                    couponId: appliedMerchantCoupon?.id,
+                    bulk: isBuyingForTeam,
+                    quantity,
+                    userId,
+                    upgradeFromPurchaseId:
+                      formattedPrice?.upgradeFromPurchaseId,
+                    cancelUrl,
+                  })}
                   method="POST"
                 >
                   <fieldset>

--- a/packages/skill-lesson/team/buy-more-seats.tsx
+++ b/packages/skill-lesson/team/buy-more-seats.tsx
@@ -3,22 +3,7 @@ import {z} from 'zod'
 import {useDebounce} from '@skillrecordings/react'
 import {PriceDisplay} from '../path-to-purchase/pricing'
 import {trpcSkillLessons} from '../utils/trpc-skill-lessons'
-
-const buildFormActionPath = (params: {
-  userId: string
-  quantity: number
-  productId: string
-}) => {
-  const {productId, quantity, userId} = params
-
-  const queryParamString = new URLSearchParams({
-    productId,
-    quantity: String(quantity),
-    userId,
-  }).toString()
-
-  return `/api/skill/checkout/stripe?${queryParamString}`
-}
+import {buildStripeCheckoutPath} from '../utils/build-stripe-checkout-path'
 
 const buyMoreSeatsSchema = z.object({
   productId: z.string(),
@@ -41,10 +26,12 @@ const BuyMoreSeats = ({
       quantity: debouncedQuantity,
     })
 
-  const formActionPath = buildFormActionPath({
+  const formActionPath = buildStripeCheckoutPath({
     userId,
     quantity: debouncedQuantity,
     productId,
+    bulk: true,
+    couponId: formattedPrice?.appliedMerchantCoupon?.id,
   })
 
   return (

--- a/packages/skill-lesson/utils/build-stripe-checkout-path.ts
+++ b/packages/skill-lesson/utils/build-stripe-checkout-path.ts
@@ -1,0 +1,34 @@
+import {z} from 'zod'
+import {omitBy, isNil} from 'lodash'
+
+const ParamsSchema = z
+  .object({
+    productId: z.string().optional(),
+    couponId: z.string().optional(),
+    bulk: z.boolean(),
+    quantity: z.number().default(1),
+    userId: z.string().optional(),
+    upgradeFromPurchaseId: z.string().optional(),
+    cancelUrl: z.string().optional(),
+  })
+  .transform((params) => {
+    return {
+      ...params,
+      bulk: params.bulk.toString(),
+      productId: params.productId || '',
+      quantity: String(params.quantity),
+    }
+  })
+type Params = z.input<typeof ParamsSchema>
+
+export const buildStripeCheckoutPath = (params: Params) => {
+  const result = ParamsSchema.safeParse(params)
+  if (result.success) {
+    const queryParams = omitBy(result.data, isNil)
+    const queryParamString = new URLSearchParams(queryParams).toString()
+    return `/api/skill/checkout/stripe?${queryParamString}`
+  }
+
+  // fallback, report to Sentry?
+  return `/api/skill/checkout/stripe?productId=${params.productId}`
+}


### PR DESCRIPTION
This commit also includes a refactor of how we are building the Skill
API stripe checkout path for form submission. It consolidates the
parameter building, adds type-checking, and uses URLSearchParams.

Example of the bulk coupon not being passed to Stripe:

![image](https://github.com/skillrecordings/products/assets/694063/dce237d9-7325-49e6-bddf-1fa7a27c6a1f)

Now, it is being passed in:

![CleanShot 2023-08-08 at 11 12 52@2x](https://github.com/skillrecordings/products/assets/694063/084f52e8-463b-4ab3-8a94-48c0e150337a)

![bulk up](https://media1.giphy.com/media/zIOdLMZDcBDc2gk6vV/giphy.gif?cid=d1fd59ab75156653l974feialpuf71gilmrjsb655uemkada&ep=v1_gifs_search&rid=giphy.gif&ct=g)
