### PR TITLE
feat(tjs): remove excess values from groq queries

### DIFF
--- a/apps/testing-javascript/src/lib/lessons.ts
+++ b/apps/testing-javascript/src/lib/lessons.ts
@@ -5,7 +5,7 @@ export const getLesson = async (
   slug: string,
   includeMedia: boolean = true,
 ): Promise<any> => {
-  const exercise = await sanityClient.fetch(
+  const lesson = await sanityClient.fetch(
     `*[_type in ['explainer'] && slug.current == $slug][0]{
       _id,
       _type,
@@ -19,23 +19,11 @@ export const getLesson = async (
         "slug": slug.current,
         title
       },
-      "stackblitz": resources[@._type == 'stackblitz'][0].openFile,
       ...resources[@->._type == 'videoResource'][0]-> {
         "videoResourceId": _id,
         "durationInSeconds": duration,
         "transcript": castingwords.transcript
       },
-      "solution": resources[@._type == 'solution'][0]{
-        _key,
-        _type,
-        "_updatedAt": ^._updatedAt,
-        title,
-        description,
-        body,
-        "videoResourceId": resources[@->._type == 'videoResource'][0]->_id,
-        "transcript": resources[@->._type == 'videoResource'][0]-> castingwords.transcript,
-        "slug": slug.current,
-      }
     } | {
       ...,
       "module": *[_type in ['module'] && references(^.section._id)][0] {
@@ -47,7 +35,7 @@ export const getLesson = async (
     {slug},
   )
 
-  return exercise
+  return lesson
 }
 
 export const getAllLessons = async (): Promise<any[]> => {
@@ -59,22 +47,10 @@ export const getAllLessons = async (): Promise<any[]> => {
       description,
       body,
       "slug": slug.current,
-      "stackblitz": resources[@._type == 'stackblitz'][0].openFile,
       ...resources[@->._type == 'videoResource'][0]-> {
         "videoResourceId": _id,
         "durationInSeconds": duration
       },
-      "solution": resources[@._type == 'solution'][0]{
-        _key,
-        _type,
-        _updatedAt,
-        title,
-        description,
-        body,
-        "stackblitz": resources[@._type == 'stackblitz'][0].openFile,
-        "videoResourceId": resources[@->._type == 'videoResource'][0],
-       "slug": slug.current
-       }
     }`)
 
   return lessons


### PR DESCRIPTION
These were leftover concepts from TT when pulling in some of that logic,
they are not relevant to the TJS Sanity data model, so they can be
removed from the lesson groq queries.

![irrelevant](https://media0.giphy.com/media/MXywxyJ5UyvtgoF94a/giphy.gif?cid=d1fd59ab65aqb6jixmjpfn1ffua3iek8448xaf0dha5pjj20&ep=v1_gifs_search&rid=giphy.gif&ct=g)