### PR TITLE
Replace PortableText lesson body with text for Lesson Description

### DIFF
--- a/apps/testing-javascript/schemas/documents/explainer.js
+++ b/apps/testing-javascript/schemas/documents/explainer.js
@@ -63,7 +63,7 @@ export default {
     {
       name: 'body',
       title: 'Body',
-      type: 'body',
+      type: 'markdown',
     },
     {
       name: 'description',

--- a/apps/testing-javascript/src/data/replace-interview-descriptions.ts
+++ b/apps/testing-javascript/src/data/replace-interview-descriptions.ts
@@ -1,0 +1,70 @@
+// This script replaces the PT descriptions with markdown descriptions for each
+// Interview of TJS.
+//
+// Execute this script with:
+//
+// ```
+// npx ts-node --files --skipProject src/data/replace-interview-descriptions.ts
+// ```
+
+import fs from 'fs'
+import {createClient} from '@sanity/client'
+import groq from 'groq'
+import {z} from 'zod'
+
+require('dotenv-flow').config({
+  default_node_env: 'development',
+})
+
+const {
+  NEXT_PUBLIC_SANITY_PROJECT_ID: PROJECT_ID,
+  NEXT_PUBLIC_SANITY_DATASET_ID: DATASET,
+  SANITY_EDITOR_TOKEN: EDITOR_TOKEN,
+  NEXT_PUBLIC_SANITY_API_VERSION: API_VERSION,
+} = process.env
+
+const dataPath = './interview-descriptions.json'
+
+function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+const readJsonData = (path: string) => {
+  let fileData = fs.readFileSync(path)
+  return JSON.parse(fileData.toString())
+}
+
+const replaceDescriptionText = async () => {
+  const client = createClient({
+    projectId: PROJECT_ID,
+    dataset: DATASET,
+    apiVersion: API_VERSION,
+    // a token with write access
+    token: EDITOR_TOKEN,
+    useCdn: false,
+  })
+
+  // Read in the interview descriptions
+  const InterviewDescriptionSchema = z
+    .object({slug: z.string(), description: z.string()})
+    .array()
+  const descriptions = InterviewDescriptionSchema.parse(readJsonData(dataPath))
+
+  for (const descriptionData of descriptions) {
+    const {slug, description} = descriptionData
+
+    const getInterviewIdQuery = groq`
+      *[_type == "interview" && slug.current == $slug][0]{_id}`
+    const {_id}: {_id: string} = await client.fetch(getInterviewIdQuery, {slug})
+
+    // Patch the videoResource by `_id` with the new `transcript` value.
+    await client.patch(_id).set({description: description}).commit()
+
+    // avoid rate-limiting
+    await sleep(250)
+  }
+}
+
+replaceDescriptionText()

--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -56,9 +56,9 @@ const LessonTemplate = () => {
             <h2 className="hidden leading-tight lg:block lg:text-4xl xl:text-5xl">
               {lesson.title}
             </h2>
-            {lesson.description && (
+            {lesson.body && (
               <article className="lg:mt-8">
-                <div className="prose md:prose-md">{lesson.description}</div>
+                <div className="prose md:prose-md">{lesson.body}</div>
               </article>
             )}
             <Code urls={codeUrls || {}} />
@@ -135,8 +135,8 @@ const GitHubUrls: React.FC<{
   const includesBranch = checkIfGitHubUrlContainsBranch(branchUrl)
 
   return (
-    <div className="flex flex-col items-center md:items-start space-y-4 md:space-y-6">
-      <div className="flex items-center flex-col md:flex-row">
+    <div className="flex flex-col items-center space-y-4 md:items-start md:space-y-6">
+      <div className="flex flex-col items-center md:flex-row">
         <a
           onClick={() => {
             // track('clicked github link', {
@@ -146,13 +146,13 @@ const GitHubUrls: React.FC<{
           href={branchUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center space-x-3 bg-[#141618] text-white px-[1.3rem] py-4 text-xl leading-none rounded-md duration-200 hover:shadow-[0_20px_50px_-10px_rgba(0,0,0,0.2)]"
+          className="inline-flex items-center space-x-3 rounded-md bg-[#141618] px-[1.3rem] py-4 text-xl leading-none text-white duration-200 hover:shadow-[0_20px_50px_-10px_rgba(0,0,0,0.2)]"
         >
           <FaGithub />
           <span>{message}</span>
         </a>
         {includesBranch && (
-          <p className="text-lg mt-3 md:mt-0 md:ml-5">
+          <p className="mt-3 text-lg md:ml-5 md:mt-0">
             The branch name corresponds to the lesson.
           </p>
         )}

--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -56,9 +56,9 @@ const LessonTemplate = () => {
             <h2 className="hidden leading-tight lg:block lg:text-4xl xl:text-5xl">
               {lesson.title}
             </h2>
-            {lesson.body && (
+            {lesson.description && (
               <article className="lg:mt-8">
-                <div className="prose md:prose-md">{lesson.body}</div>
+                <div className="prose md:prose-md">{lesson.description}</div>
               </article>
             )}
             <Code urls={codeUrls || {}} />


### PR DESCRIPTION
- feat(tjs): replace PT body with markdown
- feat(tjs): use `lesson.body` for description

Once this is merged I will need to:
- Deploy the schema change to production Sanity
- Run the data migration script to replace the PT body with markdown body
- Verify lesson descriptions are rendering appropriately

![describe](https://media0.giphy.com/media/3muwhw9Jl2dNe/giphy.gif?cid=d1fd59abkyjoqno1s9nuyi881v7l7rphc5461918dqnyi99w&ep=v1_gifs_search&rid=giphy.gif&ct=g)