### PR TITLE
feat(tjs): add video resource to TJS interviews

### DIFF
--- a/apps/testing-javascript/schemas/documents/interview.tsx
+++ b/apps/testing-javascript/schemas/documents/interview.tsx
@@ -56,6 +56,18 @@ export default {
         },
       ],
     },
+    {
+      name: 'resources',
+      title: 'Resources',
+      type: 'array',
+      of: [
+        {
+          title: 'Video Resource',
+          type: 'reference',
+          to: [{type: 'videoResource'}],
+        },
+      ],
+    },
   ],
   preview: {
     select: {


### PR DESCRIPTION
The Sanity schema for interviews has all the other metadata for the TJS interviews, but is missing a way to attach a `videoResource`. This adds it.

Once this is merged and deployed, I'll follow it with a script that will inject Mux-backed videos into each interview.

![interview](https://media3.giphy.com/media/6Q3M4BIK0lX44/giphy.gif?cid=d1fd59abki1uw6r3ik8ahs78grs6tu95tc9d3653jik8zcnv&ep=v1_gifs_search&rid=giphy.gif&ct=g)