### PR TITLE
feat(tjs): allow Interview as part of Module

### DIFF
--- a/apps/testing-javascript/schemas/documents/module.jsx
+++ b/apps/testing-javascript/schemas/documents/module.jsx
@@ -63,16 +63,18 @@ export default {
     {
       name: 'resources',
       title: 'Resources',
-      description: 'Exercises, Sections, or Explainers in the Module',
+      description:
+        'Exercises, Sections, Explainers, or Interviews in the Module',
       type: 'array',
       of: [
         {
-          title: 'Exercise, Sections and Explainers',
+          title: 'Exercise, Sections, Explainers, and Interviews',
           type: 'reference',
           to: [
             {title: 'Exercise', type: 'exercise'},
             {title: 'Section', type: 'section'},
             {title: 'Explainer', type: 'explainer'},
+            {title: 'Interview', type: 'interview'},
             {type: 'linkResource'},
           ],
         },


### PR DESCRIPTION
The `skill-lesson` package expects to be able to look up a module for an
interview when it is trying to figure out the "Next Lesson". So I'm adding
`Interview` as a Resource-type so that I can create an _Expert Interviews_
module.

![inter](https://media3.giphy.com/media/X0qgWSlFfjdgtDGyCm/giphy.gif?cid=d1fd59abqb2rnzho52rxy8ayuktfgnsw6sa2dv79b4hrv9f4&ep=v1_gifs_search&rid=giphy.gif&ct=g)