### PR TITLE
feat: product sync sanity -> skill -> stripe

### DIFF
--- a/apps/epic-web/schemas/documents/product.tsx
+++ b/apps/epic-web/schemas/documents/product.tsx
@@ -12,15 +12,19 @@ export default defineType({
       type: 'string',
     }),
     defineField({
-      name: 'productId',
-      title: 'Product ID',
-      type: 'string',
+      name: 'unitAmount',
+      title: 'Unit Amount',
+      description: 'The Default Price',
+      type: 'number',
     }),
-    {
-      name: 'convertkitPurchasedTagId',
-      title: 'Convertkit Purchase Tag ID',
-      type: 'string',
-    },
+    defineField({
+      name: 'quantityAvailable',
+      title: 'Quantity Available',
+      description: 'Set to -1 for unlimited',
+      type: 'number',
+      initialValue: -1,
+    }),
+
     defineField({
       name: 'slug',
       title: 'Slug',
@@ -46,80 +50,8 @@ export default defineType({
       },
     }),
     defineField({
-      name: 'price',
-      title: 'Price',
-      type: 'object',
-      fields: [
-        defineField({
-          name: 'priceId',
-          title: 'Price ID',
-          type: 'string',
-        }),
-        defineField({
-          name: 'amount',
-          title: 'Amount',
-          type: 'number',
-        }),
-      ],
-    }),
-    defineField({
-      name: 'merchantPrice',
-      title: 'Merchant Price',
-      type: 'object',
-      fields: [
-        defineField({
-          name: 'merchantPriceId',
-          title: 'Merchant Price ID',
-          type: 'string',
-        }),
-        defineField({
-          name: 'merchantAccountId',
-          title: 'Merchant Account ID',
-          type: 'string',
-        }),
-        defineField({
-          name: 'identifier',
-          title: 'Identifier',
-          type: 'string',
-        }),
-      ],
-    }),
-    defineField({
-      name: 'merchantProduct',
-      title: 'Merchant Product',
-      type: 'object',
-      fields: [
-        defineField({
-          name: 'merchantProductId',
-          title: 'Merchant Product ID',
-          type: 'string',
-        }),
-        defineField({
-          name: 'merchantAccountId',
-          title: 'Merchant Account ID',
-          type: 'string',
-        }),
-        defineField({
-          name: 'identifier',
-          title: 'Identifier',
-          type: 'string',
-        }),
-      ],
-    }),
-    defineField({
       name: 'upgradableTo',
       title: 'Upgradable To',
-      type: 'array',
-      of: [
-        defineArrayMember({
-          type: 'reference',
-          to: [{type: 'product'}],
-        }),
-      ],
-    }),
-    defineField({
-      name: 'upgredableFrom',
-      title: 'Upgradable From',
       type: 'array',
       of: [
         defineArrayMember({

--- a/apps/epic-web/schemas/documents/product.tsx
+++ b/apps/epic-web/schemas/documents/product.tsx
@@ -14,8 +14,9 @@ export default defineType({
     defineField({
       name: 'unitAmount',
       title: 'Unit Amount',
-      description: 'The Default Price',
+      description: 'Current Price',
       type: 'number',
+      validation: (Rule) => Rule.min(1).required(),
     }),
     defineField({
       name: 'quantityAvailable',
@@ -23,8 +24,14 @@ export default defineType({
       description: 'Set to -1 for unlimited',
       type: 'number',
       initialValue: -1,
+      validation: (Rule) => Rule.min(-1).required(),
     }),
-
+    defineField({
+      name: 'productId',
+      title: 'Skill Product ID',
+      type: 'string',
+      readOnly: true,
+    }),
     defineField({
       name: 'slug',
       title: 'Slug',

--- a/apps/epic-web/src/inngest/events/sanity.ts
+++ b/apps/epic-web/src/inngest/events/sanity.ts
@@ -2,6 +2,7 @@ type SanityEventData = {
   _type: string
   _id: string
   event: string
+  productId?: string | null
 }
 
 export const SANITY_WEBHOOK_EVENT = 'sanity/webhook'

--- a/apps/epic-web/src/inngest/functions/sanity/product.ts
+++ b/apps/epic-web/src/inngest/functions/sanity/product.ts
@@ -1,9 +1,11 @@
-import {getSdk} from '@skillrecordings/database'
+import {prisma} from '@skillrecordings/database'
 import {inngest} from 'inngest/inngest.server'
-import {updateOrCreateSanityProduct} from 'lib/products'
 import {SANITY_WEBHOOK_EVENT} from 'inngest/events/sanity'
 import groq from 'groq'
 import {createClient} from '@sanity/client'
+import z from 'zod'
+import {v4} from 'uuid'
+import {stripe} from '@skillrecordings/commerce-server'
 
 export const sanityClient = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
@@ -14,49 +16,17 @@ export const sanityClient = createClient({
   perspective: 'published',
 })
 
-async function getProduct(id: string): Promise<any> {
-  const product = await sanityClient.fetch(
-    groq`*[_type == "product" && _id == $id][0] {
-          _id,
-          _type,
-          _updatedAt,
-          _createdAt,
-          productId,
-          title,
-          image,
-          state,
-          "slug": slug.current,
-          body,
-          upgradableTo[]->{
-            ...,
-          },
-          modules[]->{
-            ...,
-          }
-    }`,
-    {id},
-  )
-  return product
-}
+const BaseSanityProductSchema = z.object({
+  _id: z.string(),
+  title: z.string(),
+  slug: z.string(),
+  unitAmount: z.number().default(0),
+  quantityAvailable: z.number().default(-1),
+  productId: z.string().optional(),
+  upgradableTo: z.array(z.any()).nullable().optional(),
+})
 
-export const sanityProductUpdated = inngest.createFunction(
-  {id: `product-update`, name: 'Update Product in Database'},
-  {
-    event: SANITY_WEBHOOK_EVENT,
-    if: 'event.data.event == "product.update"',
-  },
-  async ({event, step}) => {
-    const productToUpdate = await step.run('get product', async () => {
-      return await getProduct(event.data._id)
-    })
-
-    const product = await step.run('update product in database', async () => {
-      return await updateOrCreateSanityProduct(productToUpdate)
-    })
-
-    return {product}
-  },
-)
+export type BaseSanityProduct = z.infer<typeof BaseSanityProductSchema>
 
 export const sanityProductCreated = inngest.createFunction(
   {id: `product-create`, name: 'Create Product in Database'},
@@ -65,12 +35,34 @@ export const sanityProductCreated = inngest.createFunction(
     if: 'event.data.event == "product.create"',
   },
   async ({event, step}) => {
-    const productToUpdate = await step.run('get product', async () => {
-      return await getProduct(event.data._id)
+    const sanityProduct = await step.run('get sanity product', async () => {
+      const sanityProductData = await sanityClient.fetch(
+        groq`*[_type == "product" && _id == $id][0] {
+          _id,
+          productId,
+          unitAmount,
+          title,
+          "slug": slug.current,
+          quantityAvailable,
+          upgradableTo[]->
+    }`,
+        {id: event.data._id},
+      )
+
+      return BaseSanityProductSchema.parse(sanityProductData)
     })
 
+    // we should just have a title
+
     const product = await step.run('create product in database', async () => {
-      return await updateOrCreateSanityProduct(productToUpdate)
+      const newProductId = v4()
+      return await prisma.product.create({
+        data: {
+          id: newProductId,
+          name: sanityProduct.title,
+          quantityAvailable: sanityProduct.quantityAvailable,
+        },
+      })
     })
 
     await step.run('update productId in sanity', async () => {
@@ -82,7 +74,104 @@ export const sanityProductCreated = inngest.createFunction(
         .commit()
     })
 
-    return {product}
+    const price = await step.run('create price in database', async () => {
+      const newPriceId = v4()
+      return await prisma.price.create({
+        data: {
+          id: newPriceId,
+          unitAmount: sanityProduct.unitAmount,
+          productId: product.id,
+          nickname: sanityProduct.title,
+        },
+      })
+    })
+
+    const merchantAccount = await step.run('get merchant account', async () => {
+      return await prisma.merchantAccount.findFirst({
+        where: {
+          label: 'stripe',
+        },
+      })
+    })
+
+    if (merchantAccount) {
+      const stripeProduct = await step.run(
+        'create stripe product',
+        async () => {
+          return await stripe.products.create({
+            name: product.name,
+            metadata: {
+              slug: sanityProduct.slug,
+            },
+          })
+        },
+      )
+
+      const stripePrice = await step.run('create stripe price', async () => {
+        return await stripe.prices.create({
+          product: stripeProduct.id,
+          unit_amount: Math.floor(Number(price.unitAmount) * 100),
+          currency: 'usd',
+          nickname: sanityProduct.title,
+          metadata: {
+            slug: sanityProduct.slug,
+          },
+        })
+      })
+
+      const merchantProduct = await step.run(
+        'create merchant product in database',
+        async () => {
+          const newMerchantProductId = v4()
+          return await prisma.merchantProduct.create({
+            data: {
+              id: newMerchantProductId,
+              productId: product.id,
+              merchantAccountId: merchantAccount.id,
+              identifier: stripeProduct.id,
+            },
+          })
+        },
+      )
+
+      const merchantPrice = await step.run(
+        'create merchant product in database',
+        async () => {
+          const newMerchantPriceId = v4()
+          return await prisma.merchantPrice.create({
+            data: {
+              id: newMerchantPriceId,
+              merchantProductId: merchantProduct.id,
+              priceId: price.id,
+              merchantAccountId: merchantAccount.id,
+              identifier: stripePrice.id,
+            },
+          })
+        },
+      )
+
+      return {
+        product,
+        merchantProduct,
+        merchantPrice,
+        price,
+        stripeProduct,
+        stripePrice,
+      }
+    } else {
+      throw new Error('No merchant account found')
+    }
+  },
+)
+
+export const sanityProductUpdated = inngest.createFunction(
+  {id: `product-update`, name: 'Update Product in Database'},
+  {
+    event: SANITY_WEBHOOK_EVENT,
+    if: 'event.data.event == "product.update"',
+  },
+  async ({event, step}) => {
+    return false
   },
 )
 
@@ -93,17 +182,7 @@ export const sanityProductDeleted = inngest.createFunction(
     if: 'event.data.event == "product.delete"',
   },
   async ({event, step}) => {
-    const {deleteProduct} = getSdk()
-
-    await step.run('delete product', async () => {
-      return await deleteProduct({
-        where: {
-          id: event.data._id,
-        },
-      })
-    })
-
-    return `${event.data._id} deleted`
+    return false
   },
 )
 

--- a/apps/epic-web/src/inngest/functions/sanity/product/index.ts
+++ b/apps/epic-web/src/inngest/functions/sanity/product/index.ts
@@ -1,0 +1,57 @@
+import {prisma} from '@skillrecordings/database'
+import {inngest} from 'inngest/inngest.server'
+import {SANITY_WEBHOOK_EVENT} from 'inngest/events/sanity'
+import groq from 'groq'
+import {createClient} from '@sanity/client'
+import z from 'zod'
+import {v4} from 'uuid'
+import {stripe} from '@skillrecordings/commerce-server'
+import {sanityProductCreated} from './sanity-product-created'
+import {sanityProductUpdated} from './sanity-product-updated'
+import {sanityWriteClient} from 'utils/sanity-server'
+
+export const loadSanityProduct = async (id: string) => {
+  const sanityProductData = await sanityWriteClient.fetch(
+    groq`*[_type == "product" && _id == $id][0] {
+          _id,
+          productId,
+          unitAmount,
+          title,
+          "slug": slug.current,
+          quantityAvailable,
+          upgradableTo[]->
+    }`,
+    {id},
+  )
+
+  return BaseSanityProductSchema.parse(sanityProductData)
+}
+
+export const BaseSanityProductSchema = z.object({
+  _id: z.string(),
+  title: z.string(),
+  slug: z.string(),
+  unitAmount: z.number().default(0),
+  quantityAvailable: z.number().default(-1),
+  productId: z.string().optional(),
+  upgradableTo: z.array(z.any()).nullable().optional(),
+})
+
+export type BaseSanityProduct = z.infer<typeof BaseSanityProductSchema>
+
+export const sanityProductDeleted = inngest.createFunction(
+  {id: `product-delete`, name: 'Delete Product in Database'},
+  {
+    event: SANITY_WEBHOOK_EVENT,
+    if: 'event.data.event == "product.delete"',
+  },
+  async ({event, step}) => {
+    return false
+  },
+)
+
+export const productFunctions = [
+  sanityProductCreated,
+  sanityProductUpdated,
+  sanityProductDeleted,
+]

--- a/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-created.ts
+++ b/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-created.ts
@@ -1,10 +1,9 @@
 import {inngest} from 'inngest/inngest.server'
 import {SANITY_WEBHOOK_EVENT} from 'inngest/events/sanity'
-import groq from 'groq'
 import {v4} from 'uuid'
 import {prisma} from '@skillrecordings/database'
 import {stripe} from '@skillrecordings/commerce-server'
-import {BaseSanityProductSchema} from 'inngest/functions/sanity/product/index'
+import {loadSanityProduct} from 'inngest/functions/sanity/product/index'
 import {sanityWriteClient} from 'utils/sanity-server'
 
 export const sanityProductCreated = inngest.createFunction(
@@ -15,29 +14,26 @@ export const sanityProductCreated = inngest.createFunction(
   },
   async ({event, step}) => {
     const sanityProduct = await step.run('get sanity product', async () => {
-      const sanityProductData = await sanityWriteClient.fetch(
-        groq`*[_type == "product" && _id == $id][0] {
-          _id,
-          productId,
-          unitAmount,
-          title,
-          "slug": slug.current,
-          quantityAvailable,
-          upgradableTo[]->
-    }`,
-        {id: event.data._id},
-      )
-
-      return BaseSanityProductSchema.parse(sanityProductData)
+      return loadSanityProduct(event.data._id)
     })
+
+    const {
+      title,
+      quantityAvailable,
+      unitAmount,
+      slug,
+      image,
+      features,
+      upgradableTo,
+    } = sanityProduct
 
     const product = await step.run('create product in database', async () => {
       const newProductId = v4()
       return await prisma.product.create({
         data: {
           id: newProductId,
-          name: sanityProduct.title,
-          quantityAvailable: sanityProduct.quantityAvailable,
+          name: title,
+          quantityAvailable,
         },
       })
     })
@@ -47,6 +43,7 @@ export const sanityProductCreated = inngest.createFunction(
         .patch(event.data._id)
         .set({
           productId: product.id,
+          ...(!features && {features: getDefaultProductFeatures()}),
         })
         .commit()
     })
@@ -56,9 +53,9 @@ export const sanityProductCreated = inngest.createFunction(
       return await prisma.price.create({
         data: {
           id: newPriceId,
-          unitAmount: sanityProduct.unitAmount,
+          unitAmount,
           productId: product.id,
-          nickname: sanityProduct.title,
+          nickname: title,
         },
       })
     })
@@ -77,8 +74,9 @@ export const sanityProductCreated = inngest.createFunction(
         async () => {
           return await stripe.products.create({
             name: product.name,
+            ...(image && {images: [image.url]}),
             metadata: {
-              slug: sanityProduct.slug,
+              slug,
             },
           })
         },
@@ -87,11 +85,11 @@ export const sanityProductCreated = inngest.createFunction(
       const stripePrice = await step.run('create stripe price', async () => {
         return await stripe.prices.create({
           product: stripeProduct.id,
-          unit_amount: Math.floor(Number(price.unitAmount) * 100),
+          unit_amount: Math.floor(Number(unitAmount) * 100),
           currency: 'usd',
-          nickname: sanityProduct.title,
+          nickname: title,
           metadata: {
-            slug: sanityProduct.slug,
+            slug,
           },
         })
       })
@@ -127,6 +125,17 @@ export const sanityProductCreated = inngest.createFunction(
         },
       )
 
+      if (upgradableTo) {
+        await step.run('create product upgrades', async () => {
+          return await prisma.upgradableProducts.createMany({
+            data: upgradableTo.map((upgradeToProduct) => ({
+              upgradableFromId: product.id,
+              upgradableToId: upgradeToProduct.productId,
+            })),
+          })
+        })
+      }
+
       return {
         product,
         merchantProduct,
@@ -140,3 +149,43 @@ export const sanityProductCreated = inngest.createFunction(
     }
   },
 )
+
+const getDefaultProductFeatures = () =>
+  [
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M6.75146 12.1765C6.58598 12.1764 6.42728 12.1107 6.31028 11.9936L3.1902 8.87356C3.1306 8.81599 3.08306 8.74714 3.05036 8.671C3.01765 8.59487 3.00044 8.51299 2.99972 8.43013C2.999 8.34728 3.01479 8.26511 3.04616 8.18842C3.07754 8.11173 3.12387 8.04205 3.18247 7.98346C3.24106 7.92487 3.31073 7.87854 3.38742 7.84716C3.46411 7.81579 3.54628 7.8 3.62913 7.80072C3.71199 7.80144 3.79387 7.81865 3.87001 7.85135C3.94614 7.88406 4.015 7.9316 4.07256 7.9912L6.6641 10.5821L11.8547 3.08518C11.9004 3.01568 11.9595 2.95603 12.0287 2.90973C12.0978 2.86343 12.1754 2.83142 12.2571 2.81557C12.3388 2.79972 12.4228 2.80036 12.5042 2.81745C12.5856 2.83453 12.6628 2.86773 12.7311 2.91507C12.7995 2.96242 12.8578 3.02296 12.9024 3.09314C12.9471 3.16332 12.9773 3.24172 12.9912 3.32373C13.0051 3.40574 13.0025 3.48971 12.9835 3.57069C12.9645 3.65168 12.9295 3.72805 12.8806 3.79531L7.26441 11.9075C7.21268 11.9831 7.14494 12.0464 7.06599 12.0929C6.98705 12.1394 6.89884 12.1679 6.80763 12.1765C6.78891 12.1765 6.77018 12.1765 6.75146 12.1765Z" fill="#3A80F5"/> </svg>',
+      value: '1 Self-Paced Workshop',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M8 8.00001C9.364 9.36401 11.068 10.727 12.773 10.727C14.279 10.727 15.5 9.50601 15.5 8.00001C15.5 6.49401 14.279 5.27301 12.773 5.27301C11.068 5.27301 9.364 6.63601 8 8.00001ZM8 8.00001C6.636 6.63601 4.932 5.27301 3.227 5.27301C1.721 5.27301 0.5 6.49401 0.5 8.00001C0.5 9.50601 1.721 10.727 3.227 10.727C4.932 10.727 6.636 9.36401 8 8.00001Z" stroke="#3A80F5" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"/> </svg>',
+      value: 'Lifetime Access',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M9.5 15.5V10.5H14.5" stroke="#3A80F5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/> <path d="M9.5 15.5H1.5V0.5H14.5V10.5L9.5 15.5Z" stroke="#3A80F5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/> </svg>',
+      value: 'Customizable invoice',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <g clip-path="url(#clip0_664_2048)"> <path d="M4.5 15.5H11.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M6.5 3.5L11.5 6.5L6.5 9.5V3.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M15.5 0.5H0.5V12.5H15.5V0.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </g> <defs> <clipPath id="clip0_664_2048"> <rect width="16" height="16" fill="white"/> </clipPath> </defs> </svg>',
+      value: 'Streaming 4K Video',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M8.5 13.5H15.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M0.5 1.5L6.5 7.5L0.5 13.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </svg>',
+      value: '30 Interactive Exercises',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <g clip-path="url(#clip0_664_2054)"> <path d="M8 15.5C12.1421 15.5 15.5 12.1421 15.5 8C15.5 3.85786 12.1421 0.5 8 0.5C3.85786 0.5 0.5 3.85786 0.5 8C0.5 12.1421 3.85786 15.5 8 15.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M6.833 5.738C6.50006 5.57448 6.13286 5.49288 5.762 5.5C3.976 5.5 3.5 6.81 3.5 8C3.5 9.19 3.976 10.5 5.762 10.5C6.13286 10.5071 6.50006 10.4255 6.833 10.262" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M11.833 5.738C11.5001 5.57448 11.1329 5.49288 10.762 5.5C8.976 5.5 8.5 6.81 8.5 8C8.5 9.19 8.976 10.5 10.762 10.5C11.1329 10.5071 11.5001 10.4255 11.833 10.262" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </g> <defs> <clipPath id="clip0_664_2054"> <rect width="16" height="16" fill="white"/> </clipPath> </defs> </svg>',
+      value: 'English Transcripts & Subtitles',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M3 14.5L13 1.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M4.5 6.5C5.88071 6.5 7 5.38071 7 4C7 2.61929 5.88071 1.5 4.5 1.5C3.11929 1.5 2 2.61929 2 4C2 5.38071 3.11929 6.5 4.5 6.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M11.5 14.5C12.8807 14.5 14 13.3807 14 12C14 10.6193 12.8807 9.5 11.5 9.5C10.1193 9.5 9 10.6193 9 12C9 13.3807 10.1193 14.5 11.5 14.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </svg>',
+      value: 'Progress Tracking',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M8.5 13.5V10.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M6.5 13.5H10.5C11.0304 13.5 11.5391 13.7107 11.9142 14.0858C12.2893 14.4609 12.5 14.9696 12.5 15.5H4.5C4.5 14.9696 4.71071 14.4609 5.08579 14.0858C5.46086 13.7107 5.96957 13.5 6.5 13.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M12.5 1.5H15.5V4.5C15.5 5.29565 15.1839 6.05871 14.6213 6.62132C14.0587 7.18393 13.2956 7.5 12.5 7.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M4.5 1.5H1.5V4.5C1.5 5.29565 1.81607 6.05871 2.37868 6.62132C2.94129 7.18393 3.70435 7.5 4.5 7.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M4.5 0.5H12.5V6.5C12.5 7.56087 12.0786 8.57828 11.3284 9.32843C10.5783 10.0786 9.56087 10.5 8.5 10.5C7.43913 10.5 6.42172 10.0786 5.67157 9.32843C4.92143 8.57828 4.5 7.56087 4.5 6.5V0.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </svg>',
+      value: 'Completion Certificate',
+    },
+  ].map((feature) => ({
+    ...feature,
+    _key: v4(),
+    _type: 'feature',
+  }))

--- a/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-deleted.ts
+++ b/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-deleted.ts
@@ -1,0 +1,132 @@
+import {inngest} from 'inngest/inngest.server'
+import {SANITY_WEBHOOK_EVENT} from 'inngest/events/sanity'
+import {prisma} from '@skillrecordings/database'
+import {stripe} from '@skillrecordings/commerce-server'
+
+export const sanityProductDeleted = inngest.createFunction(
+  {id: `product-delete`, name: 'Deactivate Product in Database'},
+  {
+    event: SANITY_WEBHOOK_EVENT,
+    if: 'event.data.event == "product.delete"',
+  },
+  async ({event, step}) => {
+    const {productId} = event.data
+
+    if (!productId) {
+      throw new Error(`Product id not found`)
+    }
+
+    const product = await step.run('get product in database', async () => {
+      return await prisma.product.findUnique({
+        where: {
+          id: productId,
+        },
+        include: {
+          prices: true,
+        },
+      })
+    })
+
+    if (!product) {
+      throw new Error(`Product not found [${productId}]`)
+    }
+
+    await step.run('deactivate product', async () => {
+      return await prisma.product.update({
+        where: {
+          id: productId,
+        },
+        data: {
+          status: 0,
+          name: `(DEACTIVATED) ${product.name}`,
+        },
+      })
+    })
+
+    await step.run('deactivate prices', async () => {
+      return await Promise.all(
+        product.prices.map(async (price) => {
+          return await prisma.price.update({
+            where: {
+              id: price.id,
+            },
+            data: {
+              status: 0,
+              nickname: `(DEACTIVATED) ${price.nickname}`,
+            },
+          })
+        }),
+      )
+    })
+
+    const merchantProduct = await step.run('get merchant product', async () => {
+      return await prisma.merchantProduct.findFirst({
+        where: {
+          productId,
+        },
+        include: {
+          merchantPrices: true,
+        },
+      })
+    })
+
+    if (!merchantProduct) {
+      throw new Error(
+        `Merchant Product not found for product id [${productId}]`,
+      )
+    }
+
+    await step.run('deactivate merchant product', async () => {
+      return await prisma.merchantProduct.update({
+        where: {
+          id: merchantProduct.id,
+        },
+        data: {
+          status: 0,
+        },
+      })
+    })
+
+    await step.run('deactivate merchant prices', async () => {
+      return await Promise.all(
+        merchantProduct.merchantPrices.map(async (merchantPrice) => {
+          return await prisma.merchantPrice.update({
+            where: {
+              id: merchantPrice.id,
+            },
+            data: {
+              status: 0,
+            },
+          })
+        }),
+      )
+    })
+
+    const stripeProduct = await step.run('get stripe product', async () => {
+      if (!merchantProduct?.identifier) {
+        throw new Error('Merchant Product not found')
+      }
+      return await stripe.products.retrieve(merchantProduct.identifier)
+    })
+
+    await step.run('deactivate stripe product', async () => {
+      return await stripe.products.update(stripeProduct.id, {
+        active: false,
+      })
+    })
+
+    await step.run('deactivate all stripe prices', async () => {
+      return await Promise.all(
+        merchantProduct.merchantPrices.map(async (merchantPrice) => {
+          if (merchantPrice.identifier) {
+            return stripe.prices.update(merchantPrice.identifier, {
+              active: false,
+            })
+          } else {
+            return Promise.resolve()
+          }
+        }),
+      )
+    })
+  },
+)

--- a/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-deleted.ts
+++ b/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-deleted.ts
@@ -115,6 +115,21 @@ export const sanityProductDeleted = inngest.createFunction(
       })
     })
 
+    await step.run('delete product upgrades', async () => {
+      return await prisma.upgradableProducts.deleteMany({
+        where: {
+          OR: [
+            {
+              upgradableFromId: product.id,
+            },
+            {
+              upgradableToId: product.id,
+            },
+          ],
+        },
+      })
+    })
+
     await step.run('deactivate all stripe prices', async () => {
       return await Promise.all(
         merchantProduct.merchantPrices.map(async (merchantPrice) => {

--- a/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-updated.ts
+++ b/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-updated.ts
@@ -1,0 +1,162 @@
+import {inngest} from 'inngest/inngest.server'
+import {SANITY_WEBHOOK_EVENT} from 'inngest/events/sanity'
+import {prisma} from '@skillrecordings/database'
+import {stripe} from '@skillrecordings/commerce-server'
+import {v4} from 'uuid'
+import {loadSanityProduct} from './index'
+
+export const sanityProductUpdated = inngest.createFunction(
+  {id: `product-update`, name: 'Update Product in Database'},
+  {
+    event: SANITY_WEBHOOK_EVENT,
+    if: 'event.data.event == "product.update"',
+  },
+  async ({event, step}) => {
+    const sanityProduct = await step.run('get sanity product', async () => {
+      return loadSanityProduct(event.data._id)
+    })
+
+    const product = await step.run('get product in database', async () => {
+      return await prisma.product.findUnique({
+        where: {
+          id: sanityProduct.productId,
+        },
+        include: {
+          prices: true,
+        },
+      })
+    })
+
+    if (!product) {
+      throw new Error(`Product not found [${sanityProduct.productId}]`)
+    }
+
+    const merchantProduct = await step.run('get merchant product', async () => {
+      return await prisma.merchantProduct.findFirst({
+        where: {
+          productId: product.id,
+        },
+      })
+    })
+
+    if (!merchantProduct) {
+      throw new Error(
+        `Merchant Product not found for product id [${product.id}]`,
+      )
+    }
+
+    const stripeProduct = await step.run('get stripe product', async () => {
+      if (!merchantProduct?.identifier) {
+        throw new Error('Merchant Product not found')
+      }
+      return await stripe.products.retrieve(merchantProduct.identifier)
+    })
+
+    const priceChanged = product.prices
+      .map((price) => Number(price.unitAmount))
+      .includes(sanityProduct.unitAmount)
+
+    if (priceChanged) {
+      const currentMerchantPrice = await step.run(
+        'get current merchant price',
+        async () => {
+          return await prisma.merchantPrice.findFirst({
+            where: {
+              priceId: product.prices[0].id,
+            },
+          })
+        },
+      )
+
+      const currentStripePrice = await step.run(
+        'get stripe price',
+        async () => {
+          if (!currentMerchantPrice?.identifier) {
+            throw new Error('Merchant Price not found')
+          }
+          return await stripe.prices.retrieve(currentMerchantPrice.identifier)
+        },
+      )
+
+      const newStripePrice = await step.run(
+        'create new stripe price',
+        async () => {
+          return await stripe.prices.create({
+            unit_amount: Math.floor(Number(sanityProduct.unitAmount) * 100),
+            currency: 'usd',
+            product: stripeProduct.id,
+            active: true,
+          })
+        },
+      )
+
+      await step.run('create new merchant price', async () => {
+        const newMerchantPriceId = v4()
+        return await prisma.merchantPrice.create({
+          data: {
+            id: newMerchantPriceId,
+            merchantProductId: merchantProduct.id,
+            priceId: product.prices[0].id,
+            merchantAccountId: merchantProduct.merchantAccountId,
+            identifier: newStripePrice.id,
+            status: 1,
+          },
+        })
+      })
+
+      if (currentMerchantPrice) {
+        await step.run('deactivate old merchant price', async () => {
+          return await prisma.merchantPrice.update({
+            where: {
+              id: currentMerchantPrice.id,
+            },
+            data: {
+              status: 0,
+            },
+          })
+        })
+      }
+
+      await step.run('update price in database', async () => {
+        return await prisma.price.update({
+          where: {
+            id: product.prices[0].id,
+          },
+          data: {
+            nickname: sanityProduct.title,
+            unitAmount: sanityProduct.unitAmount,
+          },
+        })
+      })
+
+      if (currentStripePrice) {
+        await step.run('deactivate stripe price', async () => {
+          return await stripe.prices.update(currentStripePrice.id, {
+            active: false,
+          })
+        })
+      }
+    }
+
+    const updatedProduct = await step.run(
+      'update product in database',
+      async () => {
+        return await prisma.product.update({
+          where: {
+            id: product.id,
+          },
+          data: {
+            name: sanityProduct.title,
+            quantityAvailable: sanityProduct.quantityAvailable,
+          },
+          include: {
+            prices: true,
+            merchantProducts: true,
+          },
+        })
+      },
+    )
+
+    return {updatedProduct}
+  },
+)

--- a/apps/epic-web/src/inngest/inngest-config.ts
+++ b/apps/epic-web/src/inngest/inngest-config.ts
@@ -6,6 +6,8 @@ import {lessonCompleted} from 'inngest/functions/progress/lesson-completed'
 import {writeAnEmail} from 'inngest/functions/ai-email/write-an-email'
 import {purchaseTransferComplete} from 'inngest/functions/purchase/purchase-transfer-complete'
 import {productFunctions} from 'inngest/functions/sanity/product'
+import {LESSON_COMPLETED_EVENT} from '@skillrecordings/skill-lesson'
+import {prisma} from '@skillrecordings/database'
 
 export const inngestConfig = {
   client: inngest,

--- a/apps/epic-web/src/inngest/inngest.config.ts
+++ b/apps/epic-web/src/inngest/inngest.config.ts
@@ -6,8 +6,6 @@ import {lessonCompleted} from 'inngest/functions/progress/lesson-completed'
 import {writeAnEmail} from 'inngest/functions/ai-email/write-an-email'
 import {purchaseTransferComplete} from 'inngest/functions/purchase/purchase-transfer-complete'
 import {productFunctions} from 'inngest/functions/sanity/product'
-import {LESSON_COMPLETED_EVENT} from '@skillrecordings/skill-lesson'
-import {prisma} from '@skillrecordings/database'
 
 export const inngestConfig = {
   client: inngest,

--- a/apps/epic-web/src/inngest/inngest.config.ts
+++ b/apps/epic-web/src/inngest/inngest.config.ts
@@ -5,7 +5,7 @@ import {stripeCheckoutCompleted} from 'inngest/functions/stripe/checkout-complet
 import {lessonCompleted} from 'inngest/functions/progress/lesson-completed'
 import {writeAnEmail} from 'inngest/functions/ai-email/write-an-email'
 import {purchaseTransferComplete} from 'inngest/functions/purchase/purchase-transfer-complete'
-import {productFunctions} from 'inngest/functions/sanity/product'
+import {sanityProductFunctions} from 'inngest/functions/sanity/product'
 
 export const inngestConfig = {
   client: inngest,
@@ -18,6 +18,6 @@ export const inngestConfig = {
     lessonCompleted,
     writeAnEmail,
     purchaseTransferComplete,
-    ...productFunctions,
+    ...sanityProductFunctions,
   ],
 }

--- a/apps/epic-web/src/lib/products.ts
+++ b/apps/epic-web/src/lib/products.ts
@@ -1,7 +1,6 @@
 import z from 'zod'
 import groq from 'groq'
 import {sanityClient} from '@skillrecordings/skill-lesson/utils/sanity-client'
-import {getSdk} from '@skillrecordings/database'
 
 export const ProductSchema = z.object({
   _id: z.string(),
@@ -57,107 +56,4 @@ export async function getProduct(productId: string): Promise<Product> {
   )
 
   return ProductSchema.parse(product)
-}
-
-export async function updateOrCreateSanityProduct(product: any) {
-  const {updateOrCreateProduct} = getSdk()
-  const newProduct = await updateOrCreateProduct({
-    where: {
-      id: product.productId ? product.productId : product._id,
-    },
-    create: {
-      id: product._id,
-      name: product.title,
-      createdAt: product._createdAt,
-      status: product.state === 'active' ? 1 : 0,
-      quantityAvailable: -1,
-      // TODO: upgradableTo, coupons
-      ...(product.price && {
-        prices: {
-          connectOrCreate: {
-            where: {
-              id: product.price.priceId,
-            },
-            create: {
-              id: product.price.priceId,
-              unitAmount: product.price.amount,
-              merchantPrices: {
-                connectOrCreate: {
-                  where: {
-                    id: product.merchantPrice.merchantPriceId,
-                  },
-                  create: {
-                    id: product.merchantPrice.merchantPriceId,
-                    identifier: product.merchantPrice.identifier,
-                    merchantProductId: product.productId,
-                    merchantAccountId: product.merchantPrice.merchantAccountId,
-                  },
-                },
-              },
-            },
-          },
-        },
-      }),
-      ...(product.merchantProduct && {
-        merchantProducts: {
-          connectOrCreate: {
-            where: {
-              id: product.merchantProduct.merchantProductId,
-            },
-            create: {
-              id: product.merchantProduct.merchantProductId,
-              identifier: product.merchantProduct.identifier,
-              merchantAccountId: product.merchantProduct.merchantAccountId,
-            },
-          },
-        },
-      }),
-    },
-    update: {
-      name: product.title,
-      status: product.state === 'active' ? 1 : 0,
-      quantityAvailable: -1,
-      ...(product.price && {
-        prices: {
-          connectOrCreate: {
-            where: {
-              id: product.price.priceId,
-            },
-            create: {
-              id: product.price.priceId,
-              unitAmount: product.price.amount,
-              merchantPrices: {
-                connectOrCreate: {
-                  where: {
-                    id: product.merchantPrice.merchantPriceId,
-                  },
-                  create: {
-                    id: product.merchantPrice.merchantPriceId,
-                    identifier: product.merchantPrice.identifier,
-                    merchantProductId: product.productId,
-                    merchantAccountId: product.merchantPrice.merchantAccountId,
-                  },
-                },
-              },
-            },
-          },
-        },
-      }),
-      ...(product.merchantProduct && {
-        merchantProducts: {
-          connectOrCreate: {
-            where: {
-              id: product.merchantProduct.merchantProductId,
-            },
-            create: {
-              id: product.merchantProduct.merchantProductId,
-              identifier: product.merchantProduct.identifier,
-              merchantAccountId: product.merchantProduct.merchantAccountId,
-            },
-          },
-        },
-      }),
-    },
-  })
-  return newProduct
 }

--- a/apps/epic-web/src/pages/api/inngest.ts
+++ b/apps/epic-web/src/pages/api/inngest.ts
@@ -1,5 +1,5 @@
 import {serve} from 'inngest/next'
-import {inngestConfig} from 'inngest/inngest-config'
+import {inngestConfig} from 'inngest/inngest.config'
 
 export const config = {
   maxDuration: 300,

--- a/apps/epic-web/src/utils/sanity-server.ts
+++ b/apps/epic-web/src/utils/sanity-server.ts
@@ -6,4 +6,5 @@ export const sanityWriteClient = createClient({
   useCdn: false, // `false` if you want to ensure fresh data
   apiVersion: process.env.NEXT_PUBLIC_SANITY_API_VERSION,
   token: process.env.SANITY_API_TOKEN,
+  perspective: 'published',
 })

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -1,5 +1,5 @@
 import {PrismaClient} from '@prisma/client'
-import type {Decimal} from 'decimal.js'
+import {Decimal} from '@prisma/client/runtime/library'
 
 export * from '@prisma/client'
 


### PR DESCRIPTION
Took a look at the Sanity syncing workflow and wanted to make some changes to the flow.

Could use some help:

- [x] click test this (I didn't run it)
- [x] Add UpgradeTo section to the workflow
- [x] changes in unit amount need to create a new price in stripe if one for that amount doesn't exist

[🚌 1 hour struggle bus loom design and implementation session](https://www.loom.com/share/a67fc3e5336c44aea89e5d4abd3c258d?sid=13490684-7df8-4a7d-8694-29d61f563289)

![screenshot of the figjam](https://github.com/skillrecordings/products/assets/86834/182d4838-eba9-4c3f-b242-9be9f8a178e3)
