### PR TITLE
feat(tjs): allow TJS its own products router

### DIFF
--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -30,7 +30,8 @@ const LessonTemplate = () => {
   const muxPlayerRef = React.useRef<MuxPlayerRefAttributes>(null)
   const {lesson, module} = useLesson()
   const addProgressMutation = trpc.progress.add.useMutation()
-  const {data: defaultProduct} = trpc.products.getDefaultProduct.useQuery()
+  const {data: defaultProduct} =
+    trpc['testingJavascript.products'].getDefaultProduct.useQuery()
   return (
     <VideoProvider
       muxPlayerRef={muxPlayerRef}

--- a/apps/testing-javascript/src/trpc/routers/_app.ts
+++ b/apps/testing-javascript/src/trpc/routers/_app.ts
@@ -4,10 +4,12 @@ import {
   skillLessonRouter,
 } from '@skillrecordings/skill-lesson'
 import {abilitiesRouter} from './abilities'
+import {productsRouter} from './products'
 
 export const appRouter = mergeRouters(
   router({
     abilities: abilitiesRouter,
+    'testingJavascript.products': productsRouter,
   }),
   skillLessonRouter,
 )

--- a/apps/testing-javascript/src/trpc/routers/products.ts
+++ b/apps/testing-javascript/src/trpc/routers/products.ts
@@ -1,0 +1,16 @@
+import {publicProcedure, router} from '@skillrecordings/skill-lesson'
+import {getAllProducts, getActiveProduct} from 'server/products.server'
+
+export const productsRouter = router({
+  getProducts: publicProcedure.query(async () => {
+    const products = await getAllProducts()
+
+    return products
+  }),
+  getDefaultProduct: publicProcedure.query(async () => {
+    const defaultProduct = await getActiveProduct(
+      process.env.NEXT_PUBLIC_DEFAULT_PRODUCT_ID as string,
+    )
+    return defaultProduct
+  }),
+})


### PR DESCRIPTION
The `getDefaultProduct` function uses `getActiveProduct` which is
defined in a bespoke way for TJS (grabs specific data needed from that
Sanity instance). Instead of shuffling all that into `skill-lesson`,
this adds a custom products router that doesn't collide with the one
defined in `skill-lesson`.

![collide](https://media4.giphy.com/media/10uxwQ1FLDMCzu/giphy.gif?cid=d1fd59ab45egzpuonhgu6wnaoamlavxu1ak7awp6c4tk6lic&ep=v1_gifs_search&rid=giphy.gif&ct=g)