### PR TITLE
feat: create TJS purchase when bonus redeemed

### DIFF
--- a/apps/epic-web/src/trpc/routers/bonuses.ts
+++ b/apps/epic-web/src/trpc/routers/bonuses.ts
@@ -3,6 +3,7 @@ import {publicProcedure, router} from '@skillrecordings/skill-lesson'
 import {z} from 'zod'
 import {getToken} from 'next-auth/jwt'
 import {sanityClient} from '@skillrecordings/skill-lesson/utils/sanity-client'
+import {v4} from 'uuid'
 
 const redis = new Redis({
   url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -55,36 +56,81 @@ export const bonusesRouter = router({
       const bonusSlugs = availableBonuses?.split(',') || []
 
       if (bonusSlugs.includes(input.bonusSlug)) {
-        let sellableId, clientId
+        let json, sellableId, clientId, productId
 
         if (input.bonusSlug === 'testing-javascript') {
-          sellableId = 273899
-          clientId = process.env.TESTING_JAVASCRIPT_CLIENT_ID
+          // Write purchase to kcd-products
+          productId = 'kcd_4f0b26ee-d61d-4245-a204-26f5774355a5'
+
+          const purchaseData = z
+            .object({
+              id: z.string(),
+              userId: z.string(),
+              createdAt: z.string(),
+              totalAmount: z.number(),
+              city: z.string().nullable(),
+              state: z.string().nullable(),
+              country: z.string().nullable(),
+              ip_address: z.string().nullable(),
+              status: z.union([
+                z.literal('Valid'),
+                z.literal('Refunded'),
+                z.literal('Banned'),
+              ]),
+              productId: z.string(),
+              couponId: z.string().nullable(),
+              merchantChargeId: z.string().nullable(),
+              upgradedFromId: z.string().nullable(),
+              bulkCouponId: z.string().nullable(),
+              redeemedBulkCouponId: z.string().nullable(),
+              merchantPurchaseId: z.string().nullable(),
+            })
+            .parse({
+              id: v4(),
+              userId: token?.sub,
+              createdAt: new Date().toISOString(),
+              totalAmount: 0,
+              city: null,
+              state: null,
+              country: null,
+              ip_address: null,
+              status: 'Valid',
+              productId,
+              couponId: null,
+              merchantChargeId: null,
+              upgradedFromId: null,
+              bulkCouponId: null,
+              redeemedBulkCouponId: null,
+              merchantPurchaseId: null,
+            })
+
+          json = await ctx.prisma.purchase.create({data: purchaseData})
         } else if (input.bonusSlug === 'epic-react') {
+          // TODO: write to kcd-products database after cutting over ER site.
           sellableId = 385975
           clientId = process.env.EPIC_REACT_CLIENT_ID
-        }
 
-        if (!sellableId) throw new Error('No sellableId found for bonus slug')
-
-        const response = await fetch(
-          `${process.env.EGGHEAD_API_URL}/api/v1/sellable_purchases/redeem_partner_coupon`,
-          {
-            method: 'POST',
-            body: JSON.stringify({
-              sellable: 'playlist',
-              sellable_id: sellableId,
-              email: token.email,
-              client_id: clientId,
-            }),
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${process.env.EGGHEAD_EPIC_WEB_BOT_TOKEN}`,
+          const response = await fetch(
+            `${process.env.EGGHEAD_API_URL}/api/v1/sellable_purchases/redeem_partner_coupon`,
+            {
+              method: 'POST',
+              body: JSON.stringify({
+                sellable: 'playlist',
+                sellable_id: sellableId,
+                email: token.email,
+                client_id: clientId,
+              }),
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${process.env.EGGHEAD_EPIC_WEB_BOT_TOKEN}`,
+              },
             },
-          },
-        )
+          )
 
-        const json = await response.json()
+          json = await response.json()
+        } else {
+          throw new Error('No sellableId found for bonus slug')
+        }
 
         const newBonuses = bonusSlugs.filter((slug) => slug !== input.bonusSlug)
 


### PR DESCRIPTION
We have three flows through this `redeemBonus` endpoint.

1. If the bonus is TJS, then we create a `Purchase` record in `kcd-products`.
2. If the bonus is ER, then we continue to create a `purchase` record with egghead-rails.
3. If it is anything else, then we raise an error.

For flows 1 and 2, the branches come back together to update the upstash data.

![redeem](https://media1.giphy.com/media/PJLHNaEpmeqUU/giphy.gif?cid=d1fd59ab3hn97q06bk02hwn7klbetiannjey2vqmvo8jr7lr&ep=v1_gifs_search&rid=giphy.gif&ct=g)