### PR TITLE
chore(deps): bump prisma to v5.2.0

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -22,7 +22,7 @@
     "validate": "DATABASE_URL=\"mysql://root@127.0.0.1:3306/turborepo\" npx prisma validate"
   },
   "dependencies": {
-    "@prisma/client": "5.0.0",
+    "@prisma/client": "5.2.0",
     "decimal.js": "^10.4.3",
     "uuid": "^9.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,7 +410,7 @@ importers:
         version: 2.0.1(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.0.0)(next-auth@4.24.5)
+        version: 1.0.7(@prisma/client@5.2.0)(next-auth@4.24.5)
       '@next/mdx':
         specifier: ^13.5.4
         version: 13.5.6(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0)
@@ -804,7 +804,7 @@ importers:
         version: 2.0.1(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.0.0)(next-auth@4.24.5)
+        version: 1.0.7(@prisma/client@5.2.0)(next-auth@4.24.5)
       '@next/mdx':
         specifier: ^13.4.3
         version: 13.5.6(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0)
@@ -1225,7 +1225,7 @@ importers:
         version: 2.0.1(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.0.0)(next-auth@4.24.5)
+        version: 1.0.7(@prisma/client@5.2.0)(next-auth@4.24.5)
       '@next/mdx':
         specifier: ^13.5.4
         version: 13.5.6(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0)
@@ -1571,7 +1571,7 @@ importers:
         version: 2.0.1(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.0.0)(next-auth@4.24.5)
+        version: 1.0.7(@prisma/client@5.2.0)(next-auth@4.24.5)
       '@next/mdx':
         specifier: ^13.5.4
         version: 13.5.6(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0)
@@ -2094,7 +2094,7 @@ importers:
         version: 2.0.1(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.0.0)(next-auth@4.24.5)
+        version: 1.0.7(@prisma/client@5.2.0)(next-auth@4.24.5)
       '@next/mdx':
         specifier: ^13.4.3
         version: 13.5.6(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0)
@@ -2503,7 +2503,7 @@ importers:
         version: 2.0.1(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.0.0)(next-auth@4.24.5)
+        version: 1.0.7(@prisma/client@5.2.0)(next-auth@4.24.5)
       '@next/mdx':
         specifier: ^13.5.4
         version: 13.5.6(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0)
@@ -2963,421 +2963,6 @@ importers:
         specifier: 5.1.6
         version: 5.1.6
 
-  apps/skill-template:
-    dependencies:
-      '@amplitude/analytics-browser':
-        specifier: ^1.3.0
-        version: 1.13.2
-      '@code-hike/mdx':
-        specifier: ^0.8.2
-        version: 0.8.3(react@18.2.0)
-      '@headlessui/react':
-        specifier: ^1.6.1
-        version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
-      '@heroicons/react':
-        specifier: ^1.0.6
-        version: 1.0.6(react@18.2.0)
-      '@mdx-js/loader':
-        specifier: ^2.3.0
-        version: 2.3.0(webpack@5.89.0)
-      '@mdx-js/mdx':
-        specifier: ^2.3.0
-        version: 2.3.0
-      '@mdx-js/react':
-        specifier: ^2.3.0
-        version: 2.3.0(react@18.2.0)
-      '@mux/mux-node':
-        specifier: ^7.3.1
-        version: 7.3.3
-      '@mux/mux-player-react':
-        specifier: 2.0.1
-        version: 2.0.1(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
-      '@next-auth/prisma-adapter':
-        specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.0.0)(next-auth@4.24.5)
-      '@next/mdx':
-        specifier: ^13.4.3
-        version: 13.5.6(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0)
-      '@portabletext/react':
-        specifier: ^1.0.6
-        version: 1.0.6(react@18.2.0)
-      '@radix-ui/react-accordion':
-        specifier: ^1.0.0
-        version: 1.1.2(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-alert-dialog':
-        specifier: ^0.1.7
-        version: 0.1.7(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-dialog':
-        specifier: ^0.1.7
-        version: 0.1.7(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-dropdown-menu':
-        specifier: ^1.0.0
-        version: 1.0.0(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-navigation-menu':
-        specifier: ^1.1.1
-        version: 1.1.4(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-switch':
-        specifier: ^1.0.1
-        version: 1.0.3(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
-      '@sanity/block-tools':
-        specifier: ^3.9.0
-        version: 3.20.2
-      '@sanity/client':
-        specifier: ^6.1.1
-        version: 6.9.1
-      '@sanity/code-input':
-        specifier: ^4.1.0
-        version: 4.1.1(@babel/runtime@7.23.5)(@codemirror/lint@6.4.2)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.1.1)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.20.2)(styled-components@5.3.11)
-      '@sanity/icons':
-        specifier: ^2.3.1
-        version: 2.7.0(react@18.2.0)
-      '@sanity/ui':
-        specifier: ^1.3.2
-        version: 1.9.3(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.11)
-      '@sanity/vision':
-        specifier: ^3.9.0
-        version: 3.20.2(@babel/runtime@7.23.5)(@codemirror/lint@6.4.2)(@codemirror/state@6.3.2)(@codemirror/theme-one-dark@6.1.2)(@lezer/common@1.1.1)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.11)
-      '@sanity/webhook':
-        specifier: ^1.0.2
-        version: 1.1.0
-      '@sentry/nextjs':
-        specifier: ^7.83.0
-        version: 7.84.0(next@13.5.6)(react@18.2.0)(webpack@5.89.0)
-      '@sentry/tracing':
-        specifier: ^7.9.0
-        version: 7.84.0
-      '@sindresorhus/slugify':
-        specifier: ^2.1.0
-        version: 2.2.1
-      '@skillrecordings/ability':
-        specifier: workspace:*
-        version: link:../../packages/ability
-      '@skillrecordings/analytics':
-        specifier: workspace:*
-        version: link:../../packages/analytics
-      '@skillrecordings/commerce-server':
-        specifier: workspace:*
-        version: link:../../packages/commerce-server
-      '@skillrecordings/convertkit-react-ui':
-        specifier: workspace:*
-        version: link:../../packages/convertkit-react-ui
-      '@skillrecordings/database':
-        specifier: workspace:*
-        version: link:../../packages/database
-      '@skillrecordings/feedback-widget':
-        specifier: workspace:*
-        version: link:../../packages/feedback-widget
-      '@skillrecordings/inngest':
-        specifier: workspace:*
-        version: link:../../packages/inngest
-      '@skillrecordings/next-seo':
-        specifier: workspace:*
-        version: link:../../packages/next-seo
-      '@skillrecordings/quiz':
-        specifier: workspace:*
-        version: link:../../packages/quiz
-      '@skillrecordings/react':
-        specifier: workspace:*
-        version: link:../../packages/react
-      '@skillrecordings/skill-api':
-        specifier: workspace:*
-        version: link:../../packages/skill-api
-      '@skillrecordings/skill-lesson':
-        specifier: workspace:*
-        version: link:../../packages/skill-lesson
-      '@skillrecordings/ui':
-        specifier: workspace:*
-        version: link:../../packages/ui
-      '@slack/web-api':
-        specifier: ^6.7.2
-        version: 6.10.0
-      '@tanstack/react-query':
-        specifier: ^4.20.4
-        version: 4.36.1(react-dom@18.2.0)(react@18.2.0)
-      '@tanstack/react-query-devtools':
-        specifier: ^4.24.10
-        version: 4.36.1(@tanstack/react-query@4.36.1)(react-dom@18.2.0)(react@18.2.0)
-      '@tiptap/extension-highlight':
-        specifier: ^2.0.0-beta.33
-        version: 2.1.13(@tiptap/core@2.1.13)
-      '@tiptap/extension-link':
-        specifier: ^2.0.0-beta.37
-        version: 2.1.13(@tiptap/core@2.1.13)(@tiptap/pm@2.1.13)
-      '@tiptap/extension-typography':
-        specifier: ^2.0.0-beta.20
-        version: 2.1.13(@tiptap/core@2.1.13)
-      '@tiptap/react':
-        specifier: ^2.0.0-beta.109
-        version: 2.1.13(@tiptap/core@2.1.13)(@tiptap/pm@2.1.13)(react-dom@18.2.0)(react@18.2.0)
-      '@tiptap/starter-kit':
-        specifier: ^2.0.0-beta.184
-        version: 2.1.13(@tiptap/pm@2.1.13)
-      '@trpc/client':
-        specifier: '=10.7.0'
-        version: 10.7.0(@trpc/server@10.7.0)
-      '@trpc/next':
-        specifier: '=10.7.0'
-        version: 10.7.0(@tanstack/react-query@4.36.1)(@trpc/client@10.7.0)(@trpc/react-query@10.7.0)(@trpc/server@10.7.0)(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
-      '@trpc/react-query':
-        specifier: '=10.7.0'
-        version: 10.7.0(@tanstack/react-query@4.36.1)(@trpc/client@10.7.0)(@trpc/server@10.7.0)(react-dom@18.2.0)(react@18.2.0)
-      '@trpc/server':
-        specifier: '=10.7.0'
-        version: 10.7.0
-      '@upstash/redis':
-        specifier: ^1.23.3
-        version: 1.25.1
-      '@vercel/og':
-        specifier: ^0.5.4
-        version: 0.5.20
-      axios:
-        specifier: ^1.4.0
-        version: 1.6.2
-      class-variance-authority:
-        specifier: ^0.6.0
-        version: 0.6.1
-      classnames:
-        specifier: ^2.3.1
-        version: 2.3.2
-      clsx:
-        specifier: ^1.2.1
-        version: 1.2.1
-      date-fns:
-        specifier: ^2.28.0
-        version: 2.30.0
-      feed:
-        specifier: ^4.2.2
-        version: 4.2.2
-      formik:
-        specifier: 2.2.9
-        version: 2.2.9(react@18.2.0)
-      framer-motion:
-        specifier: ^10.12.4
-        version: 10.16.12(react-dom@18.2.0)(react@18.2.0)
-      groq:
-        specifier: ^2.15.0
-        version: 2.33.2
-      inngest:
-        specifier: 3.1.1
-        version: 3.1.1(typescript@5.1.6)
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
-      lucide-react:
-        specifier: ^0.224.0
-        version: 0.224.0(react@18.2.0)
-      micromark:
-        specifier: ^3.1.0
-        version: 3.2.0
-      mjml:
-        specifier: ^4.12.0
-        version: 4.14.1
-      nanoid:
-        specifier: ^4.0.2
-        version: 4.0.2
-      next:
-        specifier: ^13.5.4
-        version: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)(sass@1.69.5)
-      next-auth:
-        specifier: ^4.23.2
-        version: 4.24.5(next@13.5.6)(nodemailer@6.9.7)(react-dom@18.2.0)(react@18.2.0)
-      next-mdx-remote:
-        specifier: ^4.1.0
-        version: 4.4.1(react-dom@18.2.0)(react@18.2.0)
-      next-sitemap:
-        specifier: ^3.0.5
-        version: 3.1.55(@next/env@12.3.4)(next@13.5.6)
-      next-themes:
-        specifier: ^0.2.1
-        version: 0.2.1(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
-      nodemailer:
-        specifier: ^6.7.2
-        version: 6.9.7
-      nodemailer-postmark-transport:
-        specifier: ^5.2.1
-        version: 5.2.1(nodemailer@6.9.7)
-      openai:
-        specifier: ^4.12.1
-        version: 4.20.1
-      pluralize:
-        specifier: ^8.0.0
-        version: 8.0.0
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
-      react-countdown:
-        specifier: ^2.3.5
-        version: 2.3.5(react-dom@18.2.0)(react@18.2.0)
-      react-dom:
-        specifier: 18.2.0
-        version: 18.2.0(react@18.2.0)
-      react-gravatar:
-        specifier: ^2.6.3
-        version: 2.6.3(react@18.2.0)
-      react-hook-form:
-        specifier: ^7.29.0
-        version: 7.48.2(react@18.2.0)
-      react-hot-toast:
-        specifier: ^2.2.0
-        version: 2.4.1(csstype@3.1.2)(react-dom@18.2.0)(react@18.2.0)
-      react-icons:
-        specifier: ^4.7.1
-        version: 4.12.0(react@18.2.0)
-      react-markdown:
-        specifier: ^8.0.6
-        version: 8.0.7(@types/react@18.2.41)(react@18.2.0)
-      react-use:
-        specifier: ^17.4.0
-        version: 17.4.2(react-dom@18.2.0)(react@18.2.0)
-      react-wrap-balancer:
-        specifier: ^0.2.4
-        version: 0.2.4(react@18.2.0)
-      sanity:
-        specifier: ^3.9.0
-        version: 3.20.2(@types/node@18.19.2)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.11)
-      sanity-plugin-cloudinary:
-        specifier: ^1.1.1
-        version: 1.1.1(@babel/core@7.23.5)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.20.2)
-      sanity-plugin-markdown:
-        specifier: ^4.1.0
-        version: 4.1.0(easymde@2.18.0)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.20.2)(styled-components@5.3.11)
-      sanity-plugin-taxonomy-manager:
-        specifier: ^2.0.4
-        version: 2.3.1(@babel/core@7.23.5)(@types/react@18.2.41)(prop-types@15.8.1)(react-dom@18.2.0)(react-fast-compare@3.2.2)(react-is@18.2.0)(react@18.2.0)(rxjs@7.8.1)(sanity@3.20.2)(styled-components@5.3.11)
-      shortid:
-        specifier: ^2.2.16
-        version: 2.2.16
-      singleline:
-        specifier: ^2.0.0
-        version: 2.0.0
-      styled-components:
-        specifier: ^5.2
-        version: 5.3.11(@babel/core@7.23.5)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-      superjson:
-        specifier: '=1.11.0'
-        version: 1.11.0
-      tailwind-merge:
-        specifier: ^1.12.0
-        version: 1.14.0
-      tailwindcss-animate:
-        specifier: ^1.0.5
-        version: 1.0.7(tailwindcss@3.3.5)
-      tailwindcss-group-modifier-plugin:
-        specifier: ^0.1.1
-        version: 0.1.1(tailwindcss@3.3.5)
-      tailwindcss-radix:
-        specifier: ^2.8.0
-        version: 2.8.0
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
-      yup:
-        specifier: ^0.32.11
-        version: 0.32.11
-      zod:
-        specifier: ^3.21.4
-        version: 3.22.4
-    devDependencies:
-      '@next/env':
-        specifier: ^12.2.2
-        version: 12.3.4
-      '@skillrecordings/scripts':
-        specifier: workspace:*
-        version: link:../../packages/scripts
-      '@skillrecordings/tsconfig':
-        specifier: workspace:*
-        version: link:../../packages/tsconfig
-      '@skillrecordings/types':
-        specifier: workspace:*
-        version: link:../../packages/types
-      '@tailwindcss/typography':
-        specifier: ^0.5.9
-        version: 0.5.10(tailwindcss@3.3.5)
-      '@types/cookie':
-        specifier: ^0.4.1
-        version: 0.4.1
-      '@types/jsonwebtoken':
-        specifier: ^8.5.8
-        version: 8.5.9
-      '@types/lodash':
-        specifier: 4.14.179
-        version: 4.14.179
-      '@types/mdx':
-        specifier: ^2.0.2
-        version: 2.0.10
-      '@types/mdx-js__react':
-        specifier: ^1.5.5
-        version: 1.5.8
-      '@types/mjml':
-        specifier: ^4.7.0
-        version: 4.7.4
-      '@types/node':
-        specifier: ^18.16.13
-        version: 18.19.2
-      '@types/nodemailer':
-        specifier: ^6.4.4
-        version: 6.4.14
-      '@types/nprogress':
-        specifier: ^0.2.0
-        version: 0.2.3
-      '@types/pluralize':
-        specifier: ^0.0.29
-        version: 0.0.29
-      '@types/react':
-        specifier: ^18.2.6
-        version: 18.2.41
-      '@types/react-dom':
-        specifier: ^18.2.4
-        version: 18.2.17
-      '@types/react-gravatar':
-        specifier: ^2.6.10
-        version: 2.6.13
-      '@types/shortid':
-        specifier: ^0.0.29
-        version: 0.0.29
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.7
-      autoprefixer:
-        specifier: ^10.4.2
-        version: 10.4.16(postcss@8.4.32)
-      dotenv-flow:
-        specifier: ^3.2.0
-        version: 3.3.0
-      eslint:
-        specifier: ^8.19.0
-        version: 8.55.0
-      eslint-config-skill-recordings:
-        specifier: workspace:*
-        version: link:../../packages/eslint-config-skill-recordings
-      jest:
-        specifier: ^27.5.1
-        version: 27.5.1
-      jest-mock-extended:
-        specifier: ^2.0.4
-        version: 2.0.9(jest@27.5.1)(typescript@5.1.6)
-      postcss:
-        specifier: ^8.4.14
-        version: 8.4.32
-      prettier:
-        specifier: ^2.6.2
-        version: 2.8.8
-      prettier-plugin-tailwindcss:
-        specifier: ^0.2.5
-        version: 0.2.8(prettier@2.8.8)
-      tailwind-scrollbar:
-        specifier: ^3.0.0
-        version: 3.0.5(tailwindcss@3.3.5)
-      tailwindcss:
-        specifier: ^3.3.0
-        version: 3.3.5(ts-node@10.9.1)
-      typescript:
-        specifier: 5.1.6
-        version: 5.1.6
-      webpack:
-        specifier: ^5.73.0
-        version: 5.89.0(esbuild@0.19.8)
-
   apps/testing-javascript:
     dependencies:
       '@heroicons/react':
@@ -3400,7 +2985,7 @@ importers:
         version: 2.0.1(@types/react-dom@18.2.17)(@types/react@18.2.41)(react-dom@18.2.0)(react@18.2.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@5.0.0)(next-auth@4.24.5)
+        version: 1.0.7(@prisma/client@5.2.0)(next-auth@4.24.5)
       '@next/mdx':
         specifier: ^13.5.4
         version: 13.5.6(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0)
@@ -4679,8 +4264,8 @@ importers:
   packages/database:
     dependencies:
       '@prisma/client':
-        specifier: 5.0.0
-        version: 5.0.0(prisma@5.6.0)
+        specifier: 5.2.0
+        version: 5.2.0(prisma@5.6.0)
       decimal.js:
         specifier: ^10.4.3
         version: 10.4.3
@@ -11346,7 +10931,7 @@ packages:
     dependencies:
       '@mdx-js/mdx': 2.3.0
       source-map: 0.7.4
-      webpack: 5.89.0(esbuild@0.19.8)
+      webpack: 5.89.0
     transitivePeerDependencies:
       - supports-color
 
@@ -11520,13 +11105,13 @@ packages:
       mux-embed: 4.30.0
     dev: false
 
-  /@next-auth/prisma-adapter@1.0.7(@prisma/client@5.0.0)(next-auth@4.24.5):
+  /@next-auth/prisma-adapter@1.0.7(@prisma/client@5.2.0)(next-auth@4.24.5):
     resolution: {integrity: sha512-Cdko4KfcmKjsyHFrWwZ//lfLUbcLqlyFqjd/nYE2m3aZ7tjMNUjpks47iw7NTCnXf+5UWz5Ypyt1dSs1EP5QJw==}
     peerDependencies:
       '@prisma/client': '>=2.26.0 || >=3'
       next-auth: ^4
     dependencies:
-      '@prisma/client': 5.0.0(prisma@5.6.0)
+      '@prisma/client': 5.2.0(prisma@5.6.0)
       next-auth: 4.24.5(next@13.5.6)(nodemailer@6.9.7)(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
@@ -11886,8 +11471,8 @@ packages:
     resolution: {integrity: sha512-eiq9/kMX2bYezS4/kLFk3xNnruCFjCDdw6aYEv5ECHVKkYROiuLd3/AsP5d7tWF3+kPPy6tB0Wq8aqDG/URHGA==}
     engines: {node: ^14.13.1 || >=16.0.0 || >=18.0.0}
 
-  /@prisma/client@5.0.0(prisma@5.6.0):
-    resolution: {integrity: sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==}
+  /@prisma/client@5.2.0(prisma@5.6.0):
+    resolution: {integrity: sha512-AiTjJwR4J5Rh6Z/9ZKrBBLel3/5DzUNntMohOy7yObVnVoTNVFi2kvpLZlFuKO50d7yDspOtW6XBpiAd0BVXbQ==}
     engines: {node: '>=16.13'}
     requiresBuild: true
     peerDependencies:
@@ -11896,12 +11481,12 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584
+      '@prisma/engines-version': 5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f
       prisma: 5.6.0
     dev: false
 
-  /@prisma/engines-version@4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584:
-    resolution: {integrity: sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ==}
+  /@prisma/engines-version@5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f:
+    resolution: {integrity: sha512-jsnKT5JIDIE01lAeCj2ghY9IwxkedhKNvxQeoyLs6dr4ZXynetD0vTy7u6wMJt8vVPv8I5DPy/I4CFaoXAgbtg==}
     dev: false
 
   /@prisma/engines@5.6.0:
@@ -14888,14 +14473,6 @@ packages:
       - react-is
     dev: false
 
-  /@sanity/webhook@1.1.0:
-    resolution: {integrity: sha512-gd+9+KbQhuwYo9jltboW6qyboSyu5AOpVH/B7b4cmL8Y8NSJIS23yfE7P8Yw8i66siVe4kkyOPQ2JBjhCfimTw==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      base64url: 3.0.1
-      tslib: 2.6.2
-    dev: false
-
   /@sanity/webhook@4.0.0:
     resolution: {integrity: sha512-IRjtj17tHSmxHWZvgRnLZbWj8J8G4jqOWOYC25eV4EcfVn1yZCs0x+km6+PSiJgOphSX6Nm1+X6UJOT+GnWIFw==}
     engines: {node: '>=18.0.0'}
@@ -15005,7 +14582,7 @@ packages:
       resolve: 1.22.8
       rollup: 2.78.0
       stacktrace-parser: 0.1.10
-      webpack: 5.89.0(esbuild@0.19.8)
+      webpack: 5.89.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18443,7 +18020,7 @@ packages:
   /axios@0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.3(debug@2.6.9)
+      follow-redirects: 1.15.3(debug@4.3.4)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -18451,14 +18028,14 @@ packages:
   /axios@0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.3(debug@2.6.9)
+      follow-redirects: 1.15.3(debug@4.3.4)
     transitivePeerDependencies:
       - debug
 
   /axios@0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.3(debug@2.6.9)
+      follow-redirects: 1.15.3(debug@4.3.4)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -18466,7 +18043,7 @@ packages:
   /axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.3(debug@2.6.9)
+      follow-redirects: 1.15.3(debug@4.3.4)
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -18475,7 +18052,7 @@ packages:
   /axios@1.6.2:
     resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
     dependencies:
-      follow-redirects: 1.15.3(debug@2.6.9)
+      follow-redirects: 1.15.3(debug@4.3.4)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -18835,11 +18412,6 @@ packages:
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  /base64url@3.0.1:
-    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
-    engines: {node: '>=6.0.0'}
-    dev: false
 
   /base@0.11.2:
     resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
@@ -35419,14 +34991,6 @@ packages:
       tailwindcss: 3.3.5(ts-node@10.9.1)
     dev: false
 
-  /tailwindcss-group-modifier-plugin@0.1.1(tailwindcss@3.3.5):
-    resolution: {integrity: sha512-3dO5rJydC9nmuzvCV8h7xcn2UPWaNdikTsFifBcDnSW37/kUsyMuc8+ifiDw84Fa+LCewmHc8+eWwrvRi9oLlg==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0'
-    dependencies:
-      tailwindcss: 3.3.5(ts-node@10.9.1)
-    dev: false
-
   /tailwindcss-radix@2.8.0:
     resolution: {integrity: sha512-1k1UfoIYgVyBl13FKwwoKavjnJ5VEaUClCTAsgz3VLquN4ay/lyaMPzkbqD71sACDs2fRGImytAUlMb4TzOt1A==}
     dev: false
@@ -35606,7 +35170,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.25.0
       webpack: 5.89.0
-    dev: true
 
   /terser@4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -37606,7 +37169,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /webpack@5.89.0(esbuild@0.19.8):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}


### PR DESCRIPTION
https://github.com/prisma/prisma/releases/tag/5.2.0

Both the 5.1.0 and 5.2.0 upgrades didn't require any changes on our
part. They both add improvements in performance by reducing unnecessary
queries to the database. And 5.1.0 introduces better type resolution for
intellisense (https://github.com/prisma/prisma/pull/20319).

![bump](https://media0.giphy.com/media/3q1YkHxfNljXDZfMEx/giphy.gif?cid=d1fd59ab4bvy000qvxy91snksddrjobdp0i0g3c32eb489gw&ep=v1_gifs_search&rid=giphy.gif&ct=g)
