### PR TITLE
PPP checkbox shouldnt show when bundle ppp discount is auto-applied

### DIFF
--- a/packages/commerce-server/src/determine-coupon-to-apply.ts
+++ b/packages/commerce-server/src/determine-coupon-to-apply.ts
@@ -16,6 +16,7 @@ const DetermineCouponToApplyParamsSchema = z.object({
   userId: z.string().optional(),
   productId: z.string(),
   purchaseToBeUpgraded: PurchaseSchema.nullable(),
+  autoApplyPPP: z.boolean(),
 })
 
 type DetermineCouponToApplyParams = z.infer<
@@ -38,6 +39,7 @@ export const determineCouponToApply = async (
     userId,
     productId,
     purchaseToBeUpgraded,
+    autoApplyPPP,
   } = DetermineCouponToApplyParamsSchema.parse(params)
   // TODO: What are the lookups and logic checks we can
   // skip when there is no appliedMerchantCouponId?
@@ -64,6 +66,7 @@ export const determineCouponToApply = async (
     quantity,
     purchaseToBeUpgraded,
     userPurchases,
+    autoApplyPPP,
     prismaCtx,
   })
 
@@ -127,6 +130,7 @@ const GetPPPDetailsParamsSchema = z.object({
   country: z.string(),
   purchaseToBeUpgraded: PurchaseSchema.nullable(),
   userPurchases: UserPurchasesSchema,
+  autoApplyPPP: z.boolean(),
   prismaCtx: PrismaCtxSchema,
 })
 type GetPPPDetailsParams = z.infer<typeof GetPPPDetailsParamsSchema>
@@ -142,6 +146,7 @@ const getPPPDetails = async ({
   quantity,
   purchaseToBeUpgraded,
   userPurchases,
+  autoApplyPPP,
   prismaCtx,
 }: GetPPPDetailsParams) => {
   const hasMadeNonPPPDiscountedPurchase = userPurchases.some(
@@ -154,7 +159,8 @@ const getPPPDetails = async ({
   const shouldLookupPPPMerchantCouponForUpgrade =
     appliedMerchantCoupon === null &&
     purchaseToBeUpgraded !== null &&
-    hasOnlyPPPDiscountedPurchases
+    hasOnlyPPPDiscountedPurchases &&
+    autoApplyPPP
 
   let pppMerchantCouponForUpgrade: MerchantCoupon | null = null
   if (shouldLookupPPPMerchantCouponForUpgrade) {

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -30,6 +30,7 @@ type FormatPricesForProductOptions = {
   ctx?: Context
   upgradeFromPurchaseId?: string
   userId?: string
+  autoApplyPPP?: boolean
 }
 
 async function getChainOfPurchases({
@@ -138,6 +139,7 @@ export async function formatPricesForProduct(
     merchantCouponId,
     upgradeFromPurchaseId,
     userId,
+    autoApplyPPP = true,
   } = noContextOptions
 
   const {getProduct, getPrice, getPurchase} = getSdk({ctx})
@@ -200,6 +202,7 @@ export async function formatPricesForProduct(
       userId,
       productId: product.id,
       purchaseToBeUpgraded: upgradeFromPurchase,
+      autoApplyPPP,
     })
 
   const fireFixedDiscountForIndividualUpgrade = async () => {

--- a/packages/skill-api/src/core/services/load-prices.ts
+++ b/packages/skill-api/src/core/services/load-prices.ts
@@ -17,6 +17,7 @@ type OptionsForFormatPrices = {
   merchantCouponId?: string
   upgradeFromPurchaseId?: string
   purchases: Purchase[]
+  autoApplyPPP: boolean
 }
 
 export const formatPrices = async (options: OptionsForFormatPrices) => {
@@ -29,6 +30,7 @@ export const formatPrices = async (options: OptionsForFormatPrices) => {
     merchantCouponId,
     upgradeFromPurchaseId: _upgradeFromPurchaseId,
     purchases,
+    autoApplyPPP = true,
   } = options
 
   const {availableUpgradesForProduct} = getSdk()
@@ -71,6 +73,7 @@ export const formatPrices = async (options: OptionsForFormatPrices) => {
     merchantCouponId: activeMerchantCoupon?.id,
     ...(upgradeFromPurchaseId && {upgradeFromPurchaseId}),
     userId,
+    autoApplyPPP,
   })
 
   return {product, defaultCoupon}
@@ -87,6 +90,12 @@ export async function loadPrices({
 
     const country = (req.headers['x-vercel-ip-country'] as string) || 'US'
 
+    // coerce `autoApplyPPP` to true unless it is explicitly false
+    const autoApplyPPP =
+      req.body.autoApplyPPP === false || req.body.autoApplyPPP === 'false'
+        ? false
+        : true
+
     const options: OptionsForFormatPrices = {
       userId,
       country,
@@ -96,6 +105,7 @@ export async function loadPrices({
       merchantCouponId: req.body.merchantCouponId,
       siteCouponId: req.body.siteCouponId,
       upgradeFromPurchaseId: req.body.upgradeFromPurchaseId,
+      autoApplyPPP,
     }
 
     const {product, defaultCoupon} = await formatPrices(options)

--- a/packages/skill-lesson/path-to-purchase/pricing.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing.tsx
@@ -436,6 +436,7 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
               setMerchantCoupon={setMerchantCoupon}
               index={index}
               setAutoApplyPPP={setAutoApplyPPP}
+              purchaseToUpgradeExists={Boolean(purchaseToUpgrade)}
             />
           )}
           <div data-pricing-footer="">
@@ -653,6 +654,7 @@ type RegionalPricingBoxProps = {
   setMerchantCoupon: (coupon: any) => void
   index: number
   setAutoApplyPPP: (apply: boolean) => void
+  purchaseToUpgradeExists: boolean
 }
 
 const RegionalPricingBox: React.FC<
@@ -663,6 +665,7 @@ const RegionalPricingBox: React.FC<
   setMerchantCoupon,
   index,
   setAutoApplyPPP,
+  purchaseToUpgradeExists,
 }) => {
   const regionNames = new Intl.DisplayNames(['en'], {type: 'region'})
 
@@ -677,6 +680,10 @@ const RegionalPricingBox: React.FC<
     availablePPPCoupon.percentageDiscount,
   )
   const percentOff = Math.floor(percentageDiscount * 100)
+
+  // if we are upgrading a Core(PPP) to a Bundle(PPP) and the PPP coupon is
+  // valid and auto-applied then we hide the checkbox to reduce confusion.
+  const hideCheckbox = purchaseToUpgradeExists
 
   return (
     <div data-ppp-container={index}>
@@ -694,23 +701,25 @@ const RegionalPricingBox: React.FC<
           Please note that you will only be able to view content from within{' '}
           {country}, and no bonuses will be provided.
         </p>
-        <p>If that is something that you need:</p>
+        {!hideCheckbox && <p>If that is something that you need:</p>}
       </div>
-      <label>
-        <input
-          type="checkbox"
-          checked={Boolean(appliedPPPCoupon)}
-          onChange={() => {
-            setAutoApplyPPP(false)
-            if (appliedPPPCoupon) {
-              setMerchantCoupon(undefined)
-            } else {
-              setMerchantCoupon(availablePPPCoupon as any)
-            }
-          }}
-        />
-        <span>Activate {percentOff}% off with regional pricing</span>
-      </label>
+      {!hideCheckbox && (
+        <label>
+          <input
+            type="checkbox"
+            checked={Boolean(appliedPPPCoupon)}
+            onChange={() => {
+              setAutoApplyPPP(false)
+              if (appliedPPPCoupon) {
+                setMerchantCoupon(undefined)
+              } else {
+                setMerchantCoupon(availablePPPCoupon as any)
+              }
+            }}
+          />
+          <span>Activate {percentOff}% off with regional pricing</span>
+        </label>
+      )}
     </div>
   )
 }

--- a/packages/skill-lesson/path-to-purchase/pricing.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing.tsx
@@ -12,7 +12,7 @@ import SaleCountdown from './sale-countdown'
 import Spinner from '../spinner'
 import Image from 'next/legacy/image'
 import find from 'lodash/find'
-import {type Purchase} from '@skillrecordings/database'
+import {Decimal, type Purchase} from '@skillrecordings/database'
 import ReactMarkdown from 'react-markdown'
 import {isSellingLive} from '../utils/is-selling-live'
 import {MailIcon} from '@heroicons/react/solid'
@@ -32,6 +32,20 @@ import BuyMoreSeats from '../team/buy-more-seats'
 import first from 'lodash/first'
 import {AnimatePresence, motion} from 'framer-motion'
 import {buildStripeCheckoutPath} from '../utils/build-stripe-checkout-path'
+
+const getNumericValue = (
+  value: string | number | Decimal | undefined,
+): number => {
+  if (typeof value === 'string') {
+    return Number(value)
+  } else if (typeof value === 'number') {
+    return value
+  } else if (typeof value?.toNumber === 'function') {
+    return value.toNumber()
+  } else {
+    return 0
+  }
+}
 
 type PricingProps = {
   product: SanityProduct
@@ -117,7 +131,12 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
     appliedMerchantCoupon &&
     appliedMerchantCoupon.type !== 'ppp'
 
-  const pppCoupon = getFirstPPPCoupon(formattedPrice?.availableCoupons)
+  type AvailableCoupon = NonNullable<
+    typeof formattedPrice
+  >['availableCoupons'][0]
+  const pppCoupon = getFirstPPPCoupon<AvailableCoupon>(
+    formattedPrice?.availableCoupons,
+  )
 
   // if there is no available coupon, hide the box (it's not a toggle)
   // only show the box if ppp coupon is available
@@ -151,15 +170,7 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
 
   function getUnitPrice(formattedPrice: FormattedPrice) {
     const price = first(formattedPrice?.upgradedProduct?.prices)
-    if (typeof price?.unitAmount === 'string') {
-      return Number(price?.unitAmount)
-    } else if (typeof price?.unitAmount === 'number') {
-      return price?.unitAmount
-    } else if (typeof price?.unitAmount?.toNumber === 'function') {
-      return price?.unitAmount?.toNumber()
-    } else {
-      return 0
-    }
+    return getNumericValue(price?.unitAmount)
   }
 
   const fixedDiscount = formattedPrice?.fixedDiscountForUpgrade || 0
@@ -415,7 +426,7 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
           {showPPPBox && !canViewRegionRestriction && (
             <RegionalPricingBox
               isPPPEnabled={isPPPEnabled}
-              pppCoupon={pppCoupon || merchantCoupon}
+              pppCoupon={pppCoupon || merchantCoupon || null}
               merchantCoupon={merchantCoupon}
               setMerchantCoupon={setMerchantCoupon}
               index={index}
@@ -629,9 +640,9 @@ export const PriceDisplay = ({status, formattedPrice}: PriceDisplayProps) => {
 
 type RegionalPricingBoxProps = {
   pppCoupon: {
-    country: string
-    percentageDiscount: number
-  }
+    country?: string | undefined
+    percentageDiscount: number | Decimal
+  } | null
   merchantCoupon: any
   setMerchantCoupon: (coupon: any) => void
   index: number
@@ -654,14 +665,15 @@ const RegionalPricingBox: React.FC<
     }
   }, [isPPPEnabled, pppCoupon, setMerchantCoupon])
 
-  if (!pppCoupon.country) {
+  if (!pppCoupon?.country) {
     console.error('No country found for PPP coupon', {pppCoupon})
     return null
   }
 
   const countryCode = pppCoupon.country
   const country = regionNames.of(countryCode)
-  const percentOff = Math.floor(pppCoupon.percentageDiscount * 100)
+  const percentageDiscount = getNumericValue(pppCoupon.percentageDiscount)
+  const percentOff = Math.floor(percentageDiscount * 100)
 
   return (
     <div data-ppp-container={index}>
@@ -730,8 +742,10 @@ const SubscribeForm = ({
   )
 }
 
-export function getFirstPPPCoupon(availableCoupons: any[] = []) {
-  return find(availableCoupons, (coupon) => coupon.type === 'ppp') || false
+export function getFirstPPPCoupon<T extends {type: string | null} | undefined>(
+  availableCoupons: T[] = [],
+) {
+  return find<T>(availableCoupons, (coupon) => coupon?.type === 'ppp') || null
 }
 
 export const formatUsd = (amount: number = 0) => {

--- a/packages/skill-lesson/trpc/routers/pricing.ts
+++ b/packages/skill-lesson/trpc/routers/pricing.ts
@@ -22,6 +22,7 @@ const PricingFormattedInputSchema = z.object({
   couponId: z.string().optional(),
   merchantCoupon: merchantCouponSchema.optional(),
   upgradeFromPurchaseId: z.string().optional(),
+  autoApplyPPP: z.boolean().default(true),
 })
 
 const checkForAnyAvailableUpgrades = async ({
@@ -140,6 +141,7 @@ export const pricing = router({
         couponId,
         merchantCoupon,
         upgradeFromPurchaseId: _upgradeFromPurchaseId,
+        autoApplyPPP,
       } = input
 
       const token = await getToken({req: ctx.req})
@@ -193,6 +195,7 @@ export const pricing = router({
         merchantCouponId: activeMerchantCoupon?.id,
         ...(upgradeFromPurchaseId && {upgradeFromPurchaseId}),
         userId: verifiedUserId,
+        autoApplyPPP,
       })
 
       const formattedPrice = {


### PR DESCRIPTION
This PR takes advantage of the work done in #1117 to know whether PPP is being applied and if we should show or hide the checkbox.

This PR still includes the work done to make the Price Formatter configurable. The call site can request PPP to be not be auto-applied if it would like (test included), though we choose to always auto-apply for now.

Here is a screenshot of upgrading from Core(PPP) to Bundle(PPP). The PPP discount is auto-applied and the checkbox is hidden.

![CleanShot 2023-08-28 at 11 07 30@2x](https://github.com/skillrecordings/products/assets/694063/888f6231-43c8-4377-b761-3d497abe97e4)

![ronco](https://media0.giphy.com/media/QX18dKlUSYerVhXzOy/giphy.gif?cid=d1fd59abwtfr0k1gpdjh9cobbuqozh99v2dk4q958s4j73uv&ep=v1_gifs_search&rid=giphy.gif&ct=g)