### PR TITLE
fix(tjs): make text visible on post-redeem page

### DIFF
--- a/apps/testing-javascript/src/pages/thanks/redeem.tsx
+++ b/apps/testing-javascript/src/pages/thanks/redeem.tsx
@@ -32,7 +32,7 @@ const ThanksRedeem: React.FC<
             Success!
           </h1>
         </div>
-        <div className="relative mx-auto flex w-full max-w-screen-md items-center justify-between gap-5 overflow-hidden rounded-xl bg-brand-red p-7 text-white shadow-2xl shadow-gray-400/20 selection:bg-white selection:text-brand-red sm:p-12">
+        <div className="relative mx-auto flex w-full max-w-screen-md items-center justify-between gap-5 overflow-hidden rounded-xl bg-brand-red p-7 text-black shadow-2xl shadow-gray-400/20 sm:p-12">
           <div className="relative z-10">
             <p className="inline-flex rounded-full bg-white px-3 py-1 font-heading text-xs font-black uppercase text-brand-red sm:text-sm">
               Final step
@@ -47,7 +47,7 @@ const ThanksRedeem: React.FC<
               <MailIcon className="h-5 w-5" />{' '}
               <strong className="font-semibold">Email sent to: {email}</strong>
             </div>
-            <p className="mx-auto text-sm font-medium leading-relaxed text-white sm:text-base">
+            <p className="mx-auto text-sm font-medium leading-relaxed text-black sm:text-base">
               As a final step to access the course you need to check your inbox
               (<strong>{email}</strong>) where you will find an email from{' '}
               <strong>{process.env.NEXT_PUBLIC_SUPPORT_EMAIL}</strong> with a


### PR DESCRIPTION
On the post-redeem page, I wasn't able to see the text. That is because it is white-on-white.

The highlighting (`selection-...`) was also behaving weirdly, so I removed those classes.

<img width="940" alt="CleanShot 2023-09-18 at 10 12 24@2x" src="https://github.com/skillrecordings/products/assets/694063/f0fe9775-172a-49b7-af77-38e0d6df557f">

![bojack](https://media2.giphy.com/media/3o7aD9hC4HyZ1ZPJgk/giphy.gif?cid=d1fd59abo687adau0w9pm4mtzweua015zbdnczmtx70u70on&ep=v1_gifs_search&rid=giphy.gif&ct=g)