### PR TITLE
update(ck): filter out null values from `fullSubscriber`

### DIFF
--- a/packages/skill-api/src/core/services/convertkit/subscribe-to-convertkit.ts
+++ b/packages/skill-api/src/core/services/convertkit/subscribe-to-convertkit.ts
@@ -37,6 +37,7 @@ export async function subscribeToConvertkit({
     })
 
     const fullSubscriber = await fetchSubscriber(subscriber.id.toString())
+    const fullSubscriberWithoutEmptyFields = filterNullFields(fullSubscriber)
 
     if (fields) {
       await setConvertkitSubscriberFields(fullSubscriber, fields)
@@ -45,11 +46,29 @@ export async function subscribeToConvertkit({
     return {
       status: 200,
       body: subscriber,
-      cookies: getConvertkitSubscriberCookie(fullSubscriber),
+      cookies: getConvertkitSubscriberCookie(fullSubscriberWithoutEmptyFields),
     }
   } catch (error) {
     return {
       status: 200,
     }
   }
+}
+
+type Subscriber = Record<string, any>
+
+function filterNullFields(obj: Subscriber): Subscriber {
+  const filteredObj: Subscriber = {}
+
+  for (const key in obj) {
+    if (obj[key] !== null) {
+      if (typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
+        filteredObj[key] = filterNullFields(obj[key] as Subscriber) // Recursively filter nested objects
+      } else {
+        filteredObj[key] = obj[key]
+      }
+    }
+  }
+
+  return filteredObj
 }


### PR DESCRIPTION
full ck subscriber object includes all the fields even the empty/null ones by default. cookie value cannot be more than 4096 chars which we were exceeding on TT, resulting in subscriber cookie not being set, and users not being able to watch tutorials after subscribing.

This is a quick fix and we should investigate more deeply into whether `fullSubscriber` object is required in a cookie since this can happen again even after this is merged.

Fixes TT-341

<img src="https://media.giphy.com/media/t91fXyqEuOAM0/giphy-downsized.gif" width="200" alt="gif">