### PR TITLE
Display github URLs and codesandbox embeds for TJS

### DIFF
--- a/apps/testing-javascript/src/components/lessons-sidebar.tsx
+++ b/apps/testing-javascript/src/components/lessons-sidebar.tsx
@@ -3,34 +3,6 @@ import Link from 'next/link'
 import Image from 'next/image'
 import cx from 'classnames'
 import {Element, scroller} from 'react-scroll'
-import {useRouter} from 'next/router'
-import MuxPlayer, {
-  type MuxPlayerRefAttributes,
-  type MuxPlayerProps,
-} from '@mux/mux-player-react'
-import {Video} from '@skillrecordings/skill-lesson/video/video'
-import {
-  VideoProvider,
-  useMuxPlayer,
-} from '@skillrecordings/skill-lesson/hooks/use-mux-player'
-import {useLesson} from '@skillrecordings/skill-lesson/hooks/use-lesson'
-import {useVideoResource} from '@skillrecordings/skill-lesson/hooks/use-video-resource'
-import {
-  customPlayFromBeginningHandler,
-  customContinueHandler,
-} from 'utils/custom-handlers'
-import {VideoTranscript} from '@skillrecordings/skill-lesson/video/video-transcript'
-
-import {trpc} from 'trpc/trpc.client'
-import Spinner from 'components/spinner'
-
-const LessonsSidebarItem: React.FC<any> = () => {
-  return (
-    <li>
-      <div>1</div>
-    </li>
-  )
-}
 
 type Lesson = {
   title: string

--- a/apps/testing-javascript/src/components/lessons-sidebar.tsx
+++ b/apps/testing-javascript/src/components/lessons-sidebar.tsx
@@ -32,7 +32,24 @@ const LessonsSidebarItem: React.FC<any> = () => {
   )
 }
 
-const LessonsSidebar: React.FC<any> = ({lesson, module}) => {
+type Lesson = {
+  title: string
+  slug: string
+}
+
+type Section = {
+  lessons?: Array<Lesson> | null
+}
+
+const LessonsSidebar: React.FC<{
+  lesson: {slug: string}
+  module: {
+    slug: {current?: string | null | undefined}
+    image?: string | null | undefined
+    title: string
+    sections?: Array<Section> | null
+  }
+}> = ({lesson, module}) => {
   const [activeElement, setActiveElement] = React.useState<string>(lesson.slug)
   const scrollableNodeRef: any = React.createRef()
 
@@ -48,15 +65,24 @@ const LessonsSidebar: React.FC<any> = ({lesson, module}) => {
     handlerScrollToActiveElem()
   }, [activeElement])
 
+  const lessons = module.sections?.[0]?.lessons || []
+
   return (
     <div className="flex min-h-[450px] w-full flex-col border border-black/[.08]">
       <div className="flex shrink-0 items-center border-b border-black/[.08] p-3">
-        <Link
-          href={`/playlists/${module.slug.current}`}
-          className="mr-3 h-16 w-16 shrink-0"
-        >
-          <Image src={module.image} alt="module image" width={64} height={64} />
-        </Link>
+        {module.image && (
+          <Link
+            href={`/playlists/${module.slug.current}`}
+            className="mr-3 h-16 w-16 shrink-0"
+          >
+            <Image
+              src={module.image}
+              alt="module image"
+              width={64}
+              height={64}
+            />
+          </Link>
+        )}
         <Link
           href={`/playlists/${module.slug.current}`}
           className="font-tt-demibold text-lg leading-tight"
@@ -70,7 +96,7 @@ const LessonsSidebar: React.FC<any> = ({lesson, module}) => {
           id="scroll-container"
           className="absolute inset-0 divide-y overflow-y-auto"
         >
-          {module.sections[0].lessons.map((item: any, i: number) => {
+          {lessons.map((item: Lesson, i: number) => {
             return (
               <li key={item.slug}>
                 <Element name={item.slug} />

--- a/apps/testing-javascript/src/server/lessons.server.ts
+++ b/apps/testing-javascript/src/server/lessons.server.ts
@@ -1,0 +1,30 @@
+import groq from 'groq'
+import {sanityClient} from '@skillrecordings/skill-lesson/utils/sanity-client'
+import {z} from 'zod'
+
+const getLessonCodeUrlsQuery = groq`*[_type == "explainer" && _id == $id][0]{
+  github_branch_url,
+  github_diff_url,
+  codesandbox_url
+}`
+
+export const getLessonCodeUrls = async ({_id}: {_id: string}) => {
+  const response = await sanityClient.fetch(getLessonCodeUrlsQuery, {id: _id})
+
+  return z
+    .object({
+      github_branch_url: z
+        .string()
+        .nullish()
+        .transform((x) => x ?? undefined),
+      github_diff_url: z
+        .string()
+        .nullish()
+        .transform((x) => x ?? undefined),
+      codesandbox_url: z
+        .string()
+        .nullish()
+        .transform((x) => x ?? undefined),
+    })
+    .parse(response)
+}

--- a/apps/testing-javascript/src/styles/code.css
+++ b/apps/testing-javascript/src/styles/code.css
@@ -1,0 +1,6 @@
+[data-video-code] {
+  @apply mx-auto max-w-4xl p-5 py-16;
+  [data-title] {
+    @apply flex items-baseline text-2xl font-semibold sm:text-3xl;
+  }
+}

--- a/apps/testing-javascript/src/styles/code.css
+++ b/apps/testing-javascript/src/styles/code.css
@@ -1,6 +1,6 @@
 [data-video-code] {
-  @apply mx-auto max-w-4xl p-5 py-16;
+  @apply mt-16 mb-10 lg:mb-0;
   [data-title] {
-    @apply flex items-baseline text-2xl font-semibold sm:text-3xl;
+    @apply text-2xl md:text-3xl mb-8 flex space-x-2 items-center;
   }
 }

--- a/apps/testing-javascript/src/styles/globals.css
+++ b/apps/testing-javascript/src/styles/globals.css
@@ -13,6 +13,7 @@
 @import './team.css';
 @import './video-overlays.css';
 @import './redeem-dialog.css';
+@import './code.css';
 
 @layer base {
   html {

--- a/apps/testing-javascript/src/styles/miscellaneous.css
+++ b/apps/testing-javascript/src/styles/miscellaneous.css
@@ -10,6 +10,6 @@
   @apply scale-105;
 }
 
-[data-video-transcript] [data-title] {
-  @apply text-2xl md:text-3xl mb-0;
+[data-transcript-title] {
+  @apply text-2xl md:text-3xl mb-0 flex items-center space-x-2;
 }

--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -91,9 +91,24 @@ const checkIfGitHubUrlContainsBranch = (
 const CodeSandboxEmbed: React.FC<{url: string | undefined}> = ({url}) => {
   if (!url) return null
 
+  const iframeRefCallback = function iframeRefCallback(iframe: any) {
+    if (iframe) {
+      iframe.contentWindow.location.replace(url)
+    }
+  }
+
   return (
-    // render the CodeSandbox Embed
-    <div>CodeSandbox Embed</div>
+    <div>
+      <iframe
+        ref={iframeRefCallback}
+        title="Code"
+        allowTransparency={true}
+        frameBorder="0"
+        scrolling="no"
+        width="100%"
+        height="550px"
+      />
+    </div>
   )
 }
 

--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -15,6 +15,9 @@ import {trpc} from 'trpc/trpc.client'
 import Spinner from 'components/spinner'
 import LessonsSidebar from 'components/lessons-sidebar'
 import isEmpty from 'lodash/isEmpty'
+import {FaGithub} from 'react-icons/fa'
+import {IoCodeSharp} from 'react-icons/io5'
+import {CgNotes} from 'react-icons/cg'
 
 const LessonTemplate = () => {
   const router = useRouter()
@@ -55,13 +58,20 @@ const LessonTemplate = () => {
             </h2>
             {lesson.description && (
               <article className="lg:mt-8">
-                <div className="prose prose-md">{lesson.description}</div>
+                <div className="prose md:prose-md">{lesson.description}</div>
               </article>
             )}
             <Code urls={codeUrls || {}} />
-            <article className="lg:mt-8">
+            <article className="lg:mt-16">
+              <h3 data-transcript-title="">
+                <CgNotes color="#9396a4" size={20} />
+                <span>Transcript</span>
+              </h3>
               <div className="prose prose-md">
-                <VideoTranscript transcript={videoResource?.transcript || ''} />
+                <VideoTranscript
+                  transcript={videoResource?.transcript || ''}
+                  noTitle
+                />
               </div>
             </article>
           </div>
@@ -125,84 +135,33 @@ const GitHubUrls: React.FC<{
   const includesBranch = checkIfGitHubUrlContainsBranch(branchUrl)
 
   return (
-    <div>
-      <div
-      // className={css`
-      //   color: ${colorValues['gray-darken-30']};
-      //   display: flex;
-      //   align-items: flex-start;
-      //   flex-direction: column;
-      //   font-family: ${fonts.regular};
-      // `}
-      >
-        <div
-        // className={css`
-        //   display: flex;
-        //   flex-direction: row;
-        //   align-items: center;
-        //   ${bpMaxMD} {
-        //     flex-direction: column;
-        //     align-items: flex-start;
-        //   }
-        // `}
+    <div className="flex flex-col items-center md:items-start space-y-4 md:space-y-6">
+      <div className="flex items-center flex-col md:flex-row">
+        <a
+          onClick={() => {
+            // track('clicked github link', {
+            //   lesson: lessonSlug,
+            // })
+          }}
+          href={branchUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center space-x-3 bg-[#141618] text-white px-[1.3rem] py-4 text-xl leading-none rounded-md duration-200 hover:shadow-[0_20px_50px_-10px_rgba(0,0,0,0.2)]"
         >
-          <a
-            onClick={() => {
-              // track('clicked github link', {
-              //   lesson: lessonSlug,
-              // })
-            }}
-            href={branchUrl}
-            // className={css`
-            //   background-color: #141618;
-            //   color: white;
-            //   display: flex;
-            //   font-size: 20px;
-            //   align-items: center;
-            //   text-decoration: none;
-            //   padding: 1rem 1.3rem;
-            //   transition: 250ms all ease;
-            //   border-radius: 5px;
-            //   img {
-            //     filter: invert(1);
-            //     margin-right: 10px;
-            //     max-width: 20px;
-            //   }
-            //   &:hover {
-            //     box-shadow: 0 20px 50px -10px rgba(0, 0, 0, 0.2);
-            //     transition: 250ms all ease;
-            //   }
-            // `}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {/* GitHub Icon missing */}
-            {/* <img src={iconGithub} alt="Github" />*/} {message}
-          </a>
-          {includesBranch && (
-            <p
-            // className={css`
-            //   font-size: 18px;
-            //   padding-left: 20px;
-            //   padding-top: 0;
-            //   ${bpMaxMD} {
-            //     padding-left: 0;
-            //     padding-top: 10px;
-            //   }
-            // `}
-            >
-              The branch name corresponds to the lesson.
-            </p>
-          )}
-        </div>
+          <FaGithub />
+          <span>{message}</span>
+        </a>
+        {includesBranch && (
+          <p className="text-lg mt-3 md:mt-0 md:ml-5">
+            The branch name corresponds to the lesson.
+          </p>
+        )}
       </div>
       {!isEmpty(diffUrl) && (
-        <div
-        // css={css`
-        //   padding-bottom: 15px;
-        // `}
-        >
-          <a href={diffUrl}>View the Code Diff on Github</a>
+        <div>
+          <a href={diffUrl} className="text-blue-600 underline">
+            View the Code Diff on Github
+          </a>
         </div>
       )}
     </div>
@@ -224,7 +183,10 @@ const Code: React.FC<{
 
   return (
     <div data-video-code="">
-      <h2 data-title="">{/* code icon */} Code</h2>
+      <h3 data-title="">
+        <IoCodeSharp color="#9396a4" size={24} />
+        <span>Code</span>
+      </h3>
       <CodeSandboxEmbed url={codesandbox_url} />
       <GitHubUrls branchUrl={github_branch_url} diffUrl={github_diff_url} />
     </div>

--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -1,15 +1,8 @@
 import * as React from 'react'
-import Link from 'next/link'
 import {useRouter} from 'next/router'
-import MuxPlayer, {
-  type MuxPlayerRefAttributes,
-  type MuxPlayerProps,
-} from '@mux/mux-player-react'
+import {type MuxPlayerRefAttributes} from '@mux/mux-player-react'
 import {Video} from '@skillrecordings/skill-lesson/video/video'
-import {
-  VideoProvider,
-  useMuxPlayer,
-} from '@skillrecordings/skill-lesson/hooks/use-mux-player'
+import {VideoProvider} from '@skillrecordings/skill-lesson/hooks/use-mux-player'
 import {useLesson} from '@skillrecordings/skill-lesson/hooks/use-lesson'
 import {useVideoResource} from '@skillrecordings/skill-lesson/hooks/use-video-resource'
 import {
@@ -24,14 +17,13 @@ import LessonsSidebar from 'components/lessons-sidebar'
 
 const LessonTemplate = () => {
   const router = useRouter()
-  const {muxPlayerProps} = useMuxPlayer()
-  const {videoResource, loadingVideoResource, videoResourceId} =
-    useVideoResource()
+  const {videoResource} = useVideoResource()
   const muxPlayerRef = React.useRef<MuxPlayerRefAttributes>(null)
   const {lesson, module} = useLesson()
   const addProgressMutation = trpc.progress.add.useMutation()
   const {data: defaultProduct} =
     trpc['testingJavascript.products'].getDefaultProduct.useQuery()
+
   return (
     <VideoProvider
       muxPlayerRef={muxPlayerRef}
@@ -39,7 +31,7 @@ const LessonTemplate = () => {
       handleContinue={customContinueHandler}
       handlePlayFromBeginning={customPlayFromBeginningHandler}
     >
-      <div className="container max-w-6xl pt-4 pb-8 md:pb-12 md:pt-6 lg:pb-16">
+      <div className="container max-w-6xl pb-8 pt-4 md:pb-12 md:pt-6 lg:pb-16">
         <main className="relative mx-auto w-full items-start border-t border-transparent 2xl:flex 2xl:max-w-none 2xl:border-gray-800">
           <div className="flex flex-col border-gray-800 2xl:relative 2xl:h-full 2xl:w-full 2xl:border-r">
             <Video
@@ -50,9 +42,9 @@ const LessonTemplate = () => {
             />
           </div>
         </main>
-        <div className="flex flex-col-reverse lg:flex-row mt-12">
+        <div className="mt-12 flex flex-col-reverse lg:flex-row">
           <div className="grow">
-            <h2 className="lg:text-4xl xl:text-5xl leading-tight hidden lg:block">
+            <h2 className="hidden leading-tight lg:block lg:text-4xl xl:text-5xl">
               {lesson.title}
             </h2>
             <article className="lg:mt-8">
@@ -61,8 +53,8 @@ const LessonTemplate = () => {
               </div>
             </article>
           </div>
-          <div className="w-full lg:max-w-[350px] shrink-0 lg:ml-8">
-            <h2 className="text-3xl md:text-[2.125rem] leading-tight block lg:hidden mb-8">
+          <div className="w-full shrink-0 lg:ml-8 lg:max-w-[350px]">
+            <h2 className="mb-8 block text-3xl leading-tight md:text-[2.125rem] lg:hidden">
               {lesson.title}
             </h2>
             <LessonsSidebar lesson={lesson} module={module} />

--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -47,6 +47,11 @@ const LessonTemplate = () => {
             <h2 className="hidden leading-tight lg:block lg:text-4xl xl:text-5xl">
               {lesson.title}
             </h2>
+            {lesson.description && (
+              <article className="lg:mt-8">
+                <div className="prose prose-md">{lesson.description}</div>
+              </article>
+            )}
             <article className="lg:mt-8">
               <div className="prose prose-md">
                 <VideoTranscript transcript={videoResource?.transcript || ''} />

--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -223,8 +223,8 @@ const Code: React.FC<{
   }
 
   return (
-    <div>
-      <h2>{/* code icon */} Code</h2>
+    <div data-video-code="">
+      <h2 data-title="">{/* code icon */} Code</h2>
       <CodeSandboxEmbed url={codesandbox_url} />
       <GitHubUrls branchUrl={github_branch_url} diffUrl={github_diff_url} />
     </div>

--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -14,6 +14,7 @@ import {VideoTranscript} from '@skillrecordings/skill-lesson/video/video-transcr
 import {trpc} from 'trpc/trpc.client'
 import Spinner from 'components/spinner'
 import LessonsSidebar from 'components/lessons-sidebar'
+import isEmpty from 'lodash/isEmpty'
 
 const LessonTemplate = () => {
   const router = useRouter()
@@ -23,6 +24,11 @@ const LessonTemplate = () => {
   const addProgressMutation = trpc.progress.add.useMutation()
   const {data: defaultProduct} =
     trpc['testingJavascript.products'].getDefaultProduct.useQuery()
+  const {data: codeUrls} = trpc[
+    'testingJavascript.lessons'
+  ].getLessonCodeUrls.useQuery({
+    _id: lesson._id,
+  })
 
   return (
     <VideoProvider
@@ -52,6 +58,7 @@ const LessonTemplate = () => {
                 <div className="prose prose-md">{lesson.description}</div>
               </article>
             )}
+            <Code urls={codeUrls || {}} />
             <article className="lg:mt-8">
               <div className="prose prose-md">
                 <VideoTranscript transcript={videoResource?.transcript || ''} />
@@ -67,6 +74,145 @@ const LessonTemplate = () => {
         </div>
       </div>
     </VideoProvider>
+  )
+}
+
+const checkIfGitHubUrlContainsBranch = (
+  github_branch_url: string | undefined,
+) => {
+  if (!github_branch_url) return false
+
+  const pattern = /\/tree\/.+$/
+
+  // Test if the URL contains a branch
+  return pattern.test(github_branch_url)
+}
+
+const CodeSandboxEmbed: React.FC<{url: string | undefined}> = ({url}) => {
+  if (!url) return null
+
+  return (
+    // render the CodeSandbox Embed
+    <div>CodeSandbox Embed</div>
+  )
+}
+
+const GitHubUrls: React.FC<{
+  branchUrl: string | undefined
+  diffUrl: string | undefined
+}> = ({branchUrl, diffUrl}) => {
+  if (!branchUrl) return null
+
+  // render one or both of the GitHub URLs
+  // return <div>GitHub URLs</div>
+  const message = `Get the code on GitHub`
+
+  const includesBranch = checkIfGitHubUrlContainsBranch(branchUrl)
+
+  return (
+    <div>
+      <div
+      // className={css`
+      //   color: ${colorValues['gray-darken-30']};
+      //   display: flex;
+      //   align-items: flex-start;
+      //   flex-direction: column;
+      //   font-family: ${fonts.regular};
+      // `}
+      >
+        <div
+        // className={css`
+        //   display: flex;
+        //   flex-direction: row;
+        //   align-items: center;
+        //   ${bpMaxMD} {
+        //     flex-direction: column;
+        //     align-items: flex-start;
+        //   }
+        // `}
+        >
+          <a
+            onClick={() => {
+              // track('clicked github link', {
+              //   lesson: lessonSlug,
+              // })
+            }}
+            href={branchUrl}
+            // className={css`
+            //   background-color: #141618;
+            //   color: white;
+            //   display: flex;
+            //   font-size: 20px;
+            //   align-items: center;
+            //   text-decoration: none;
+            //   padding: 1rem 1.3rem;
+            //   transition: 250ms all ease;
+            //   border-radius: 5px;
+            //   img {
+            //     filter: invert(1);
+            //     margin-right: 10px;
+            //     max-width: 20px;
+            //   }
+            //   &:hover {
+            //     box-shadow: 0 20px 50px -10px rgba(0, 0, 0, 0.2);
+            //     transition: 250ms all ease;
+            //   }
+            // `}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {/* GitHub Icon missing */}
+            {/* <img src={iconGithub} alt="Github" />*/} {message}
+          </a>
+          {includesBranch && (
+            <p
+            // className={css`
+            //   font-size: 18px;
+            //   padding-left: 20px;
+            //   padding-top: 0;
+            //   ${bpMaxMD} {
+            //     padding-left: 0;
+            //     padding-top: 10px;
+            //   }
+            // `}
+            >
+              The branch name corresponds to the lesson.
+            </p>
+          )}
+        </div>
+      </div>
+      {!isEmpty(diffUrl) && (
+        <div
+        // css={css`
+        //   padding-bottom: 15px;
+        // `}
+        >
+          <a href={diffUrl}>View the Code Diff on Github</a>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const Code: React.FC<{
+  urls: {
+    github_branch_url?: string | undefined
+    github_diff_url?: string | undefined
+    codesandbox_url?: string | undefined
+  }
+}> = ({urls}) => {
+  const {codesandbox_url, github_branch_url, github_diff_url} = urls
+
+  if (isEmpty(codesandbox_url) && isEmpty(github_branch_url)) {
+    return null
+  }
+
+  return (
+    <div>
+      <h2>{/* code icon */} Code</h2>
+      <CodeSandboxEmbed url={codesandbox_url} />
+      <GitHubUrls branchUrl={github_branch_url} diffUrl={github_diff_url} />
+    </div>
   )
 }
 

--- a/apps/testing-javascript/src/trpc/routers/_app.ts
+++ b/apps/testing-javascript/src/trpc/routers/_app.ts
@@ -5,11 +5,13 @@ import {
 } from '@skillrecordings/skill-lesson'
 import {abilitiesRouter} from './abilities'
 import {productsRouter} from './products'
+import {lessonsRouter} from './lessons'
 
 export const appRouter = mergeRouters(
   router({
     abilities: abilitiesRouter,
     'testingJavascript.products': productsRouter,
+    'testingJavascript.lessons': lessonsRouter,
   }),
   skillLessonRouter,
 )

--- a/apps/testing-javascript/src/trpc/routers/lessons.ts
+++ b/apps/testing-javascript/src/trpc/routers/lessons.ts
@@ -1,0 +1,22 @@
+import {publicProcedure, router} from '@skillrecordings/skill-lesson'
+import {getLessonCodeUrls} from 'server/lessons.server'
+import {z} from 'zod'
+
+export const lessonsRouter = router({
+  getLessonCodeUrls: publicProcedure
+    .input(z.object({_id: z.string().optional()}))
+    .query(async ({input}) => {
+      const {_id} = input
+
+      if (!_id)
+        return {
+          github_branch_url: undefined,
+          github_diff_url: undefined,
+          codesandbox_url: undefined,
+        }
+
+      const codeUrls = await getLessonCodeUrls({_id})
+
+      return codeUrls
+    }),
+})

--- a/packages/skill-lesson/video/video-transcript.tsx
+++ b/packages/skill-lesson/video/video-transcript.tsx
@@ -8,7 +8,8 @@ import {getTranscriptComponents} from '../markdown/transcript-components'
 
 export const VideoTranscript: React.FC<{
   transcript: string | any[]
-}> = ({transcript}) => {
+  noTitle?: boolean
+}> = ({transcript, noTitle = false}) => {
   const {handlePlay, canShowVideo, muxPlayerRef} = useMuxPlayer()
   const transcriptMarkdownComponent = getTranscriptComponents({
     handlePlay,
@@ -22,7 +23,7 @@ export const VideoTranscript: React.FC<{
 
   return (
     <div data-video-transcript="">
-      <h2 data-title="">Transcript</h2>
+      {!noTitle && <h2 data-title="">Transcript</h2>}
       <div data-transcript="">
         {typeof transcript === 'string' ? (
           <ReactMarkdown components={transcriptMarkdownComponent}>


### PR DESCRIPTION
- feat(tjs): specify types for Lesson Sidebar
- cleanup(tjs): remove unused imports
- feat(tjs): make placeholder to display description
- feat(tjs): load and render code URLs
- feat(tjs): render codesandbox url to iframe
- feat(tjs): add styles for code section

Here are URLs for the different scenarios:
- CodeSandbox embed: http://localhost:3018/lessons/javascript-support-async-tests-with-javascripts-promises-through-async-await
- Just a link to a github branch: http://localhost:3018/lessons/javascript-intro-to-static-analysis-testing-javascript-applications
- Link to github branch AND to a github diff: http://localhost:3018/lessons/javascript-lint-javascript-by-configuring-and-running-eslint

There are a few styling issues that need to be resolved. Here is what it looks like as of this PR, followed by a screenshot of the existing current site:

![CleanShot 2023-11-20 at 11 06 15@2x](https://github.com/skillrecordings/products/assets/694063/364ea225-fb2a-4701-8b65-f79740992397)

<img width="1163" alt="CleanShot 2023-11-20 at 11 07 51@2x" src="https://github.com/skillrecordings/products/assets/694063/01a242e8-c6ae-47da-95d8-30b62e9b4e9f">

![embed](https://media0.giphy.com/media/PO942x3eahcI9hBG8q/giphy.gif?cid=d1fd59abt3iyah89l8n9wr42dmu8qd7g4m6w1ss53dlx38au&ep=v1_gifs_search&rid=giphy.gif&ct=g)