### PR TITLE
fix(builds): await isValidSignature in sanity webhook

### DIFF
--- a/apps/colt-steele/src/pages/api/webhooks/sanity/videoResource/created.ts
+++ b/apps/colt-steele/src/pages/api/webhooks/sanity/videoResource/created.ts
@@ -25,7 +25,7 @@ const sanityVideoResourceWebhook = async (
   res: NextApiResponse,
 ) => {
   const signature = req.headers[SIGNATURE_HEADER_NAME] as string
-  const isValid = isValidSignature(
+  const isValid = await isValidSignature(
     JSON.stringify(req.body),
     signature,
     process.env.SANITY_WEBHOOK_SECRET,

--- a/apps/epic-web/src/pages/api/webhooks/sanity/videoResource/created.ts
+++ b/apps/epic-web/src/pages/api/webhooks/sanity/videoResource/created.ts
@@ -25,7 +25,7 @@ const sanityVideoResourceWebhook = async (
   res: NextApiResponse,
 ) => {
   const signature = req.headers[SIGNATURE_HEADER_NAME] as string
-  const isValid = isValidSignature(
+  const isValid = await isValidSignature(
     JSON.stringify(req.body),
     signature,
     process.env.SANITY_WEBHOOK_SECRET,

--- a/apps/pro-nextjs/src/pages/api/webhooks/sanity/article/updated.ts
+++ b/apps/pro-nextjs/src/pages/api/webhooks/sanity/article/updated.ts
@@ -11,7 +11,11 @@ export const sanityArticleWebhook = async (
   res: NextApiResponse,
 ) => {
   const signature = req.headers[SIGNATURE_HEADER_NAME] as string
-  const isValid = isValidSignature(JSON.stringify(req.body), signature, secret)
+  const isValid = await isValidSignature(
+    JSON.stringify(req.body),
+    signature,
+    secret,
+  )
 
   try {
     if (isValid) {

--- a/packages/skill-api/src/core/services/process-sanity-webhooks.ts
+++ b/packages/skill-api/src/core/services/process-sanity-webhooks.ts
@@ -16,7 +16,7 @@ export async function processSanityWebhooks({
       options: {nextAuthOptions},
     } = params
     const signature = req.headers[SIGNATURE_HEADER_NAME] as string
-    const isValid = isValidSignature(
+    const isValid = await isValidSignature(
       JSON.stringify(req.body),
       signature,
       webhookSecret,

--- a/packages/skill-lesson/lib/sanity.ts
+++ b/packages/skill-lesson/lib/sanity.ts
@@ -156,7 +156,11 @@ export const sanityVideoResourceWebhook = async (
   res: NextApiResponse,
 ) => {
   const signature = req.headers[SIGNATURE_HEADER_NAME] as string
-  const isValid = isValidSignature(JSON.stringify(req.body), signature, secret)
+  const isValid = await isValidSignature(
+    JSON.stringify(req.body),
+    signature,
+    secret,
+  )
 
   try {
     if (isValid) {


### PR DESCRIPTION
`isValidSignature` from `@sanity/webhook` returns type of `Promise<boolean>` thus has to be awaited.

<img src="https://media.giphy.com/media/W2KcfZICjiFtdBOMvF/giphy-downsized.gif" width="200" alt="gif">