### PR TITLE
fix(commerce): display correct Applied Credit amt

### DIFF
--- a/packages/commerce-server/src/@types/index.ts
+++ b/packages/commerce-server/src/@types/index.ts
@@ -20,6 +20,7 @@ export type FormattedPrice = {
   quantity: number
   unitPrice: number
   fullPrice: number
+  fixedDiscountForUpgrade: number
   calculatedPrice: number
   availableCoupons: Array<
     Omit<MerchantCouponWithCountry, 'identifier'> | undefined

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -238,6 +238,7 @@ export async function formatPricesForProduct(
     quantity,
     unitPrice,
     fullPrice,
+    fixedDiscountForUpgrade,
     calculatedPrice: getCalculatedPrice({
       unitPrice,
       percentOfDiscount,

--- a/packages/skill-lesson/path-to-purchase/pricing.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing.tsx
@@ -162,9 +162,7 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
     }
   }
 
-  const upgradedProductPrice = formattedPrice?.upgradedProduct
-    ? getUnitPrice(formattedPrice)
-    : 0
+  const fixedDiscount = formattedPrice?.fixedDiscountForUpgrade || 0
 
   const [isBuyingMoreSeats, setIsBuyingMoreSeats] = React.useState(false)
 
@@ -207,10 +205,10 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
               )}
               {formattedPrice?.upgradeFromPurchaseId &&
                 !isRestrictedUpgrade &&
-                upgradedProductPrice > 0 && (
+                fixedDiscount > 0 && (
                   <div data-byline="">
-                    {`${formatUsd(upgradedProductPrice).dollars}.${
-                      formatUsd(upgradedProductPrice).cents
+                    {`${formatUsd(fixedDiscount).dollars}.${
+                      formatUsd(fixedDiscount).cents
                     } credit applied`}
                   </div>
                 )}


### PR DESCRIPTION
The `fixedDiscount` value that is computed in the price formatter
is the value we want to be displaying when there is a 'credit applied',
so this now passes that value along. Before we were only display an
applied credit based on the unit price of the purchase which doesn't
factor in PPP.

## Before

![image](https://github.com/skillrecordings/products/assets/694063/2f69a131-5c24-430a-9927-e4b69d83d971)


## Applied Credit for a standard purchase upgrade

![CleanShot 2023-08-22 at 16 52 23@2x](https://github.com/skillrecordings/products/assets/694063/9f52fd53-8c73-4dc9-bdbf-a1bb65ead137)


## Applied Credit for a PPP purchase upgrade

![CleanShot 2023-08-22 at 16 55 44@2x](https://github.com/skillrecordings/products/assets/694063/c5a82938-e289-4acc-855d-d13f42e9c169)

![severance](https://media0.giphy.com/media/q29OEyEuQErokpS4xE/giphy.gif?cid=d1fd59abbrxor0hudyat0xi468507ixe33jqd3lnvvl0bfev&ep=v1_gifs_search&rid=giphy.gif&ct=g)