### PR TITLE
jbranchaud/tt 340 fix pricing confusion for team seat upgrades 2

### DIFF
--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -31,7 +31,7 @@ type FormatPricesForProductOptions = {
   userId?: string
 }
 
-export async function getFixedDiscountForUpgrade({
+export async function getFixedDiscountForIndividualUpgrade({
   purchaseToBeUpgraded,
   productToBePurchased,
   purchaseWillBeRestricted,
@@ -166,12 +166,22 @@ export async function formatPricesForProduct(
       purchaseToBeUpgraded: upgradeFromPurchase,
     })
 
-  const fixedDiscountForUpgrade = await getFixedDiscountForUpgrade({
-    purchaseToBeUpgraded: upgradeFromPurchase,
-    productToBePurchased: product,
-    purchaseWillBeRestricted: appliedCouponType === 'ppp',
-    ctx,
-  })
+  const fireFixedDiscountForIndividualUpgrade = async () => {
+    return await getFixedDiscountForIndividualUpgrade({
+      purchaseToBeUpgraded: upgradeFromPurchase,
+      productToBePurchased: product,
+      purchaseWillBeRestricted: appliedCouponType === 'ppp',
+      ctx,
+    })
+  }
+
+  // Right now, we have fixed discounts to apply to upgrades for indvidual
+  // purchases. If it is a bulk purchase, a fixed discount shouldn't be
+  // applied. It's likely this will change in the future, so this allows us
+  // to handle both and distinguishes them as two different flows.
+  const fixedDiscountForUpgrade = result.bulk
+    ? 0
+    : await fireFixedDiscountForIndividualUpgrade()
 
   const unitPrice: number = price.unitAmount.toNumber()
   const fullPrice: number = unitPrice * quantity - fixedDiscountForUpgrade

--- a/packages/skill-api/src/core/services/stripe-checkout.ts
+++ b/packages/skill-api/src/core/services/stripe-checkout.ts
@@ -12,7 +12,7 @@ import {add} from 'date-fns'
 import {
   getCalculatedPrice,
   stripe,
-  getFixedDiscountForUpgrade,
+  getFixedDiscountForIndividualUpgrade,
 } from '@skillrecordings/commerce-server'
 import {getToken} from 'next-auth/jwt'
 import {NextApiRequest} from 'next'
@@ -270,21 +270,22 @@ export async function stripeCheckout({
         const purchaseWillBeRestricted = merchantCoupon?.type === 'ppp'
         appliedPPPStripeCouponId = merchantCoupon?.identifier
 
-        const fixedDiscountForUpgrade = await getFixedDiscountForUpgrade({
-          purchaseToBeUpgraded: upgradeFromPurchase,
-          productToBePurchased: loadedProduct,
-          purchaseWillBeRestricted,
-        })
+        const fixedDiscountForIndividualUpgrade =
+          await getFixedDiscountForIndividualUpgrade({
+            purchaseToBeUpgraded: upgradeFromPurchase,
+            productToBePurchased: loadedProduct,
+            purchaseWillBeRestricted,
+          })
 
         const fullPrice = loadedProduct.prices?.[0].unitAmount.toNumber()
         const calculatedPrice = getCalculatedPrice({
           unitPrice: fullPrice,
           percentOfDiscount: stripeCouponPercentOff || 0,
           quantity: 1,
-          fixedDiscount: fixedDiscountForUpgrade,
+          fixedDiscount: fixedDiscountForIndividualUpgrade,
         })
 
-        if (fixedDiscountForUpgrade > 0) {
+        if (fixedDiscountForIndividualUpgrade > 0) {
           const couponName = buildCouponName(
             upgradeFromPurchase,
             productId,

--- a/packages/skill-lesson/trpc/routers/pricing.ts
+++ b/packages/skill-lesson/trpc/routers/pricing.ts
@@ -43,24 +43,30 @@ const checkForAnyAvailableUpgrades = async ({
     (purchase) => purchase.productId,
   )
 
-  const availableUpgrades = await availableUpgradesForProduct(
+  const potentialUpgrades = await availableUpgradesForProduct(
     validPurchases,
     productId,
   )
 
+  type AvailableUpgrade = Awaited<
+    ReturnType<typeof availableUpgradesForProduct>
+  >[0]
+  // filter out potential upgrades that have already been purchased
+  const availableUpgrades = potentialUpgrades.filter<AvailableUpgrade>(
+    (
+      availableUpgrade: AvailableUpgrade,
+    ): availableUpgrade is AvailableUpgrade => {
+      return !productIdsAlreadyPurchased.includes(
+        availableUpgrade.upgradableTo.id,
+      )
+    },
+  )
+
   return find(validPurchases, (purchase) => {
-    // find potential upgrade opportunities based on existing purchases
     const upgradeProductIds = availableUpgrades.map(
       (upgrade) => upgrade.upgradableFrom.id,
     )
-
-    // filter out any productIds that have already been purchased
-    const upgradeProductIdsNotAlreadyPurchased = upgradeProductIds.filter(
-      (upgradeProductId) =>
-        !productIdsAlreadyPurchased.includes(upgradeProductId),
-    )
-
-    return upgradeProductIdsNotAlreadyPurchased.includes(purchase.productId)
+    return upgradeProductIds.includes(purchase.productId)
   })?.id
 }
 


### PR DESCRIPTION
- fix(commerce): missing individual upgrade

> Because I was checking the `upgradeFrom` instead of the `upgradeTo` when
filtering out already-purchased products, we were missing the fixed
discount for an individual Core to Bundle upgrade.

- feat(commerce): no fixed discount for bulk

> We may at some point have a fixed discount for bulk pricing when that
part of the commerce flow is further developed, but for now the fixed
discount we are computing is for individual purchases and so this now
differentiates for that.

![whoops](https://media1.giphy.com/media/RIq4nU3TgUQztUhYRr/giphy.gif?cid=d1fd59abu4lv4n9dunm64ea4jgcrl9hd0buryiz545umzq0h&ep=v1_gifs_search&rid=giphy.gif&ct=g)
