### PR TITLE
fix: address lint errors for new ER app

### DIFF
--- a/apps/epic-react/src/components/app/layout.tsx
+++ b/apps/epic-react/src/components/app/layout.tsx
@@ -13,7 +13,13 @@ const inter = Inter({
 })
 
 type LayoutProps = {
-  meta?: NextSeoProps & {titleAppendSiteName?: boolean}
+  meta?: NextSeoProps & {
+    titleAppendSiteName?: boolean
+    url?: string
+    type?: string
+    ogImage?: {url: string; alt: string}
+    date?: string
+  }
   noIndex?: boolean
   className?: string
   nav?: React.ReactElement | null
@@ -42,12 +48,12 @@ const Layout: FunctionComponent<React.PropsWithChildren<LayoutProps>> = ({
   const {
     title,
     description,
-    openGraph,
     titleAppendSiteName = true,
-    defaultTitle = process.env.NEXT_PUBLIC_SITE_TITLE,
+    url,
+    type = 'website',
+    ogImage,
+    date,
   } = meta || {}
-
-  const {url} = openGraph || {}
 
   return (
     <div
@@ -62,7 +68,16 @@ const Layout: FunctionComponent<React.PropsWithChildren<LayoutProps>> = ({
             ? `%s | ${process.env.NEXT_PUBLIC_SITE_TITLE}`
             : undefined
         }
-        openGraph={openGraph}
+        openGraph={{
+          title,
+          description,
+          type,
+          url,
+          images: ogImage ? [ogImage] : undefined,
+          article: {
+            publishedTime: date,
+          },
+        }}
         canonical={url}
         noindex={noIndex}
       />

--- a/apps/epic-react/src/pages/api/inngest.ts
+++ b/apps/epic-react/src/pages/api/inngest.ts
@@ -1,5 +1,5 @@
 import {serve} from 'inngest/next'
-import {inngest, syncSanityProductsWithDb} from '@skillrecordings/inngest'
+import {inngest} from '@skillrecordings/inngest'
 
 export const config = {
   maxDuration: 300,
@@ -7,5 +7,5 @@ export const config = {
 
 export default serve({
   client: inngest,
-  functions: [syncSanityProductsWithDb],
+  functions: [],
 })

--- a/apps/epic-react/src/templates/tip-template.tsx
+++ b/apps/epic-react/src/templates/tip-template.tsx
@@ -22,9 +22,9 @@ import {getOgImage} from '@/utils/get-og-image'
 import {useTipComplete} from '@skillrecordings/skill-lesson/hooks/use-tip-complete'
 import {localProgressDb} from '@skillrecordings/skill-lesson/utils/dexie'
 import {
+  redirectUrlBuilder,
   SubscribeToConvertkitForm,
-  convertkitRedirectUrlBuilder,
-} from '@skillrecordings/ui'
+} from '@skillrecordings/convertkit-react-ui'
 import {useConvertkit} from '@skillrecordings/skill-lesson/hooks/use-convertkit'
 import {setUserId} from '@amplitude/analytics-browser'
 import {ArticleJsonLd, VideoJsonLd} from '@skillrecordings/next-seo'
@@ -67,13 +67,9 @@ const TipTemplate: React.FC<{
 
   const handleOnSuccess = (subscriber: any, email?: string) => {
     if (subscriber) {
-      const redirectUrl = convertkitRedirectUrlBuilder(
-        subscriber,
-        router.asPath,
-        {
-          confirmToast: 'true',
-        },
-      )
+      const redirectUrl = redirectUrlBuilder(subscriber, router.asPath, {
+        confirmToast: 'true',
+      })
       email && setUserId(email)
       track('subscribed to email list', {
         lesson: tip.slug,

--- a/packages/create-skill-app/templates/next/src/templates/tip-template.tsx
+++ b/packages/create-skill-app/templates/next/src/templates/tip-template.tsx
@@ -22,9 +22,9 @@ import {getOgImage} from '@/utils/get-og-image'
 import {useTipComplete} from '@skillrecordings/skill-lesson/hooks/use-tip-complete'
 import {localProgressDb} from '@skillrecordings/skill-lesson/utils/dexie'
 import {
+  redirectUrlBuilder,
   SubscribeToConvertkitForm,
-  convertkitRedirectUrlBuilder,
-} from '@skillrecordings/ui'
+} from '@skillrecordings/convertkit-react-ui'
 import {useConvertkit} from '@skillrecordings/skill-lesson/hooks/use-convertkit'
 import {setUserId} from '@amplitude/analytics-browser'
 import {ArticleJsonLd, VideoJsonLd} from '@skillrecordings/next-seo'
@@ -67,13 +67,9 @@ const TipTemplate: React.FC<{
 
   const handleOnSuccess = (subscriber: any, email?: string) => {
     if (subscriber) {
-      const redirectUrl = convertkitRedirectUrlBuilder(
-        subscriber,
-        router.asPath,
-        {
-          confirmToast: 'true',
-        },
-      )
+      const redirectUrl = redirectUrlBuilder(subscriber, router.asPath, {
+        confirmToast: 'true',
+      })
       email && setUserId(email)
       track('subscribed to email list', {
         lesson: tip.slug,


### PR DESCRIPTION
There were a few things from `create-skill-app` that are out of sync and in an error state. This cleans them out so that ER builds aren't failing.

![build fail](https://media3.giphy.com/media/iiEJyrLf2lDYaaomc3/giphy.gif?cid=d1fd59abqdw7o6igx74jelzuyjzctu2d2w3940qmhz4jbeje&ep=v1_gifs_search&rid=giphy.gif&ct=g)