### PR TITLE
jbranchaud/ew 86 allow purchase with valid coupon when selling isnt yet live

### DIFF
--- a/apps/epic-web/src/pages/buy.tsx
+++ b/apps/epic-web/src/pages/buy.tsx
@@ -29,6 +29,7 @@ const BuyPage: React.FC<React.PropsWithChildren<CommerceProps>> = ({
   products,
   couponIdFromCoupon,
   defaultCoupon,
+  allowPurchase,
 }) => {
   const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
     couponFromCode,
@@ -49,9 +50,6 @@ const BuyPage: React.FC<React.PropsWithChildren<CommerceProps>> = ({
   const purchasedProductIds = purchases.map((purchase) => purchase.productId)
 
   const router = useRouter()
-  const ALLOW_PURCHASE =
-    router.query.allowPurchase === 'true' ||
-    process.env.NEXT_PUBLIC_SELLING_LIVE === 'true'
 
   return (
     <Layout
@@ -92,7 +90,7 @@ const BuyPage: React.FC<React.PropsWithChildren<CommerceProps>> = ({
               >
                 <div data-pricing-container="" key={product.name}>
                   <Pricing
-                    allowPurchase={ALLOW_PURCHASE}
+                    allowPurchase={allowPurchase}
                     userId={userId}
                     product={product}
                     purchased={purchasedProductIds.includes(product.productId)}

--- a/apps/epic-web/src/pages/buy.tsx
+++ b/apps/epic-web/src/pages/buy.tsx
@@ -97,6 +97,7 @@ const BuyPage: React.FC<React.PropsWithChildren<CommerceProps>> = ({
                     purchases={purchases}
                     index={i}
                     couponId={couponId}
+                    couponFromCode={couponFromCode}
                   />
                 </div>
               </PriceCheckProvider>

--- a/packages/commerce-server/src/@types/index.ts
+++ b/packages/commerce-server/src/@types/index.ts
@@ -3,6 +3,7 @@ import {
   MerchantCoupon,
   Product,
   Price,
+  Coupon,
 } from '@skillrecordings/database'
 import type {PortableTextBlock} from '@portabletext/types'
 
@@ -36,9 +37,8 @@ export type FormattedPrice = {
   bulk: boolean
 }
 
-export type CouponForCode = {
+export type CouponForCode = Coupon & {
   isValid: boolean
-  id: string
   isRedeemable: boolean
 }
 

--- a/packages/skill-lesson/path-to-purchase/pricing.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing.tsx
@@ -55,6 +55,7 @@ type PricingProps = {
   userId?: string
   index?: number
   couponId?: string
+  couponFromCode?: {merchantCouponId: string | null}
   cancelUrl?: string
   allowPurchase?: boolean
   canViewRegionRestriction?: boolean
@@ -74,6 +75,7 @@ type PricingProps = {
  * @param userId - If user is logged in, this is the user's ID.
  * @param index
  * @param couponId
+ * @param couponFromCode
  * @constructor
  */
 export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
@@ -83,7 +85,8 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
   userId,
   index = 0,
   couponId,
-  allowPurchase = false,
+  couponFromCode,
+  allowPurchase: _allowPurchase = false,
   canViewRegionRestriction = false,
   cancelUrl,
   options = {withImage: true, isPPPEnabled: false, withGuaranteeBadge: true},
@@ -128,6 +131,14 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
 
   const defaultCoupon = formattedPrice?.defaultCoupon
   const appliedMerchantCoupon = formattedPrice?.appliedMerchantCoupon
+
+  const allowPurchaseAnyway = Boolean(
+    appliedMerchantCoupon &&
+      appliedMerchantCoupon.type === 'special' &&
+      appliedMerchantCoupon.id === couponFromCode?.merchantCouponId,
+  )
+
+  const allowPurchase = _allowPurchase || allowPurchaseAnyway
 
   const isRestrictedUpgrade =
     purchaseToUpgrade?.status === 'Restricted' &&


### PR DESCRIPTION
This allows purchasing with a special coupon code even if selling hasn't been turned "live". We might be able to consolidate some things to do this a little cleaner (e.g. not need to add a new prop to the `Pricing` component), but this was the best solution I could come up with for now that didn't touch too many things.

- feat(ew): allowPurchase already powered by commerce
- feat(ew): allow purchase with valid coupon code

![slow horses](https://media3.giphy.com/media/aQu2FEVFtbTzq0GJvu/giphy.gif?cid=d1fd59abqs242itv9vr6kcri3a3biiwpaeb6pd2pfhsugsbh&ep=v1_gifs_search&rid=giphy.gif&ct=g)