### PR TITLE
feat(commerce): multi-purchase fixed discount

### DIFF
--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -3,6 +3,7 @@ import {Context, defaultContext, getSdk} from '@skillrecordings/database'
 import type {Purchase, Product} from '@skillrecordings/database'
 import {FormattedPrice} from './@types'
 import isEmpty from 'lodash/isEmpty'
+import sum from 'lodash/sum'
 import {determineCouponToApply} from './determine-coupon-to-apply'
 
 // 10% premium for an upgrade
@@ -29,6 +30,35 @@ type FormatPricesForProductOptions = {
   ctx?: Context
   upgradeFromPurchaseId?: string
   userId?: string
+}
+
+async function getChainOfPurchases({
+  purchase,
+  ctx,
+}: {
+  purchase: Purchase | null
+  ctx: Context
+}): Promise<Purchase[]> {
+  if (purchase === null) {
+    return []
+  } else {
+    const {getPurchase} = getSdk({ctx})
+    const {upgradedFromId} = purchase
+
+    const purchaseThisWasUpgradedFrom = upgradedFromId
+      ? await getPurchase({
+          where: {id: upgradedFromId},
+        })
+      : null
+
+    return [
+      purchase,
+      ...(await getChainOfPurchases({
+        purchase: purchaseThisWasUpgradedFrom,
+        ctx,
+      })),
+    ]
+  }
 }
 
 export async function getFixedDiscountForIndividualUpgrade({
@@ -58,7 +88,12 @@ export async function getFixedDiscountForIndividualUpgrade({
   // `productId` with the Product To Be Purchased, then this is a PPP
   // upgrade, so use the purchase amount.
   if (transitioningToUnrestrictedAccess) {
-    return purchaseToBeUpgraded.totalAmount.toNumber()
+    const purchaseChain = await getChainOfPurchases({
+      purchase: purchaseToBeUpgraded,
+      ctx,
+    })
+
+    return sum(purchaseChain.map((purchase) => purchase.totalAmount.toNumber()))
   }
 
   // if Purchase To Be Upgraded is upgradeable to the Product To Be Purchased,
@@ -123,6 +158,7 @@ export async function formatPricesForProduct(
           totalAmount: true,
           productId: true,
           status: true,
+          upgradedFromId: true,
         },
       })
     : null


### PR DESCRIPTION
When we compute the fixed discount for a PPP to Unrestricted upgrade, we
have been assuming that the _Purchase to be Upgraded_ is the only
purchase. However, it is possible that someone purchase Core(PPP), then
purchased an upgrade to Bundle(PPP), and now wants to upgrade to
Unrestricted Bundle. In that case, we need to get the _amount paid_ for
each of the purchases in the chain of purchases when computing the fixed
discount, otherwise we are overcharging the user.

### Before

![image](https://github.com/skillrecordings/products/assets/694063/a9882fd2-3cf8-41e7-8011-3a252db7965a)


### After

![CleanShot 2023-08-22 at 12 54 15@2x](https://github.com/skillrecordings/products/assets/694063/8bf7d0ef-97bc-4c68-bd8b-77deaf4d5be1)

![severance](https://media4.giphy.com/media/XjDZoIXRpaJjZY6VFI/giphy.gif?cid=d1fd59abbrxor0hudyat0xi468507ixe33jqd3lnvvl0bfev&ep=v1_gifs_search&rid=giphy.gif&ct=g)
