### PR TITLE
feat(commerce): record upgradedFromId on purchase

### DIFF
--- a/packages/commerce-server/src/record-new-purchase.ts
+++ b/packages/commerce-server/src/record-new-purchase.ts
@@ -140,6 +140,7 @@ export async function recordNewPurchase(checkoutSessionId: string): Promise<{
     bulk: metadata?.bulk === 'true',
     country: metadata?.country,
     appliedPPPStripeCouponId: metadata?.appliedPPPStripeCouponId,
+    upgradedFromPurchaseId: metadata?.upgradedFromPurchaseId,
     checkoutSessionId,
   })
 

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -431,6 +431,7 @@ export function getSdk(
       bulk?: boolean
       checkoutSessionId: string
       appliedPPPStripeCouponId: string | undefined
+      upgradedFromPurchaseId: string | undefined
       country?: string
     }) {
       const {
@@ -445,6 +446,7 @@ export function getSdk(
         quantity = 1,
         checkoutSessionId,
         appliedPPPStripeCouponId,
+        upgradedFromPurchaseId,
         country,
       } = options
       // we are using uuids so we can generate this!
@@ -571,6 +573,7 @@ export function getSdk(
           bulkCouponId,
           merchantSessionId,
           country,
+          upgradedFromId: upgradedFromPurchaseId || null,
         },
       })
 

--- a/packages/skill-api/src/core/services/stripe-checkout.ts
+++ b/packages/skill-api/src/core/services/stripe-checkout.ts
@@ -256,6 +256,7 @@ export async function stripeCheckout({
 
       let discounts = []
       let appliedPPPStripeCouponId: string | undefined | null = undefined
+      let upgradedFromPurchaseId: string | undefined | null = undefined
 
       const isUpgrade = Boolean(
         (availableUpgrade || upgradeFromPurchase?.status === 'Restricted') &&
@@ -269,6 +270,7 @@ export async function stripeCheckout({
       if (isUpgrade && upgradeFromPurchase && loadedProduct && customerId) {
         const purchaseWillBeRestricted = merchantCoupon?.type === 'ppp'
         appliedPPPStripeCouponId = merchantCoupon?.identifier
+        upgradedFromPurchaseId = upgradeFromPurchase.id
 
         const fixedDiscountForIndividualUpgrade =
           await getFixedDiscountForIndividualUpgrade({
@@ -357,6 +359,7 @@ export async function stripeCheckout({
         }),
         bulk: bulk === 'true' ? 'true' : quantity > 1 ? 'true' : 'false',
         ...(appliedPPPStripeCouponId && {appliedPPPStripeCouponId}),
+        ...(upgradedFromPurchaseId && {upgradedFromPurchaseId}),
         country:
           (req.headers['x-vercel-ip-country'] as string) ||
           process.env.DEFAULT_COUNTRY ||


### PR DESCRIPTION
We have the `upgradedFromId` on the `Purchase` table which exists to
record when a Purchase record is one that was upgraded from an existing
Purchase record. We haven't been using it tho.

This includes that info in the Stripe metadata during the checkout phase
when we have easy access to the purchase being upgraded from and then in
the post-purchase handler, we record that on the new purchase record.

The reason this is useful beyond just generally doing record keeping and knowing what is connected is that we can use the info in order to determine a chain of purchases in order to accurate compute the fixed discount to be applied in certain scenarios (https://linear.app/skillrecordings/issue/TT-338/ppp-to-unrestricted-upgrade-for-a-multi-purchase-bundle-is-not).

As an example, if I purchase Core:

```
> select * from Purchase order by createdAt desc limit 1\G
*************************** 1. row ***************************
                  id: eb73e6f1-c4f9-4e9c-aeac-06a189d57550
              userId: 53b886b3-26d5-4b67-9be8-6f1c61955417
           createdAt: 2023-08-18 17:56:25.377
         totalAmount: 472.000000000000000000000000000000
          ip_address: NULL
                city: NULL
               state: NULL
             country: US
            couponId: NULL
           productId: tt_00c02ac7-6f95-4ad4-8aac-999b243df6c1
    merchantChargeId: bfb5f9b5-253a-4892-a049-bf5585ffa6e1
      upgradedFromId: NULL
              status: Valid
        bulkCouponId: NULL
redeemedBulkCouponId: NULL
   merchantSessionId: 6963e162-e73c-4393-ba04-757b6f29ca17
1 row in set (0.01 sec)
```

Then I have a Purchase record that will be recognized at a later time when I'm prompted to upgrade to the Bundle.

Now, if I purchase the Bundle, then the original purchase id (`eb73e6f1-c4f9-4e9c-aeac-06a189d57550`) is recorded on the new purchase as the `upgradedFromId`:

```
> select * from Purchase order by createdAt desc limit 1\G
*************************** 1. row ***************************
                  id: d8a94591-55bf-45a8-a558-7225481622d7
              userId: 53b886b3-26d5-4b67-9be8-6f1c61955417
           createdAt: 2023-08-18 17:57:24.433
         totalAmount: 200.000000000000000000000000000000
          ip_address: NULL
                city: NULL
               state: NULL
             country: US
            couponId: NULL
           productId: tt_product_79434686-6437-48ac-956e-1357aba87672
    merchantChargeId: a6415670-427e-4f84-98be-d3f1ef4efc68
      upgradedFromId: eb73e6f1-c4f9-4e9c-aeac-06a189d57550
              status: Valid
        bulkCouponId: NULL
redeemedBulkCouponId: NULL
   merchantSessionId: 9d7bb239-768b-476a-b94d-674bae3deefa
1 row in set (0.00 sec)
```

![kirby](https://media4.giphy.com/media/Md5UqmyyS2dhu/giphy.gif?cid=d1fd59abugfaxbl0us1dk7d22uleexclzgifgv60t66yelcu&ep=v1_gifs_search&rid=giphy.gif&ct=g)
