### PR TITLE
jbranchaud/tt 335 ppp purchaser gets unrestricted access when upgrading to

### DIFF
--- a/packages/commerce-server/src/record-new-purchase.ts
+++ b/packages/commerce-server/src/record-new-purchase.ts
@@ -139,6 +139,7 @@ export async function recordNewPurchase(checkoutSessionId: string): Promise<{
     quantity,
     bulk: metadata?.bulk === 'true',
     country: metadata?.country,
+    pppApplied: metadata?.pppApplied === 'true',
     checkoutSessionId,
   })
 

--- a/packages/commerce-server/src/record-new-purchase.ts
+++ b/packages/commerce-server/src/record-new-purchase.ts
@@ -139,7 +139,7 @@ export async function recordNewPurchase(checkoutSessionId: string): Promise<{
     quantity,
     bulk: metadata?.bulk === 'true',
     country: metadata?.country,
-    pppApplied: metadata?.pppApplied === 'true',
+    appliedPPPStripeCouponId: metadata?.appliedPPPStripeCouponId,
     checkoutSessionId,
   })
 

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -430,6 +430,7 @@ export function getSdk(
       quantity?: number
       bulk?: boolean
       checkoutSessionId: string
+      pppApplied?: boolean
       country?: string
     }) {
       const {
@@ -443,6 +444,7 @@ export function getSdk(
         stripeChargeAmount,
         quantity = 1,
         checkoutSessionId,
+        pppApplied = false,
         country,
       } = options
       // we are using uuids so we can generate this!
@@ -552,7 +554,10 @@ export function getSdk(
       const purchase = ctx.prisma.purchase.create({
         data: {
           id: purchaseId,
-          status: merchantCoupon?.type === 'ppp' ? 'Restricted' : 'Valid',
+          status:
+            merchantCoupon?.type === 'ppp' || pppApplied
+              ? 'Restricted'
+              : 'Valid',
           userId,
           productId,
           merchantChargeId,

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -430,7 +430,7 @@ export function getSdk(
       quantity?: number
       bulk?: boolean
       checkoutSessionId: string
-      pppApplied?: boolean
+      appliedPPPStripeCouponId: string | undefined
       country?: string
     }) {
       const {
@@ -444,7 +444,7 @@ export function getSdk(
         stripeChargeAmount,
         quantity = 1,
         checkoutSessionId,
-        pppApplied = false,
+        appliedPPPStripeCouponId,
         country,
       } = options
       // we are using uuids so we can generate this!
@@ -551,11 +551,17 @@ export function getSdk(
         where: {identifier: stripeCouponId},
       })
 
+      const pppMerchantCoupon = appliedPPPStripeCouponId
+        ? await ctx.prisma.merchantCoupon.findFirst({
+            where: {identifier: appliedPPPStripeCouponId, type: 'ppp'},
+          })
+        : null
+
       const purchase = ctx.prisma.purchase.create({
         data: {
           id: purchaseId,
           status:
-            merchantCoupon?.type === 'ppp' || pppApplied
+            merchantCoupon?.type === 'ppp' || Boolean(pppMerchantCoupon)
               ? 'Restricted'
               : 'Valid',
           userId,


### PR DESCRIPTION
There is a bug in the post-purchase logic for an upgrade from Core to Bundle PPP purchase where we don't recognize that the purchase should be region restricted and end up marking it as Valid even though the user paid a PPP price.

This PR fixes it by including the PPP Coupon Stripe Identifier in the checkout metadata so that on the other end we are able to know post purchase whether PPP was applied or not. Typically this hasn't been an issue, but when we combine the PPP discount **with** the Fixed Discount for Upgrade, we lose track the PPP coupon ID.

- fix(tt): upgrades with PPP should be restricted
- feat(commerce): use Stripe ID instead of boolean

![stripe](https://media3.giphy.com/media/sdGuvS3aQHHZB9f5FP/giphy.gif?cid=d1fd59abe6vpwf3z90zpgndptw3yw028w2a2h670745vq2fm&ep=v1_gifs_search&rid=giphy.gif&ct=g)
