### PR TITLE
feat(tjs): add code URLs to Sanity lesson schema

### DIFF
--- a/apps/testing-javascript/schemas/documents/explainer.js
+++ b/apps/testing-javascript/schemas/documents/explainer.js
@@ -72,5 +72,24 @@ export default {
       type: 'text',
       validation: (Rule) => Rule.max(160),
     },
+    {
+      name: 'github_branch_url',
+      title: 'GitHub Branch URL',
+      description: 'The branch containing code relevant to this lesson',
+      type: 'url',
+    },
+    {
+      name: 'github_diff_url',
+      title: 'GitHub Diff Url',
+      description:
+        "A diff view between the previous lesson's code and this one",
+      type: 'url',
+    },
+    {
+      name: 'codesandbox_url',
+      title: 'CodeSandbox URL',
+      description: 'An embeddable CodeSandbox example for this lesson',
+      type: 'url',
+    },
   ],
 }


### PR DESCRIPTION
TJS has three kinds of code URLs, this allows for each kind of those to
be stored. We store them independently because they are each treated a
little differently and the two github ones can both be present for the
same lesson.

![sandbox](https://media1.giphy.com/media/Cdh5kRCVW1nVcJVjZE/giphy.gif?cid=d1fd59ab1y17987y57nz6h8vncae8uriefce6cxzr3ym76ce&ep=v1_gifs_search&rid=giphy.gif&ct=g)
