### PR TITLE
feat(progress): add lessonSlug to epic-web progress API

### DIFF
--- a/apps/epic-web/src/pages/api/progress.ts
+++ b/apps/epic-web/src/pages/api/progress.ts
@@ -18,6 +18,7 @@ const lesson = async (req: NextApiRequest, res: NextApiResponse) => {
         lessonProgress.map((progress) => {
           return {
             lessonId: progress.lessonId,
+            lessonSlug: progress.lessonSlug,
             completedAt: progress.completedAt,
           }
         }),


### PR DESCRIPTION
![lesson slug](https://media3.giphy.com/media/10VvjYsRpQ5Mt2/giphy.gif?cid=ecf05e473hmi2g283pr1amx8xa8c4kplnaz2zcigoynasg4f&ep=v1_gifs_search&rid=giphy.gif&ct=g)

This is necessary because on https://gist.githubusercontent.com/joelhooks/ca912713d61ef024da520a0d2fec135c/raw/eb4bd1a4759e8447581a13ee717ee567c1aedefd/module.json we have the `solution` which does not iniclude its ID. 

I thought about adding it here: https://github.com/skillrecordings/products/blob/19a3680302e45ff686de6c521717d69ef849641b/packages/skill-lesson/lib/modules.ts#L22

But that impacts more than just epic web. I'll make a PR for that anyway and you can merge whatever you like.