### PR TITLE
feat(commerce): indicate bulk purchase in price

### DIFF
--- a/apps/scriptkit/src/team/buy-more-seats.tsx
+++ b/apps/scriptkit/src/team/buy-more-seats.tsx
@@ -23,7 +23,7 @@ const BuyMoreSeats = (props: BuyMoreSeatsProps) => {
     userId,
     quantity: debouncedQuantity,
     productId: formattedPrice?.id,
-    bulk: true,
+    bulk: Boolean(formattedPrice?.bulk),
     couponId: formattedPrice?.appliedMerchantCoupon?.id,
   })
 

--- a/apps/testingaccessibility/src/components/pricing.tsx
+++ b/apps/testingaccessibility/src/components/pricing.tsx
@@ -196,7 +196,7 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
               userId,
               quantity,
               productId: formattedPrice?.id,
-              bulk: quantity > 1,
+              bulk: Boolean(formattedPrice?.bulk),
               couponId: appliedMerchantCoupon?.id,
               upgradeFromPurchaseId: formattedPrice?.upgradeFromPurchaseId,
             })}

--- a/apps/testingaccessibility/src/components/team/buy-more-seats.tsx
+++ b/apps/testingaccessibility/src/components/team/buy-more-seats.tsx
@@ -46,7 +46,7 @@ const BuyMoreSeats = (props: BuyMoreSeatsProps) => {
     userId,
     quantity: debouncedQuantity,
     productId,
-    bulk: debouncedQuantity > 1,
+    bulk: Boolean(formattedPrice?.bulk),
     couponId: formattedPrice?.appliedMerchantCoupon?.id,
   })
 

--- a/apps/total-typescript/src/templates/purchased-product-template.tsx
+++ b/apps/total-typescript/src/templates/purchased-product-template.tsx
@@ -201,7 +201,7 @@ const Upgrade: React.FC<{
     userId,
     quantity: formattedPrice?.quantity,
     productId: formattedPrice?.id,
-    bulk: false,
+    bulk: Boolean(formattedPrice?.bulk),
     couponId: formattedPrice?.appliedMerchantCoupon?.id,
     upgradeFromPurchaseId: formattedPrice?.upgradeFromPurchaseId,
   })

--- a/packages/commerce-server/src/@types/index.ts
+++ b/packages/commerce-server/src/@types/index.ts
@@ -32,6 +32,7 @@ export type FormattedPrice = {
     percentageDiscount: string
   }
   upgradedProduct?: ProductWithPrices | null
+  bulk: boolean
 }
 
 export type CouponForCode = {

--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -67,7 +67,7 @@ export const determineCouponToApply = async (
     prismaCtx,
   })
 
-  const bulkCouponToBeApplied = await getBulkCouponDetails({
+  const {bulkCouponToBeApplied, consideredBulk} = await getBulkCouponDetails({
     prismaCtx,
     userId,
     productId,
@@ -111,6 +111,7 @@ export const determineCouponToApply = async (
     appliedMerchantCoupon: couponToApply || undefined,
     appliedCouponType,
     availableCoupons,
+    bulk: consideredBulk,
   }
 }
 
@@ -297,6 +298,7 @@ const getBulkCouponDetails = async (params: GetBulkCouponDetailsParams) => {
     newPurchaseQuantity: quantity,
     prismaCtx,
   })
+  const consideredBulk = seatCount > 1
 
   const bulkCouponPercent = getBulkDiscountPercent(seatCount)
 
@@ -315,9 +317,9 @@ const getBulkCouponDetails = async (params: GetBulkCouponDetailsParams) => {
     )
     const bulkCoupon = bulkCoupons[0]
 
-    return bulkCoupon
+    return {bulkCouponToBeApplied: bulkCoupon, consideredBulk}
   } else {
-    return null
+    return {bulkCouponToBeApplied: null, consideredBulk}
   }
 }
 

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -200,6 +200,7 @@ export async function formatPricesForProduct(
     }),
     availableCoupons: result.availableCoupons,
     appliedMerchantCoupon,
+    bulk: result.bulk,
     ...upgradeDetails,
   }
 }

--- a/packages/skill-lesson/team/buy-more-seats.tsx
+++ b/packages/skill-lesson/team/buy-more-seats.tsx
@@ -30,7 +30,7 @@ const BuyMoreSeats = ({
     userId,
     quantity: debouncedQuantity,
     productId,
-    bulk: formattedPrice.bulk,
+    bulk: Boolean(formattedPrice?.bulk),
     couponId: formattedPrice?.appliedMerchantCoupon?.id,
   })
 

--- a/packages/skill-lesson/team/buy-more-seats.tsx
+++ b/packages/skill-lesson/team/buy-more-seats.tsx
@@ -30,7 +30,7 @@ const BuyMoreSeats = ({
     userId,
     quantity: debouncedQuantity,
     productId,
-    bulk: true,
+    bulk: formattedPrice.bulk,
     couponId: formattedPrice?.appliedMerchantCoupon?.id,
   })
 


### PR DESCRIPTION
The FormattedPrice should indicate to consumers whether the purchase is
going to be a bulk purchase or not. This is because the price formatting
logic does a qualified seat count lookup and knows if the purchase is
individual or adding to an existing bulk purchase.

Existing logic might think a purchase of `quanity = 1` is an individual
purchase when in fact a single seat is being added to an existing bulk
purchase.

![captain planet](https://media4.giphy.com/media/Oh77rYzm6la8M/giphy.gif?cid=d1fd59abdk5b0ff93qrvfva8brlki3gpwvmhf6rye24zcgoo&ep=v1_gifs_search&rid=giphy.gif&ct=g)
