### PR TITLE
feat(tjs): use original video for mux intro upload

### DIFF
--- a/apps/testing-javascript/src/templates/landing-template.tsx
+++ b/apps/testing-javascript/src/templates/landing-template.tsx
@@ -80,7 +80,7 @@ const LandingTemplate: React.FC<LandingTemplateProps> = ({
           <div className="mt-20">
             <MuxPlayer
               streamType="on-demand"
-              playbackId="hv3g00UD00KrTt56100700PHZmZ1SWPd01Xa318p6xQ67EAA"
+              playbackId="aYqygpEcRs14JrREocaLqqrTuMY4kZKSV7DwWLJNEb00"
             />
           </div>
         </div>


### PR DESCRIPTION
The original mux upload that I did for the course intro video was not
using the highest quality original video. This changes it to a new
upload that uses the original.

![original beef](https://media2.giphy.com/media/M0AO2gfRspretF65Xq/giphy.gif?cid=d1fd59ab44rggff5qwy2wfqznsx82va9k2vnl4v1nv06f6fp&ep=v1_gifs_search&rid=giphy.gif&ct=g)