### PR TITLE
chore: fix foundations URL

### DIFF
--- a/apps/epic-web/src/pages/get-started/index.tsx
+++ b/apps/epic-web/src/pages/get-started/index.tsx
@@ -209,7 +209,7 @@ const WorkshopAppScreenshot = () => {
 const getDeployedUrl = (repo: string) => {
   switch (repo) {
     case 'https://github.com/epicweb-dev/full-stack-foundations':
-      return 'https://foundations.epicreact.dev'
+      return 'https://foundations.epicweb.dev'
     case 'https://github.com/epicweb-dev/web-forms':
       return 'https://forms.epicweb.dev'
     case 'https://github.com/epicweb-dev/data-modeling':


### PR DESCRIPTION
I make this mistake all the time 😅

![oops](https://media0.giphy.com/media/1Y7ChRtbWnYONjDidg/giphy.gif?cid=ecf05e470n4n4fyjm2n2ynzmg8lh01xalkb2qqp0u75z8xzb&ep=v1_gifs_search&rid=giphy.gif&ct=g)