### PR TITLE
feat(commerce): exclude already purchased upgrade

### DIFF
--- a/packages/skill-lesson/trpc/routers/pricing.ts
+++ b/packages/skill-lesson/trpc/routers/pricing.ts
@@ -39,6 +39,9 @@ const checkForAnyAvailableUpgrades = async ({
 
   const {availableUpgradesForProduct} = getSdk()
   const validPurchases = getValidPurchases(purchases)
+  const productIdsAlreadyPurchased = validPurchases.map(
+    (purchase) => purchase.productId,
+  )
 
   const availableUpgrades = await availableUpgradesForProduct(
     validPurchases,
@@ -46,10 +49,18 @@ const checkForAnyAvailableUpgrades = async ({
   )
 
   return find(validPurchases, (purchase) => {
+    // find potential upgrade opportunities based on existing purchases
     const upgradeProductIds = availableUpgrades.map(
       (upgrade) => upgrade.upgradableFrom.id,
     )
-    return upgradeProductIds.includes(purchase.productId)
+
+    // filter out any productIds that have already been purchased
+    const upgradeProductIdsNotAlreadyPurchased = upgradeProductIds.filter(
+      (upgradeProductId) =>
+        !productIdsAlreadyPurchased.includes(upgradeProductId),
+    )
+
+    return upgradeProductIdsNotAlreadyPurchased.includes(purchase.productId)
   })?.id
 }
 


### PR DESCRIPTION
If you've already purchased the upgrade (e.g. from Core to Bundle), then
we shouldn't be re-identifying the Bundle upgrade as an *available*
upgrade. You can't purchase the upgrade twice, so it isn't available.

This now checks against all your existing purchases before passing along
a potential upgrade opportunity.

![CleanShot 2023-08-17 at 18 36 18@2x](https://github.com/skillrecordings/products/assets/694063/e0798b92-6124-4e42-8bd1-f9b8b0fcbedb)


![already](https://media4.giphy.com/media/6oyMuvF0iy0T8UqPwg/giphy.gif?cid=d1fd59abe85zouyvh54k8j3vpvbnfjixtbebu1s7w4i1c56j&ep=v1_gifs_search&rid=giphy.gif&ct=g)

