### PR TITLE
feat(tjs): switch interview descriptions to text

### DIFF
--- a/apps/testing-javascript/schemas/documents/interview.tsx
+++ b/apps/testing-javascript/schemas/documents/interview.tsx
@@ -16,7 +16,7 @@ export default {
     {
       name: 'description',
       title: 'Description',
-      type: 'text',
+      type: 'markdown',
       validation: (Rule) => Rule.required(),
     },
     {

--- a/apps/testing-javascript/schemas/documents/interview.tsx
+++ b/apps/testing-javascript/schemas/documents/interview.tsx
@@ -16,7 +16,7 @@ export default {
     {
       name: 'description',
       title: 'Description',
-      type: 'body',
+      type: 'text',
       validation: (Rule) => Rule.required(),
     },
     {


### PR DESCRIPTION
The Portable Text data type is conflicting with the expectations of
parsing logic in skill-lesson (e.g. useNextLesson).

Since there are only 10 small descriptions, I am going to manually copy the text over once this schema change is merged and deployed.

![taylor](https://media4.giphy.com/media/jO2B3Llymxny6BSObJ/giphy.gif?cid=d1fd59abjyixzgz3jn8pkol66lzjh0pgi5ys56tbvuzy0fy6&ep=v1_gifs_search&rid=giphy.gif&ct=g)
