### PR TITLE
refactor(skill-lesson): use Progress primitive

### DIFF
--- a/apps/colt-steele/src/styles/video/video-overlays.css
+++ b/apps/colt-steele/src/styles/video/video-overlays.css
@@ -39,9 +39,9 @@
   [data-progress] {
     @apply flex w-full max-w-sm items-center justify-center gap-2 pt-5;
     [data-progress-bar] {
-      @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-700;
+      @apply bg-gray-700;
       [data-indicator] {
-        @apply relative h-full w-full flex-1 bg-brand-red transition-all duration-300 ease-out;
+        @apply bg-brand-red duration-300 ease-out;
       }
     }
     [data-lessons-completed] {
@@ -203,9 +203,9 @@
   [data-progress] {
     @apply flex w-full max-w-sm items-center justify-center gap-2 pt-5;
     [data-progress-bar] {
-      @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-700;
+      @apply bg-gray-700;
       [data-indicator] {
-        @apply relative h-full w-full flex-1 bg-brand-red transition-all duration-300 ease-out;
+        @apply bg-brand-red duration-300 ease-out;
       }
     }
     [data-lessons-completed] {

--- a/apps/epic-web/src/styles/video/video-overlays.css
+++ b/apps/epic-web/src/styles/video/video-overlays.css
@@ -31,9 +31,9 @@
   [data-progress] {
     @apply flex w-full max-w-sm items-center justify-center gap-2 pt-8;
     [data-progress-bar] {
-      @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-700 shadow-inner;
+      @apply bg-gray-700 shadow-inner;
       [data-indicator] {
-        @apply relative h-full w-full flex-1 bg-primary transition-all duration-300 ease-out;
+        @apply duration-300 ease-out;
       }
     }
     [data-lessons-completed] {
@@ -187,9 +187,9 @@
   [data-progress] {
     @apply flex w-full max-w-sm items-center justify-center gap-2 pt-8;
     [data-progress-bar] {
-      @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-700 shadow-inner;
+      @apply bg-gray-700 shadow-inner;
       [data-indicator] {
-        @apply relative h-full w-full flex-1 bg-primary transition-all duration-300 ease-out;
+        @apply duration-300 ease-out;
       }
     }
     [data-lessons-completed] {

--- a/apps/pro-nextjs/src/styles/video/video-overlays.css
+++ b/apps/pro-nextjs/src/styles/video/video-overlays.css
@@ -25,9 +25,9 @@
   [data-progress] {
     @apply flex w-full max-w-sm items-center justify-center gap-2 py-3;
     [data-progress-bar] {
-      @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-100 shadow-inner;
+      @apply bg-gray-100 shadow-inner;
       [data-indicator] {
-        @apply relative h-full w-full flex-1 bg-gradient-to-r from-indigo-300 via-indigo-300 to-purple-300 transition-all duration-300 ease-out;
+        @apply bg-gradient-to-r from-indigo-300 via-indigo-300 to-purple-300 duration-300 ease-out;
       }
     }
     [data-lessons-completed] {
@@ -198,9 +198,9 @@
   [data-progress] {
     @apply mt-4 flex w-full max-w-sm items-center justify-center gap-2 py-3;
     [data-progress-bar] {
-      @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-100 shadow-inner;
+      @apply bg-gray-100 shadow-inner;
       [data-indicator] {
-        @apply relative h-full w-full flex-1 bg-gradient-to-r from-indigo-300 via-indigo-300 to-purple-300 transition-all duration-300 ease-out;
+        @apply bg-gradient-to-r from-indigo-300 via-indigo-300 to-purple-300 duration-300 ease-out;
       }
     }
     [data-lessons-completed] {

--- a/apps/total-typescript/src/styles/video/video-overlays.css
+++ b/apps/total-typescript/src/styles/video/video-overlays.css
@@ -32,7 +32,8 @@
   [data-progress] {
     @apply flex w-full max-w-sm items-center justify-center gap-2 pt-5;
     [data-progress-bar] {
-      @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-700;
+      /* @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-700; */
+      @apply bg-gray-700;
       [data-indicator] {
         @apply relative h-full w-full flex-1 bg-teal-500 transition-all duration-300 ease-out;
       }

--- a/apps/total-typescript/src/styles/video/video-overlays.css
+++ b/apps/total-typescript/src/styles/video/video-overlays.css
@@ -35,7 +35,8 @@
       /* @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-700; */
       @apply bg-gray-700;
       [data-indicator] {
-        @apply relative h-full w-full flex-1 bg-teal-500 transition-all duration-300 ease-out;
+        /* @apply relative h-full w-full flex-1 bg-teal-500 transition-all duration-300 ease-out; */
+        @apply bg-teal-500 duration-300 ease-out;
       }
     }
     [data-lessons-completed] {

--- a/apps/total-typescript/src/styles/video/video-overlays.css
+++ b/apps/total-typescript/src/styles/video/video-overlays.css
@@ -32,10 +32,8 @@
   [data-progress] {
     @apply flex w-full max-w-sm items-center justify-center gap-2 pt-5;
     [data-progress-bar] {
-      /* @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-700; */
       @apply bg-gray-700;
       [data-indicator] {
-        /* @apply relative h-full w-full flex-1 bg-teal-500 transition-all duration-300 ease-out; */
         @apply bg-teal-500 duration-300 ease-out;
       }
     }
@@ -196,9 +194,9 @@
   [data-progress] {
     @apply flex w-full max-w-sm items-center justify-center gap-2 pt-2 md:pt-5;
     [data-progress-bar] {
-      @apply relative h-2 w-full overflow-hidden rounded-full bg-gray-700;
+      @apply bg-gray-700;
       [data-indicator] {
-        @apply relative h-full w-full flex-1 bg-teal-500 transition-all duration-300 ease-out;
+        @apply bg-teal-500 duration-300 ease-out;
       }
     }
     [data-lessons-completed] {

--- a/packages/skill-lesson/video/video-overlays.tsx
+++ b/packages/skill-lesson/video/video-overlays.tsx
@@ -261,45 +261,20 @@ const DefaultOverlay: React.FC = () => {
           </Balancer>
         </p>
         {moduleProgress && session.status === 'authenticated' && (
-          <>
-            {/* Substituted with Progress primitive */}
-            {/* <div data-progress="">
-              <ProgressBar.Root
-                data-progress-bar=""
-                className="relative h-2 w-full overflow-hidden rounded-full bg-gray-700"
-                max={moduleProgress?.lessonCount}
-              >
-                <ProgressBar.Indicator
-                  data-indicator={moduleProgress?.percentComplete}
-                  style={{
-                    transform: `translateX(-${
-                      ((moduleProgress?.lessonCount -
-                        (completedLessonCount || 0)) /
-                        moduleProgress?.lessonCount) *
-                      100
-                    }%)`,
-                  }}
-                />
-              </ProgressBar.Root>
-              <div data-lessons-completed="">
-                {completedLessonCount} / {moduleProgress?.lessonCount} lessons
-                completed
-              </div>
-            </div> */}
-            <div data-progress="">
-              <Progress
-                value={
-                  ((moduleProgress?.lessonCount - (completedLessonCount || 0)) /
-                    moduleProgress?.lessonCount) *
-                  100
-                }
-              />
-              <div data-lessons-completed="">
-                {completedLessonCount} / {moduleProgress?.lessonCount} lessons
-                completed
-              </div>
+          <div data-progress="">
+            <Progress
+              value={
+                ((moduleProgress?.lessonCount - (completedLessonCount || 0)) /
+                  moduleProgress?.lessonCount) *
+                100
+              }
+              className="h-2"
+            />
+            <div data-lessons-completed="">
+              {completedLessonCount} / {moduleProgress?.lessonCount} lessons
+              completed
             </div>
-          </>
+          </div>
         )}
         <div data-actions="">
           <CompleteAndContinueButton
@@ -380,22 +355,15 @@ const FinishedOverlay = () => {
         </h2>
         {moduleProgress && session.status === 'authenticated' && (
           <div data-progress="">
-            <ProgressBar.Root
-              data-progress-bar=""
-              max={moduleProgress?.lessonCount}
-            >
-              <ProgressBar.Indicator
-                data-indicator={moduleProgress?.percentComplete}
-                style={{
-                  transform: `translateX(-${
-                    ((moduleProgress?.lessonCount -
-                      (moduleProgress.completedLessonCount || 0)) /
-                      moduleProgress?.lessonCount) *
-                    100
-                  }%)`,
-                }}
-              />
-            </ProgressBar.Root>
+            <Progress
+              value={
+                ((moduleProgress?.lessonCount -
+                  (moduleProgress.completedLessonCount || 0)) /
+                  moduleProgress?.lessonCount) *
+                100
+              }
+              className="h-2"
+            />
             <div data-lessons-completed="">
               {moduleProgress.completedLessonCount} /{' '}
               {moduleProgress?.lessonCount} lessons completed
@@ -798,22 +766,14 @@ const FinishedSectionOverlay = () => {
         </p>
         {moduleProgress && session.status === 'authenticated' && (
           <div data-progress="">
-            <ProgressBar.Root
-              data-progress-bar=""
-              max={moduleProgress?.lessonCount}
-            >
-              <ProgressBar.Indicator
-                data-indicator={moduleProgress?.percentComplete}
-                style={{
-                  transform: `translateX(-${
-                    ((moduleProgress?.lessonCount -
-                      (completedLessonCount || 0)) /
-                      moduleProgress?.lessonCount) *
-                    100
-                  }%)`,
-                }}
-              />
-            </ProgressBar.Root>
+            <Progress
+              value={
+                ((moduleProgress?.lessonCount - (completedLessonCount || 0)) /
+                  moduleProgress?.lessonCount) *
+                100
+              }
+              className="h-2"
+            />
             <div data-lessons-completed="">
               {completedLessonCount} / {moduleProgress?.lessonCount} lessons
               completed

--- a/packages/skill-lesson/video/video-overlays.tsx
+++ b/packages/skill-lesson/video/video-overlays.tsx
@@ -33,7 +33,6 @@ import {portableTextComponents} from '../portable-text'
 import Spinner from '../spinner'
 import {isNextSectionEmpty} from '../utils/get-next-section'
 import {type ModuleProgress, useModuleProgress} from './module-progress'
-import * as ProgressBar from '@radix-ui/react-progress'
 import {Button} from '@skillrecordings/ui'
 import {Progress} from '@skillrecordings/ui'
 

--- a/packages/skill-lesson/video/video-overlays.tsx
+++ b/packages/skill-lesson/video/video-overlays.tsx
@@ -35,6 +35,7 @@ import {isNextSectionEmpty} from '../utils/get-next-section'
 import {type ModuleProgress, useModuleProgress} from './module-progress'
 import * as ProgressBar from '@radix-ui/react-progress'
 import {Button} from '@skillrecordings/ui'
+import {Progress} from '@skillrecordings/ui'
 
 const OverlayWrapper: React.FC<
   React.PropsWithChildren<{dismissable?: boolean}>
@@ -260,28 +261,45 @@ const DefaultOverlay: React.FC = () => {
           </Balancer>
         </p>
         {moduleProgress && session.status === 'authenticated' && (
-          <div data-progress="">
-            <ProgressBar.Root
-              data-progress-bar=""
-              max={moduleProgress?.lessonCount}
-            >
-              <ProgressBar.Indicator
-                data-indicator={moduleProgress?.percentComplete}
-                style={{
-                  transform: `translateX(-${
-                    ((moduleProgress?.lessonCount -
-                      (completedLessonCount || 0)) /
-                      moduleProgress?.lessonCount) *
-                    100
-                  }%)`,
-                }}
+          <>
+            {/* Substituted with Progress primitive */}
+            {/* <div data-progress="">
+              <ProgressBar.Root
+                data-progress-bar=""
+                className="relative h-2 w-full overflow-hidden rounded-full bg-gray-700"
+                max={moduleProgress?.lessonCount}
+              >
+                <ProgressBar.Indicator
+                  data-indicator={moduleProgress?.percentComplete}
+                  style={{
+                    transform: `translateX(-${
+                      ((moduleProgress?.lessonCount -
+                        (completedLessonCount || 0)) /
+                        moduleProgress?.lessonCount) *
+                      100
+                    }%)`,
+                  }}
+                />
+              </ProgressBar.Root>
+              <div data-lessons-completed="">
+                {completedLessonCount} / {moduleProgress?.lessonCount} lessons
+                completed
+              </div>
+            </div> */}
+            <div data-progress="">
+              <Progress
+                value={
+                  ((moduleProgress?.lessonCount - (completedLessonCount || 0)) /
+                    moduleProgress?.lessonCount) *
+                  100
+                }
               />
-            </ProgressBar.Root>
-            <div data-lessons-completed="">
-              {completedLessonCount} / {moduleProgress?.lessonCount} lessons
-              completed
+              <div data-lessons-completed="">
+                {completedLessonCount} / {moduleProgress?.lessonCount} lessons
+                completed
+              </div>
             </div>
-          </div>
+          </>
         )}
         <div data-actions="">
           <CompleteAndContinueButton

--- a/packages/ui/primitives/progress.tsx
+++ b/packages/ui/primitives/progress.tsx
@@ -13,7 +13,7 @@ const Progress = React.forwardRef<
     ref={ref}
     data-progress-bar=""
     className={cn(
-      'relative h-2 w-full overflow-hidden rounded-full bg-secondary',
+      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
       className,
     )}
     {...props}
@@ -25,26 +25,6 @@ const Progress = React.forwardRef<
     />
   </ProgressPrimitive.Root>
 ))
-// const Progress = React.forwardRef<
-//   React.ElementRef<typeof ProgressPrimitive.Root>,
-//   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
-// >(({className, value, ...props}, ref) => (
-//   <ProgressPrimitive.Root
-//     ref={ref}
-//     data-progress-bar=""
-//     className={cn(
-//       'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
-//       className,
-//     )}
-//     {...props}
-//   >
-//     <ProgressPrimitive.Indicator
-//       data-indicator=""
-//       className="h-full w-full flex-1 bg-primary transition-all"
-//       style={{transform: `translateX(-${100 - (value || 0)}%)`}}
-//     />
-//   </ProgressPrimitive.Root>
-// ))
 Progress.displayName = ProgressPrimitive.Root.displayName
 
 export {Progress}

--- a/packages/ui/primitives/progress.tsx
+++ b/packages/ui/primitives/progress.tsx
@@ -11,8 +11,9 @@ const Progress = React.forwardRef<
 >(({className, value, ...props}, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
+    data-progress-bar=""
     className={cn(
-      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+      'relative h-2 w-full overflow-hidden rounded-full bg-secondary',
       className,
     )}
     {...props}
@@ -20,10 +21,30 @@ const Progress = React.forwardRef<
     <ProgressPrimitive.Indicator
       data-indicator=""
       className="h-full w-full flex-1 bg-primary transition-all"
-      style={{transform: `translateX(-${100 - (value || 0)}%)`}}
+      style={{transform: `translateX(-${value}%)`}}
     />
   </ProgressPrimitive.Root>
 ))
+// const Progress = React.forwardRef<
+//   React.ElementRef<typeof ProgressPrimitive.Root>,
+//   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+// >(({className, value, ...props}, ref) => (
+//   <ProgressPrimitive.Root
+//     ref={ref}
+//     data-progress-bar=""
+//     className={cn(
+//       'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+//       className,
+//     )}
+//     {...props}
+//   >
+//     <ProgressPrimitive.Indicator
+//       data-indicator=""
+//       className="h-full w-full flex-1 bg-primary transition-all"
+//       style={{transform: `translateX(-${100 - (value || 0)}%)`}}
+//     />
+//   </ProgressPrimitive.Root>
+// ))
 Progress.displayName = ProgressPrimitive.Root.displayName
 
 export {Progress}


### PR DESCRIPTION
This refactors `skill-lesson`'s video overlays and involved applications (TT, EW, CS and PNJS) to use shared Progress component.
Also some unused styles are cleaned up.

@joelhooks `TJS` doesn't use progress currently. Do we want to implement it?

<details>
  <summary>Colt Steele (default):</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/0a7d4886-3a7b-44b3-8cec-2a8ee1bccfc7">
</details>
<details>
  <summary>Colt Steele (finished):</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/9c3db2ca-3b92-47a5-81ed-2f7620c9325b">
</details>
<details>
  <summary>EpicWeb (default):</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/05dd8305-d536-45f1-9cee-eb807f849a28">
</details>
<details>
  <summary>EpicWeb (finished):</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/4cb09ad4-2456-49d8-a4db-0be9e7d408be">
</details>
<details>
  <summary>ProNextJS (default):</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/ca96c8cd-2906-4c54-8dba-24b97e80a853">
</details>
<details>
  <summary>ProNextJS (finished):</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/48812162-fb8a-40f1-9c49-980cc0f6e4c0">
</details>
<details>
  <summary>Total Typescript (default):</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/55bde218-dbff-4c7b-8a89-c80925e359b3">
</details>
<details>
  <summary>Total Typescript (finished):</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/7035d110-a0c2-4a07-a4a8-091b57694adf">
</details>

![Aaron Paul Progress GIF by HULU](https://github.com/skillrecordings/products/assets/1519448/a6f8f648-a95e-42e7-a510-ff8a7e8927b3)

