### PR TITLE
fix: deduplicate lesson progress data

### DIFF
--- a/packages/skill-lesson/trpc/routers/module-progress.ts
+++ b/packages/skill-lesson/trpc/routers/module-progress.ts
@@ -6,7 +6,7 @@ import {LessonProgress, prisma} from '@skillrecordings/database'
 import {getToken} from 'next-auth/jwt'
 import {ModuleProgressSchema} from '../../video/module-progress'
 import {getModule} from '../../lib/modules'
-import {uniqBy, sortBy, isNull} from 'lodash'
+import {uniqBy, sortBy} from 'lodash'
 
 export const moduleProgressRouter = router({
   bySlug: publicProcedure
@@ -39,8 +39,7 @@ export const moduleProgressRouter = router({
         },
       })
 
-      const sortedModuleLessonProgress =
-        sortByLessonSlugNotNull(moduleLessonProgress)
+      const sortedModuleLessonProgress = sortByUpdatedAt(moduleLessonProgress)
 
       const filteredModuleLessonProgress = uniqBy(
         sortedModuleLessonProgress,
@@ -129,6 +128,6 @@ export const moduleProgressRouter = router({
     }),
 })
 
-function sortByLessonSlugNotNull(lessons: LessonProgress[]) {
-  return sortBy(lessons, [(lesson) => isNull(lesson.lessonSlug), 'updatedAt'])
+function sortByUpdatedAt(lessons: LessonProgress[]) {
+  return sortBy(lessons, ['updatedAt']).reverse()
 }

--- a/packages/skill-lesson/trpc/routers/module-progress.ts
+++ b/packages/skill-lesson/trpc/routers/module-progress.ts
@@ -2,10 +2,11 @@ import {publicProcedure, router} from '../trpc.server'
 import {z} from 'zod'
 import {Section} from '../../schemas/section'
 import {Lesson} from '../../schemas/lesson'
-import {prisma} from '@skillrecordings/database'
+import {LessonProgress, prisma} from '@skillrecordings/database'
 import {getToken} from 'next-auth/jwt'
 import {ModuleProgressSchema} from '../../video/module-progress'
 import {getModule} from '../../lib/modules'
+import {uniqBy, sortBy, isNull} from 'lodash'
 
 export const moduleProgressRouter = router({
   bySlug: publicProcedure
@@ -38,12 +39,20 @@ export const moduleProgressRouter = router({
         },
       })
 
+      const sortedModuleLessonProgress =
+        sortByLessonSlugNotNull(moduleLessonProgress)
+
+      const filteredModuleLessonProgress = uniqBy(
+        sortedModuleLessonProgress,
+        'lessonId',
+      )
+
       const moduleProgressLessons = allModuleLessons.map((lesson: Lesson) => {
         return {
           id: lesson._id,
           slug: lesson.slug,
           lessonCompleted: Boolean(
-            moduleLessonProgress.find(
+            filteredModuleLessonProgress.find(
               (progress) =>
                 progress.lessonId === lesson._id && progress.completedAt,
             ),
@@ -119,3 +128,7 @@ export const moduleProgressRouter = router({
       })
     }),
 })
+
+function sortByLessonSlugNotNull(lessons: LessonProgress[]) {
+  return sortBy(lessons, [(lesson) => isNull(lesson.lessonSlug), 'updatedAt'])
+}


### PR DESCRIPTION
fixes #1116 

Linear issue: https://linear.app/skillrecordings/issue/TT-342/app-should-gracefully-handle-duplicate-lessonprogress-records

<img src="https://media.giphy.com/media/xBIuPT5pjvarJZXyBw/giphy-downsized.gif" width="200" alt="gif">