### PR TITLE
feat(tjs): display duration of Modules/Lessons

### DIFF
--- a/apps/testing-javascript/src/@types/index.ts
+++ b/apps/testing-javascript/src/@types/index.ts
@@ -1,6 +1,18 @@
 import {StaticImageData} from 'next/legacy/image'
 import type {PortableTextBlock} from '@portabletext/types'
 import {DefaultCoupon} from '@skillrecordings/commerce-server/dist/@types'
+import type {Module as ModuleWithoutDuration} from '@skillrecordings/skill-lesson/schemas/module'
+
+// https://www.totaltypescript.com/concepts/the-prettify-helper
+type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
+export type Module = Prettify<
+  ModuleWithoutDuration & {
+    durationInSeconds: string
+  }
+>
 
 export type Contributor = {
   name: string

--- a/apps/testing-javascript/src/components/playlist/playlist-item.tsx
+++ b/apps/testing-javascript/src/components/playlist/playlist-item.tsx
@@ -12,6 +12,7 @@ import {track} from '@skillrecordings/skill-lesson/utils/analytics'
 
 import Icon from 'components/icons'
 import {useModuleProgress} from 'utils/module-progress'
+import {secondsToFormattedTime} from 'lib/secondsToFormattedTime'
 
 const PlaylistItem: React.FC<{
   playlist: SanityDocument
@@ -146,16 +147,20 @@ const PlaylistItem: React.FC<{
               </div>
             </>
           )}
-          <div className="space-x-1 sm:space-x-2 flex items-center text-base">
-            <Icon
-              name="duration"
-              className="w-[18px] h-[18px] sm:w-[20px] sm:h-[20px]"
-            />
-            <span>
-              Xh XXm{' '}
-              <span className="hidden lg:inline">of learning material</span>
-            </span>
-          </div>
+          {playlist.durationInSeconds && (
+            <div className="space-x-1 sm:space-x-2 flex items-center text-base">
+              <Icon
+                name="duration"
+                className="w-[18px] h-[18px] sm:w-[20px] sm:h-[20px]"
+              />
+              <span>
+                {secondsToFormattedTime(
+                  Number.parseInt(playlist.durationInSeconds),
+                )}{' '}
+                <span className="hidden lg:inline">of learning material</span>
+              </span>
+            </div>
+          )}
         </div>
         {purchased && (
           <Link

--- a/apps/testing-javascript/src/lib/lessons.ts
+++ b/apps/testing-javascript/src/lib/lessons.ts
@@ -20,8 +20,11 @@ export const getLesson = async (
         title
       },
       "stackblitz": resources[@._type == 'stackblitz'][0].openFile,
-      "videoResourceId": resources[@->._type == 'videoResource'][0]->_id,
-      "transcript": resources[@->._type == 'videoResource'][0]-> castingwords.transcript,
+      ...resources[@->._type == 'videoResource'][0]-> {
+        "videoResourceId": _id,
+        "durationInSeconds": duration,
+        "transcript": castingwords.transcript
+      },
       "solution": resources[@._type == 'solution'][0]{
         _key,
         _type,
@@ -57,7 +60,10 @@ export const getAllLessons = async (): Promise<any[]> => {
       body,
       "slug": slug.current,
       "stackblitz": resources[@._type == 'stackblitz'][0].openFile,
-      "videoResourceId": resources[@->._type == 'videoResource'][0],
+      ...resources[@->._type == 'videoResource'][0]-> {
+        "videoResourceId": _id,
+        "durationInSeconds": duration
+      },
       "solution": resources[@._type == 'solution'][0]{
         _key,
         _type,
@@ -73,5 +79,3 @@ export const getAllLessons = async (): Promise<any[]> => {
 
   return lessons
 }
-
-// ['exercise', 'explainer', 'interview']

--- a/apps/testing-javascript/src/lib/playlists.ts
+++ b/apps/testing-javascript/src/lib/playlists.ts
@@ -10,6 +10,7 @@ const workshopsQuery = groq`*[_type == "module" && moduleType == 'workshop'] | o
   _updatedAt,
   _createdAt,
   description,
+  'durationInSeconds': duration,
   state,
   body,
   preview,
@@ -51,6 +52,7 @@ export const getPlaylist = async (slug: string) =>
         title,
         state,
         slug,
+        "durationInSeconds": duration,
         body[]{
           ...,
           _type == "bodyTestimonial" => {
@@ -92,6 +94,7 @@ export const getPlaylist = async (slug: string) =>
             title,
             description,
             body,
+            "durationInSeconds": resources[@->._type == 'videoResource'][0]->duration,
             "slug": slug.current,
             "solution": resources[@._type == 'solution'][0]{
               _key,

--- a/apps/testing-javascript/src/lib/secondsToFormattedTime.ts
+++ b/apps/testing-javascript/src/lib/secondsToFormattedTime.ts
@@ -1,0 +1,20 @@
+type Options = {resolveToSeconds: boolean}
+
+export function secondsToFormattedTime(
+  seconds: number,
+  options?: Options,
+): string {
+  const {resolveToSeconds = false} = options || {}
+
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const remainingSeconds = seconds % 60
+
+  const secondsDisplay = resolveToSeconds ? ` ${remainingSeconds}s` : ''
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m${secondsDisplay}`
+  } else {
+    return `${minutes}m${secondsDisplay}`
+  }
+}

--- a/apps/testing-javascript/src/pages/playlists/[module].tsx
+++ b/apps/testing-javascript/src/pages/playlists/[module].tsx
@@ -1,11 +1,10 @@
 import * as React from 'react'
 import {GetStaticPaths, GetStaticProps} from 'next'
-import {type User} from '@skillrecordings/database'
-import {type Module} from '@skillrecordings/skill-lesson/schemas/module'
 
 import {getPlaylist, getAllPlaylists} from 'lib/playlists'
 import {ModuleProgressProvider} from 'utils/module-progress'
 import WorkshopTemplate from 'templates/workshop-template'
+import {Module} from '@types'
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
   const workshop = await getPlaylist(params?.module as string)

--- a/apps/testing-javascript/src/templates/workshop-template.tsx
+++ b/apps/testing-javascript/src/templates/workshop-template.tsx
@@ -2,18 +2,18 @@ import React from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import {PortableText} from '@portabletext/react'
-import type {User} from '@skillrecordings/database'
-import type {Module} from '@skillrecordings/skill-lesson/schemas/module'
 
 import {useModuleProgress} from 'utils/module-progress'
 import Layout from 'components/layout'
 import Icon from 'components/icons'
+import {secondsToFormattedTime} from 'lib/secondsToFormattedTime'
+import {Module} from '@types'
 
 const LessonItem: React.FC<{lesson: any; index: number}> = ({
   lesson,
   index,
 }) => {
-  const {title, slug, body} = lesson
+  const {title, slug, body, durationInSeconds} = lesson
   const moduleProgress = useModuleProgress()
   const isLessonCompleted = moduleProgress?.lessons.find(
     (progressLesson) =>
@@ -45,10 +45,16 @@ const LessonItem: React.FC<{lesson: any; index: number}> = ({
           <Icon name="play" className="w-[10px] h-[10px]" />
           <span>{isLessonCompleted ? 'Rewatch Lesson' : 'Watch Lesson'}</span>
         </Link>
-        <div className="space-x-2 flex items-center text-base">
-          <Icon name="duration" className="w-5 h-5 text-gray-400" />
-          <span>XXm</span>
-        </div>
+        {durationInSeconds && (
+          <div className="space-x-2 flex items-center text-base">
+            <Icon name="duration" className="w-5 h-5 text-gray-400" />
+            <span>
+              {secondsToFormattedTime(Number.parseInt(durationInSeconds), {
+                resolveToSeconds: true,
+              })}
+            </span>
+          </div>
+        )}
       </div>
     </li>
   )
@@ -89,10 +95,17 @@ const WorkshopTemplate: React.FC<{
                   {workshop?.sections?.[0]?.lessons?.length} video lessons
                 </span>
               </div>
-              <div className="space-x-2 flex items-center text-base">
-                <Icon name="duration" className="w-[22px] h-[22px]" />
-                <span>Xh XXm of learning material</span>
-              </div>
+              {workshop.durationInSeconds && (
+                <div className="space-x-2 flex items-center text-base">
+                  <Icon name="duration" className="w-[22px] h-[22px]" />
+                  <span>
+                    {secondsToFormattedTime(
+                      Number.parseInt(workshop.durationInSeconds),
+                    )}{' '}
+                    of learning material
+                  </span>
+                </div>
+              )}
             </div>
             <Link
               href={


### PR DESCRIPTION
Use values now available in Sanity along with time-formatting helper to display Module and Lesson duration throughout the site.

@DrShpongle should the Lesson duration also show in the individual lesson page itself?

### Homepage

![CleanShot 2023-08-28 at 08 45 32@2x](https://github.com/skillrecordings/products/assets/694063/cde734ef-2d20-4022-8d61-b327f957a9f8)

### Module Page

![CleanShot 2023-08-28 at 08 46 33@2x](https://github.com/skillrecordings/products/assets/694063/21a079c1-1850-4588-8566-dc9ee1079e24)

![CleanShot 2023-08-28 at 08 46 15@2x](https://github.com/skillrecordings/products/assets/694063/2ad4a994-39d5-479c-b19f-a1e1e6fc8661)


![module](https://media4.giphy.com/media/k1g9hVriuo6Hs4Ty9I/giphy.gif?cid=d1fd59abs7xcd4icjx1sxk8ov50s4l75go3yvxfddguzi8k0&ep=v1_gifs_search&rid=giphy.gif&ct=g)