### PR TITLE
feat(tjs): include intro Mux playback ID w/ GROQ

### DIFF
--- a/apps/testing-javascript/src/components/playlist/playlist-item.tsx
+++ b/apps/testing-javascript/src/components/playlist/playlist-item.tsx
@@ -57,7 +57,7 @@ const PlaylistItem: React.FC<{
             <Dialog.Content className="fixed left-1/2 top-1/2 z-40 w-full -translate-x-1/2 -translate-y-1/2 container max-w-6xl">
               <MuxPlayer
                 streamType="on-demand"
-                playbackId="lZ7JLEsycJZ1hi9D02NlGo701t2IILWuXssviaT9fy8u8"
+                playbackId={playlist.introPlaybackId}
               />
               <Dialog.Close className="absolute right-7 -top-14 rounded-full px-3 py-1 space-x-2 flex items-center bg-gray-100 hover:bg-white duration-200">
                 <span>close</span>

--- a/apps/testing-javascript/src/lib/playlists.ts
+++ b/apps/testing-javascript/src/lib/playlists.ts
@@ -14,6 +14,9 @@ const workshopsQuery = groq`*[_type == "module" && moduleType == 'workshop'] | o
   state,
   body,
   preview,
+  "introPlaybackId": resources[@->._type == 'section'][0]->resources[@->._type in ['exercise', 'explainer']][0]->resources[@->._type == 'videoResource'][0]->{
+    "muxPlaybackId": muxAsset.muxPlaybackId,
+  }.muxPlaybackId,
   "sections": resources[@->._type == 'section']->{
     _id,
     _type,


### PR DESCRIPTION
The groq query that fetches all the playlists for the homepage should
include the Mux playback ID for each of the module intros so that inline
preview players can show those to unauth'd users.

This is instead of having the Backend module's Mux playback ID hardcoded for all of these.

![CleanShot 2023-09-06 at 15 07 11@2x](https://github.com/skillrecordings/products/assets/694063/c485276b-acfb-473f-b493-d34cb056ca53)


![adam scott](https://media0.giphy.com/media/RmjYu4f8reOBUZtTE9/giphy.gif?cid=d1fd59abd14tg2epjweng0x7vfuj4kvplotk58b5365ov5qm&ep=v1_gifs_search&rid=giphy.gif&ct=g)
