### PR TITLE
jbranchaud/tt 334 ppp box should be checked for bundle upgrade w ppp pricing

### DIFF
--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -16,6 +16,7 @@ const DetermineCouponToApplyParamsSchema = z.object({
   userId: z.string().optional(),
   productId: z.string(),
   purchaseToBeUpgraded: PurchaseSchema.nullable(),
+  autoApplyPPP: z.boolean(),
 })
 
 type DetermineCouponToApplyParams = z.infer<
@@ -38,6 +39,7 @@ export const determineCouponToApply = async (
     userId,
     productId,
     purchaseToBeUpgraded,
+    autoApplyPPP,
   } = DetermineCouponToApplyParamsSchema.parse(params)
   // TODO: What are the lookups and logic checks we can
   // skip when there is no appliedMerchantCouponId?
@@ -64,6 +66,7 @@ export const determineCouponToApply = async (
     quantity,
     purchaseToBeUpgraded,
     userPurchases,
+    autoApplyPPP,
     prismaCtx,
   })
 
@@ -127,6 +130,7 @@ const GetPPPDetailsParamsSchema = z.object({
   country: z.string(),
   purchaseToBeUpgraded: PurchaseSchema.nullable(),
   userPurchases: UserPurchasesSchema,
+  autoApplyPPP: z.boolean(),
   prismaCtx: PrismaCtxSchema,
 })
 type GetPPPDetailsParams = z.infer<typeof GetPPPDetailsParamsSchema>
@@ -142,6 +146,7 @@ const getPPPDetails = async ({
   quantity,
   purchaseToBeUpgraded,
   userPurchases,
+  autoApplyPPP,
   prismaCtx,
 }: GetPPPDetailsParams) => {
   const hasMadeNonPPPDiscountedPurchase = userPurchases.some(
@@ -154,7 +159,8 @@ const getPPPDetails = async ({
   const shouldLookupPPPMerchantCouponForUpgrade =
     appliedMerchantCoupon === null &&
     purchaseToBeUpgraded !== null &&
-    hasOnlyPPPDiscountedPurchases
+    hasOnlyPPPDiscountedPurchases &&
+    autoApplyPPP
 
   let pppMerchantCouponForUpgrade: MerchantCoupon | null = null
   if (shouldLookupPPPMerchantCouponForUpgrade) {

--- a/packages/commerce-server/src/format-prices-for-product.test.ts
+++ b/packages/commerce-server/src/format-prices-for-product.test.ts
@@ -388,6 +388,36 @@ test('applies previous-purchase fixed discount and site-wide discount', async ()
   expect(product.calculatedPrice).toBe(64)
 })
 
+test('PPP is auto-applied to upgrade when original purchase was PPP', async () => {
+  mockPPPPurchaseAndUpgradeProduct()
+
+  const product = await formatPricesForProduct({
+    productId: UPGRADE_PRODUCT_ID,
+    upgradeFromPurchaseId: UPGRADE_PURCHASE_ID,
+    country: 'IN',
+    ctx,
+  })
+
+  expect(product.calculatedPrice).toBe(20)
+})
+
+test('PPP can be forced to not auto-apply for upgrade', async () => {
+  mockPPPPurchaseAndUpgradeProduct()
+
+  const product = await formatPricesForProduct({
+    productId: UPGRADE_PRODUCT_ID,
+    upgradeFromPurchaseId: UPGRADE_PURCHASE_ID,
+    country: 'IN',
+    autoApplyPPP: false, // <-- instructing price formatter to *not* auto-apply PPP
+    ctx,
+  })
+
+  // by not applying PPP, we are choosing to do an Unrestricted Bundle Upgrade
+  // so the difference of the originally paid amount with the bundle price is
+  // the calculated price.
+  expect(product.calculatedPrice).toBe(155)
+})
+
 test('PPP coupon not available for non-ppp purchasers', async () => {
   const mockPurchases = [
     {
@@ -585,6 +615,8 @@ const mockPPPPurchaseAndUpgradeProduct = () => {
     prices: [mockUpgradePrice],
   })
   mockCtx.prisma.price.findFirst.mockResolvedValueOnce(mockUpgradePrice)
+
+  mockCtx.prisma.merchantCoupon.findFirst.mockResolvedValue(MOCK_INDIA_COUPON)
 
   // fixed discount price lookup
   mockCtx.prisma.price.findFirst.mockResolvedValueOnce(mockPrice)

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -29,6 +29,7 @@ type FormatPricesForProductOptions = {
   ctx?: Context
   upgradeFromPurchaseId?: string
   userId?: string
+  autoApplyPPP?: boolean
 }
 
 export async function getFixedDiscountForUpgrade({
@@ -103,6 +104,7 @@ export async function formatPricesForProduct(
     merchantCouponId,
     upgradeFromPurchaseId,
     userId,
+    autoApplyPPP = true,
   } = noContextOptions
 
   const {getProduct, getPrice, getPurchase} = getSdk({ctx})
@@ -164,6 +166,7 @@ export async function formatPricesForProduct(
       userId,
       productId: product.id,
       purchaseToBeUpgraded: upgradeFromPurchase,
+      autoApplyPPP,
     })
 
   const fixedDiscountForUpgrade = await getFixedDiscountForUpgrade({

--- a/packages/skill-api/src/core/services/load-prices.ts
+++ b/packages/skill-api/src/core/services/load-prices.ts
@@ -17,6 +17,7 @@ type OptionsForFormatPrices = {
   merchantCouponId?: string
   upgradeFromPurchaseId?: string
   purchases: Purchase[]
+  autoApplyPPP: boolean
 }
 
 export const formatPrices = async (options: OptionsForFormatPrices) => {
@@ -29,6 +30,7 @@ export const formatPrices = async (options: OptionsForFormatPrices) => {
     merchantCouponId,
     upgradeFromPurchaseId: _upgradeFromPurchaseId,
     purchases,
+    autoApplyPPP = true,
   } = options
 
   const {availableUpgradesForProduct} = getSdk()
@@ -71,6 +73,7 @@ export const formatPrices = async (options: OptionsForFormatPrices) => {
     merchantCouponId: activeMerchantCoupon?.id,
     ...(upgradeFromPurchaseId && {upgradeFromPurchaseId}),
     userId,
+    autoApplyPPP,
   })
 
   return {product, defaultCoupon}
@@ -87,6 +90,12 @@ export async function loadPrices({
 
     const country = (req.headers['x-vercel-ip-country'] as string) || 'US'
 
+    // coerce `autoApplyPPP` to true unless it is explicitly false
+    const autoApplyPPP =
+      req.body.autoApplyPPP === false || req.body.autoApplyPPP === 'false'
+        ? false
+        : true
+
     const options: OptionsForFormatPrices = {
       userId,
       country,
@@ -96,6 +105,7 @@ export async function loadPrices({
       merchantCouponId: req.body.merchantCouponId,
       siteCouponId: req.body.siteCouponId,
       upgradeFromPurchaseId: req.body.upgradeFromPurchaseId,
+      autoApplyPPP,
     }
 
     const {product, defaultCoupon} = await formatPrices(options)

--- a/packages/skill-lesson/path-to-purchase/pricing.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing.tsx
@@ -4,6 +4,7 @@ import type {
   SanityProduct,
   FormattedPrice,
   SanityProductModule,
+  MinimalMerchantCoupon,
 } from '@skillrecordings/commerce-server/dist/@types'
 import {CheckCircleIcon} from '@heroicons/react/outline'
 import {useDebounce} from '@skillrecordings/react'
@@ -102,6 +103,7 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
     usePriceCheck()
   const {subscriber, loadingSubscriber} = useConvertkit()
   const router = useRouter()
+  const [autoApplyPPP, setAutoApplyPPP] = React.useState<boolean>(true)
 
   const {data: formattedPrice, status} =
     trpcSkillLessons.pricing.formatted.useQuery(
@@ -110,6 +112,7 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
         quantity: debouncedQuantity,
         couponId,
         merchantCoupon,
+        autoApplyPPP,
       },
       {
         onSuccess: (formattedPrice) => {
@@ -134,16 +137,19 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
   type AvailableCoupon = NonNullable<
     typeof formattedPrice
   >['availableCoupons'][0]
-  const pppCoupon = getFirstPPPCoupon<AvailableCoupon>(
+  const availablePPPCoupon = getFirstPPPCoupon<AvailableCoupon>(
     formattedPrice?.availableCoupons,
   )
+
+  const appliedPPPCoupon =
+    appliedMerchantCoupon?.type === 'ppp' ? appliedMerchantCoupon : null
 
   // if there is no available coupon, hide the box (it's not a toggle)
   // only show the box if ppp coupon is available
   // do not show the box if purchased
   // do not show the box if it's a downgrade
   const showPPPBox =
-    Boolean(pppCoupon || merchantCoupon?.type === 'ppp') &&
+    Boolean(availablePPPCoupon || appliedPPPCoupon) &&
     !purchased &&
     !isDowngrade(formattedPrice) &&
     !isBuyingForTeam
@@ -427,11 +433,11 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
           )}
           {showPPPBox && !canViewRegionRestriction && (
             <RegionalPricingBox
-              isPPPEnabled={isPPPEnabled}
-              pppCoupon={pppCoupon || merchantCoupon || null}
-              merchantCoupon={merchantCoupon}
+              availablePPPCoupon={availablePPPCoupon}
+              appliedPPPCoupon={appliedPPPCoupon}
               setMerchantCoupon={setMerchantCoupon}
               index={index}
+              setAutoApplyPPP={setAutoApplyPPP}
             />
           )}
           <div data-pricing-footer="">
@@ -641,40 +647,37 @@ export const PriceDisplay = ({status, formattedPrice}: PriceDisplayProps) => {
 }
 
 type RegionalPricingBoxProps = {
-  pppCoupon: {
+  availablePPPCoupon: {
     country?: string | undefined
     percentageDiscount: number | Decimal
   } | null
-  merchantCoupon: any
+  appliedPPPCoupon: MinimalMerchantCoupon | null
   setMerchantCoupon: (coupon: any) => void
   index: number
-  isPPPEnabled?: boolean
+  setAutoApplyPPP: (apply: boolean) => void
 }
 
 const RegionalPricingBox: React.FC<
   React.PropsWithChildren<RegionalPricingBoxProps>
 > = ({
-  pppCoupon,
-  merchantCoupon,
+  availablePPPCoupon,
+  appliedPPPCoupon,
   setMerchantCoupon,
   index,
-  isPPPEnabled = false,
+  setAutoApplyPPP,
 }) => {
   const regionNames = new Intl.DisplayNames(['en'], {type: 'region'})
-  React.useEffect(() => {
-    if (isPPPEnabled) {
-      setMerchantCoupon(pppCoupon as any)
-    }
-  }, [isPPPEnabled, pppCoupon, setMerchantCoupon])
 
-  if (!pppCoupon?.country) {
-    console.error('No country found for PPP coupon', {pppCoupon})
+  if (!availablePPPCoupon?.country) {
+    console.error('No country found for PPP coupon', {availablePPPCoupon})
     return null
   }
 
-  const countryCode = pppCoupon.country
+  const countryCode = availablePPPCoupon.country
   const country = regionNames.of(countryCode)
-  const percentageDiscount = getNumericValue(pppCoupon.percentageDiscount)
+  const percentageDiscount = getNumericValue(
+    availablePPPCoupon.percentageDiscount,
+  )
   const percentOff = Math.floor(percentageDiscount * 100)
 
   return (
@@ -698,11 +701,14 @@ const RegionalPricingBox: React.FC<
       <label>
         <input
           type="checkbox"
-          checked={Boolean(merchantCoupon)}
+          checked={Boolean(appliedPPPCoupon)}
           onChange={() => {
-            merchantCoupon
-              ? setMerchantCoupon(undefined)
-              : setMerchantCoupon(pppCoupon as any)
+            setAutoApplyPPP(false)
+            if (appliedPPPCoupon) {
+              setMerchantCoupon(undefined)
+            } else {
+              setMerchantCoupon(availablePPPCoupon as any)
+            }
           }}
         />
         <span>Activate {percentOff}% off with regional pricing</span>

--- a/packages/skill-lesson/trpc/routers/pricing.ts
+++ b/packages/skill-lesson/trpc/routers/pricing.ts
@@ -22,6 +22,7 @@ const PricingFormattedInputSchema = z.object({
   couponId: z.string().optional(),
   merchantCoupon: merchantCouponSchema.optional(),
   upgradeFromPurchaseId: z.string().optional(),
+  autoApplyPPP: z.boolean().default(true),
 })
 
 const checkForAnyAvailableUpgrades = async ({
@@ -123,6 +124,7 @@ export const pricing = router({
         couponId,
         merchantCoupon,
         upgradeFromPurchaseId: _upgradeFromPurchaseId,
+        autoApplyPPP,
       } = input
 
       const token = await getToken({req: ctx.req})
@@ -176,6 +178,7 @@ export const pricing = router({
         merchantCouponId: activeMerchantCoupon?.id,
         ...(upgradeFromPurchaseId && {upgradeFromPurchaseId}),
         userId: verifiedUserId,
+        autoApplyPPP,
       })
 
       const formattedPrice = {


### PR DESCRIPTION
This PR adds an option to `formatPricesForProduct` to control whether a qualifying PPP coupon should be auto-applied to the upgrade of an existing purchase.

- types(tt): clean up flow of types for PPP Pricing
- feat(commerce): get pricing w/o PPP auto-applied

Scenario: Let's say a user has purchased Core(PPP). When we are computing the pricing for the upgrade to the Bundle, we want to auto-apply the PPP discount to that upgrade as long as they are in the same region. This is a great default, but we need it to be configurable in case the user wants to toggle-off PPP pricing and make an unrestricted purchase.

Adding this option allows the UI to request pricing with and without the PPP discount being auto-applied.

### Before

![image](https://github.com/skillrecordings/products/assets/694063/de6f90c0-3d47-4786-854d-308e675abe32)

### After


https://github.com/skillrecordings/products/assets/694063/ce65d476-7c13-4cb1-a515-72a6712147af


![auto](https://media0.giphy.com/media/3oKIPmnZ2IxoAQBta8/giphy.gif?cid=d1fd59aburjq32g50tgg205dvgotq8imp9y95xo8219nzqjo&ep=v1_gifs_search&rid=giphy.gif&ct=g)