### PR TITLE
refactor: use Sanity createClient everywhere

### DIFF
--- a/apps/colt-steele/src/utils/sanity-client.ts
+++ b/apps/colt-steele/src/utils/sanity-client.ts
@@ -1,7 +1,7 @@
-import client from '@sanity/client'
+import {createClient} from '@sanity/client'
 import type {SanityClient} from '@sanity/client'
 
-export const sanityClient: SanityClient = client({
+export const sanityClient: SanityClient = createClient({
   projectId: process.env.SANITY_PROJECT_ID,
   dataset: process.env.SANITY_DATASET,
   useCdn: true, // `false` if you want to ensure fresh data

--- a/apps/epic-react/src/data/sanity-import.ts
+++ b/apps/epic-react/src/data/sanity-import.ts
@@ -18,7 +18,6 @@
 import fs from 'fs'
 import fetch from 'node-fetch'
 import Mux from '@mux/mux-node'
-// import sanityClient from '@sanity/client'
 import {v4 as uuidv4} from 'uuid'
 import {z, ZodError} from 'zod'
 import csvParser from 'csv-parser'

--- a/apps/epic-web/src/utils/sanity-server.ts
+++ b/apps/epic-web/src/utils/sanity-server.ts
@@ -1,6 +1,6 @@
-import sanityClient from '@sanity/client'
+import {createClient} from '@sanity/client'
 
-export const sanityWriteClient = sanityClient({
+export const sanityWriteClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET_ID,
   useCdn: false, // `false` if you want to ensure fresh data

--- a/apps/protailwind/src/utils/sanity-server.ts
+++ b/apps/protailwind/src/utils/sanity-server.ts
@@ -1,6 +1,6 @@
-import sanityClient from '@sanity/client'
+import {createClient} from '@sanity/client'
 
-export const sanityWriteClient = sanityClient({
+export const sanityWriteClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET_ID,
   useCdn: false, // `false` if you want to ensure fresh data

--- a/apps/scriptkit/src/utils/sanity-client.ts
+++ b/apps/scriptkit/src/utils/sanity-client.ts
@@ -1,6 +1,6 @@
-import client from '@sanity/client'
+import {createClient} from '@sanity/client'
 
-export const sanityClient = client({
+export const sanityClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET_ID,
   useCdn: false, // `false` if you want to ensure fresh data

--- a/apps/scriptkit/src/utils/sanity-server.ts
+++ b/apps/scriptkit/src/utils/sanity-server.ts
@@ -1,6 +1,6 @@
-import sanityClient from '@sanity/client'
+import {createClient} from '@sanity/client'
 
-export const sanityWriteClient = sanityClient({
+export const sanityWriteClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET_ID,
   useCdn: false, // `false` if you want to ensure fresh data

--- a/apps/technical-interviews/src/utils/sanity-client.ts
+++ b/apps/technical-interviews/src/utils/sanity-client.ts
@@ -1,7 +1,7 @@
-import client from '@sanity/client'
+import {createClient} from '@sanity/client'
 import type {SanityClient} from '@sanity/client'
 
-export const sanityClient: SanityClient = client({
+export const sanityClient: SanityClient = createClient({
   projectId: process.env.SANITY_PROJECT_ID,
   dataset: process.env.SANITY_DATASET,
   useCdn: true, // `false` if you want to ensure fresh data

--- a/apps/testing-javascript/src/data/add-duration-to-sanity.ts
+++ b/apps/testing-javascript/src/data/add-duration-to-sanity.ts
@@ -8,7 +8,7 @@
 // ```
 
 import fs from 'fs'
-import sanityClient from '@sanity/client'
+import {createClient} from '@sanity/client'
 import groq from 'groq'
 import {z} from 'zod'
 
@@ -38,7 +38,7 @@ const readJsonData = (path: string) => {
 }
 
 const addDurationToSanity = async () => {
-  const client = sanityClient({
+  const client = createClient({
     projectId: PROJECT_ID,
     dataset: DATASET,
     apiVersion: API_VERSION,

--- a/apps/testing-javascript/src/data/add-videos-to-sanity-interviews.ts
+++ b/apps/testing-javascript/src/data/add-videos-to-sanity-interviews.ts
@@ -8,7 +8,7 @@
 // ```
 
 import fs from 'fs'
-import sanityClient from '@sanity/client'
+import {createClient} from '@sanity/client'
 import groq from 'groq'
 import {z} from 'zod'
 import fetch from 'node-fetch'
@@ -39,7 +39,7 @@ const readJsonData = (path: string) => {
 }
 
 const addVideosToSanityInterviews = async () => {
-  const client = sanityClient({
+  const client = createClient({
     projectId: PROJECT_ID,
     dataset: DATASET,
     apiVersion: API_VERSION,

--- a/apps/testing-javascript/src/data/sanity-import.ts
+++ b/apps/testing-javascript/src/data/sanity-import.ts
@@ -13,7 +13,6 @@
 import fs from 'fs'
 import fetch from 'node-fetch'
 import Mux from '@mux/mux-node'
-// import sanityClient from '@sanity/client'
 import {v4 as uuidv4} from 'uuid'
 import {z} from 'zod'
 import last from 'lodash/last'
@@ -250,19 +249,6 @@ const buildCastingWordsBlock = (
 }
 
 const importCourseData = async () => {
-  // Note: not using client because it doesn't directly support multi-object
-  // transactional creates. You have to drop down to directly calling API
-  // endpoints for that.
-  //
-  // const client = sanityClient({
-  //   projectId: PROJECT_ID,
-  //   dataset: DATASET,
-  //   apiVersion: API_VERSION,
-  //   // a token with write access
-  //   token: EDITOR_TOKEN,
-  //   useCdn: false,
-  // })
-
   const lessonSchema = z.object({
     id: z.coerce.string(),
     slug: z.string(),

--- a/apps/testing-javascript/src/utils/sanity-client.ts
+++ b/apps/testing-javascript/src/utils/sanity-client.ts
@@ -1,7 +1,7 @@
-import client from '@sanity/client'
+import {createClient} from '@sanity/client'
 import type {SanityClient} from '@sanity/client'
 
-export const sanityClient: SanityClient = client({
+export const sanityClient: SanityClient = createClient({
   projectId: process.env.SANITY_PROJECT_ID,
   dataset: process.env.SANITY_DATASET,
   useCdn: true, // `false` if you want to ensure fresh data

--- a/apps/testingaccessibility/src/utils/sanity-client.ts
+++ b/apps/testingaccessibility/src/utils/sanity-client.ts
@@ -1,7 +1,7 @@
-import client from '@sanity/client'
+import {createClient} from '@sanity/client'
 import type {SanityClient} from '@sanity/client'
 
-export const sanityClient: SanityClient = client({
+export const sanityClient: SanityClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET_ID,
   useCdn: true, // `false` if you want to ensure fresh data

--- a/apps/typescriptcourse/src/utils/sanity-server.ts
+++ b/apps/typescriptcourse/src/utils/sanity-server.ts
@@ -1,6 +1,6 @@
-import sanityClient from '@sanity/client'
+import {createClient} from '@sanity/client'
 
-export const sanityWriteClient = sanityClient({
+export const sanityWriteClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET_ID,
   useCdn: false, // `false` if you want to ensure fresh data

--- a/packages/skill-api/src/lib/sanity-client.ts
+++ b/packages/skill-api/src/lib/sanity-client.ts
@@ -1,7 +1,7 @@
-import client from '@sanity/client'
+import {createClient} from '@sanity/client'
 import type {SanityClient} from '@sanity/client'
 
-export const sanityClient: SanityClient = client({
+export const sanityClient: SanityClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET_ID,
   useCdn: true, // `false` if you want to ensure fresh data


### PR DESCRIPTION
The default export from `@sanity/client` is deprecated as a method for
creating a client instance, and `createClient` should be used going
forward. This refactor will clean up a bunch of errors/warnings in the
logs.

![amtrak](https://media4.giphy.com/media/26tPjKRCMDoBmi9Og/giphy.gif?cid=d1fd59ab08ninlesbcdiwbw7g2ibt5n6trsvljv83lwyko41&ep=v1_gifs_search&rid=giphy.gif&ct=g)