### PR TITLE
feat(tjs): add in team coupon redemption dialog

### DIFF
--- a/apps/testing-javascript/src/pages/index.tsx
+++ b/apps/testing-javascript/src/pages/index.tsx
@@ -139,17 +139,19 @@ const Home: React.FC<
 
   return (
     <Layout>
-      <LandingTemplate
-        canViewContent={canViewContent}
-        playlists={playlists}
-        testimonials={testimonials}
-        faqs={faqs}
-        interviews={interviews}
-        proTestingPurchased={proTestingPurchased}
-        commerceProps={commerceProps}
-        mostValuedProduct={mostValuedProduct}
-      />
-      {/* {redeemableCoupon ? <RedeemDialogForCoupon /> : null} */}
+      <main>
+        <LandingTemplate
+          canViewContent={canViewContent}
+          playlists={playlists}
+          testimonials={testimonials}
+          faqs={faqs}
+          interviews={interviews}
+          proTestingPurchased={proTestingPurchased}
+          commerceProps={commerceProps}
+          mostValuedProduct={mostValuedProduct}
+        />
+        {redeemableCoupon ? <RedeemDialogForCoupon /> : null}
+      </main>
     </Layout>
   )
 }

--- a/apps/testing-javascript/src/styles/globals.css
+++ b/apps/testing-javascript/src/styles/globals.css
@@ -12,6 +12,7 @@
 @import './miscellaneous.css';
 @import './team.css';
 @import './video-overlays.css';
+@import './redeem-dialog.css';
 
 @layer base {
   html {

--- a/apps/testing-javascript/src/styles/redeem-dialog.css
+++ b/apps/testing-javascript/src/styles/redeem-dialog.css
@@ -1,11 +1,11 @@
 /* Redeem dialog */
 [data-redeem-dialog-content] {
-  @apply fixed left-1/2 top-1/2 z-50 w-full max-w-[95%] -translate-x-1/2 -translate-y-1/2 rounded-md bg-gray-800 shadow-xl sm:max-w-md;
+  @apply fixed left-1/2 top-1/2 z-50 w-full max-w-[95%] -translate-x-1/2 -translate-y-1/2 rounded-md bg-white shadow-xl sm:max-w-md;
   [data-title] {
     @apply px-8 pt-8 text-xl font-bold;
   }
   [data-description] {
-    @apply border-b border-gray-700/50 px-8 pb-8 pt-4 text-gray-200;
+    @apply border-b border-gray-700/50 px-8 pb-8 pt-4 text-body;
   }
   form {
     @apply px-8 py-4;
@@ -15,7 +15,7 @@
         @apply pb-1;
       }
       input {
-        @apply rounded-sm border border-gray-800 bg-gray-900 px-4 py-2 focus-visible:border-transparent;
+        @apply rounded-sm border border-gray-800 bg-transparent px-4 py-2 focus-visible:border-transparent;
       }
     }
     [data-actions] {
@@ -27,7 +27,7 @@
         @apply bg-gray-600;
       }
       [data-submit] {
-        @apply flex rounded-sm border border-transparent bg-cyan-300 px-4 py-2 text-sm font-medium text-black shadow-sm transition focus:outline-none focus:ring-white;
+        @apply flex rounded-sm border border-transparent bg-indigo-600 hover:bg-indigo-700 px-4 py-2 text-sm font-medium text-white shadow-sm transition focus:outline-none focus:ring-white;
       }
       [data-submit]:hover {
         @apply brightness-105;

--- a/apps/testing-javascript/src/styles/redeem-dialog.css
+++ b/apps/testing-javascript/src/styles/redeem-dialog.css
@@ -2,7 +2,7 @@
 [data-redeem-dialog-content] {
   @apply fixed left-1/2 top-1/2 z-50 w-full max-w-[95%] -translate-x-1/2 -translate-y-1/2 rounded-md bg-white shadow-xl sm:max-w-md;
   [data-title] {
-    @apply px-8 pt-8 text-xl font-bold;
+    @apply px-8 pt-8 text-2xl font-bold;
   }
   [data-description] {
     @apply border-b border-gray-700/50 px-8 pb-8 pt-4 text-body;
@@ -19,15 +19,12 @@
       }
     }
     [data-actions] {
-      @apply flex w-full justify-end gap-3 py-8;
+      @apply flex w-full justify-end gap-3 pt-8 pb-4;
       [data-cancel] {
-        @apply flex rounded-sm bg-gray-700 px-4 py-2 text-sm font-medium text-gray-300;
-      }
-      [data-cancel]:hover {
-        @apply bg-gray-600;
+        @apply flex shrink-0 items-center gap-1 rounded-md px-5 py-2 text-lg font-semibold text-white transition hover:bg-gray-700 ml-3 bg-gray-600 min-w-[80px] justify-center;
       }
       [data-submit] {
-        @apply flex rounded-sm border border-transparent bg-indigo-600 hover:bg-indigo-700 px-4 py-2 text-sm font-medium text-white shadow-sm transition focus:outline-none focus:ring-white;
+        @apply flex shrink-0 items-center gap-1 rounded-md px-5 py-2 text-lg font-semibold text-white transition hover:bg-indigo-700 ml-3 bg-indigo-600 min-w-[80px] justify-center;
       }
       [data-submit]:hover {
         @apply brightness-105;

--- a/apps/testing-javascript/src/styles/redeem-dialog.css
+++ b/apps/testing-javascript/src/styles/redeem-dialog.css
@@ -33,5 +33,5 @@
   }
 }
 [data-redeem-dialog-overlay] {
-  @apply fixed inset-0 z-40 bg-black bg-opacity-30 backdrop-blur-sm;
+  @apply fixed inset-0 z-50 bg-black bg-opacity-30 backdrop-blur-sm;
 }

--- a/apps/testing-javascript/src/styles/redeem-dialog.css
+++ b/apps/testing-javascript/src/styles/redeem-dialog.css
@@ -1,0 +1,40 @@
+/* Redeem dialog */
+[data-redeem-dialog-content] {
+  @apply fixed left-1/2 top-1/2 z-50 w-full max-w-[95%] -translate-x-1/2 -translate-y-1/2 rounded-md bg-gray-800 shadow-xl sm:max-w-md;
+  [data-title] {
+    @apply px-8 pt-8 text-xl font-bold;
+  }
+  [data-description] {
+    @apply border-b border-gray-700/50 px-8 pb-8 pt-4 text-gray-200;
+  }
+  form {
+    @apply px-8 py-4;
+    [data-email] {
+      @apply mt-2 flex flex-col;
+      label {
+        @apply pb-1;
+      }
+      input {
+        @apply rounded-sm border border-gray-800 bg-gray-900 px-4 py-2 focus-visible:border-transparent;
+      }
+    }
+    [data-actions] {
+      @apply flex w-full justify-end gap-3 py-8;
+      [data-cancel] {
+        @apply flex rounded-sm bg-gray-700 px-4 py-2 text-sm font-medium text-gray-300;
+      }
+      [data-cancel]:hover {
+        @apply bg-gray-600;
+      }
+      [data-submit] {
+        @apply flex rounded-sm border border-transparent bg-cyan-300 px-4 py-2 text-sm font-medium text-black shadow-sm transition focus:outline-none focus:ring-white;
+      }
+      [data-submit]:hover {
+        @apply brightness-105;
+      }
+    }
+  }
+}
+[data-redeem-dialog-overlay] {
+  @apply fixed inset-0 z-40 bg-black bg-opacity-30 backdrop-blur-sm;
+}


### PR DESCRIPTION
*Update*: This PR is now ready to go. A new user can now redeem a team invite.

<img width="940" alt="CleanShot 2023-09-18 at 10 59 54@2x" src="https://github.com/skillrecordings/products/assets/694063/c596718e-d15e-431e-b3c9-e9fa7afab034">


---

This is a WIP. The `redeem-dialog.css` styles aren't being applied to
the radix dialog components and so the overlay and dialog are not
appearing.

To reproduce:

1. Log in as a team owner or create a team owner by making a multi-seat purchase
2. Go to the `localhost:3018/team` page and find the Invite Team link
3. Open that link in a separate browser/incognito mode
4. ... notice the dialog doesn't appear, but the overlay does take control of the page, you can't scroll

@DrShpongle any help you could provide on this would be greatly appreciated.

![dialog](https://media2.giphy.com/media/YJieN1rpUyszgcHXcZ/giphy.gif?cid=d1fd59abt8sfyo7v3ccdgd1fmuyfj5se9eji0im0966g8aif&ep=v1_gifs_search&rid=giphy.gif&ct=g)
