### PR TITLE
feat: add script to migrate PT fields to Markdown

### DIFF
--- a/apps/epic-react/package.json
+++ b/apps/epic-react/package.json
@@ -122,6 +122,7 @@
   },
   "devDependencies": {
     "@next/env": "^12.2.2",
+    "@sanity/block-content-to-markdown": "^0.0.5",
     "@skillrecordings/scripts": "workspace:*",
     "@skillrecordings/tsconfig": "workspace:*",
     "@skillrecordings/types": "workspace:*",

--- a/apps/epic-react/src/migrations/pt-to-md.ts
+++ b/apps/epic-react/src/migrations/pt-to-md.ts
@@ -1,0 +1,189 @@
+// HOW TO USE:
+// 1. Change the field type from 'body' to 'markdown' (e.g. in schemas/documents/article.ts)
+// 2. Run `sanity exec --with-user-token migrations/pt-to-md.ts`
+
+// @ts-ignore
+import BlocksToMarkdown from '@sanity/block-content-to-markdown'
+import {getCliClient} from 'sanity/cli'
+import {Transaction} from '@sanity/client'
+import chunk from 'lodash/chunk'
+
+type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
+type Metadata = {
+  _id: string
+  _rev: string
+}
+
+type Doc = Prettify<
+  | ({
+      body: any[]
+    } & Metadata)
+  | ({summary: any[]} & Metadata)
+>
+
+type DocPatch = {
+  id: string
+  patch:
+    | {
+        set: {body: string}
+        ifRevisionID: string
+      }
+    | {
+        set: {summary: string}
+        ifRevisionID: string
+      }
+}
+
+// Gets the client configuration from `sanity.cli.ts` and returns a client.
+// Will include write token when run with `sanity exec --with-user-token`
+const client = getCliClient()
+
+// Fetch the documents we want to migrate, and return only the fields we need.
+const fetchDocuments = async () => {
+  const pairs = [
+    ['section', 'body'],
+    ['module', 'body'],
+    ['tip', 'body'],
+    ['tip', 'summary'],
+    ['explainer', 'body'],
+    ['testimonial', 'body'],
+    ['exercise', 'body'],
+  ]
+
+  const collectionOfDocuments: {[key: string]: any[]} = {}
+
+  for (const pair of pairs) {
+    const [documentType, fieldName] = pair
+
+    const key = `${documentType}:${fieldName}`
+
+    collectionOfDocuments[key] = await client.fetch(
+      `*[_type == '${documentType}' && defined(${fieldName})] {_id, _rev, ${fieldName}}`,
+    )
+  }
+
+  return collectionOfDocuments
+}
+
+// Build a patch for each document, represented as a tuple of `[documentId, patch]`
+const buildPatches = (docs: Doc[]) => {
+  return docs.map((doc: Doc): DocPatch => {
+    if ('body' in doc) {
+      const bodyMarkdown = BlocksToMarkdown(doc.body, {serializers})
+      console.log({bodyMarkdown})
+      return {
+        id: doc._id,
+        patch: {
+          set: {body: bodyMarkdown},
+          // this will cause the migration to fail if any of the documents has been
+          // modified since it was fetched.
+          ifRevisionID: doc._rev,
+        },
+      }
+    } else if ('summary' in doc) {
+      const bodyMarkdown = BlocksToMarkdown(doc.summary, {serializers})
+      console.log({bodyMarkdown})
+      return {
+        id: doc._id,
+        patch: {
+          set: {summary: bodyMarkdown},
+          // this will cause the migration to fail if any of the documents has been
+          // modified since it was fetched.
+          ifRevisionID: doc._rev,
+        },
+      }
+    } else {
+      const exhaustiveCheck: never = doc
+      throw new Error(`Unhandled doc case: ${exhaustiveCheck}`)
+    }
+  })
+}
+
+const createTransaction = (patches: DocPatch[]): Transaction =>
+  patches.reduce(
+    (tx: any, patch: DocPatch) => tx.patch(patch.id, patch.patch),
+    client.transaction(),
+  )
+
+const commitTransaction = (tx: Transaction) => tx.commit()
+
+const migrateByDocumentInBatches = async (): Promise<void> => {
+  const documents = await fetchDocuments()
+  for (const [docKey, collection] of Object.entries(documents)) {
+    // const [documentType, fieldName] = docKey.split(':')
+
+    for (const subCollection of chunk(collection, 100)) {
+      const patches = buildPatches(subCollection)
+
+      console.log(
+        `Migrating batch:\n %s`,
+        patches
+          .map((patch) => `${patch.id} => ${JSON.stringify(patch)}`)
+          .join('\n'),
+      )
+      const transaction = createTransaction(patches)
+      await commitTransaction(transaction)
+    }
+  }
+}
+
+migrateByDocumentInBatches().catch((err: any) => {
+  console.error(err)
+  process.exit(1)
+})
+
+const {getImageUrl} = BlocksToMarkdown
+
+const serializers = {
+  types: {
+    image: ({node}: any) =>
+      `![${node.alt || ''}](${getImageUrl({options: {}, node})})`,
+    // From @sanity/code-input
+    code: ({node}: any) => `\`\`\`${node.language || ''}\n${node.code}\n\`\`\``,
+    bodyTweet: ({node}: any) => `Tweet from ${node.tweet.handle}`,
+    bodyImage: ({node}: any) =>
+      `![${node.image.alt ? node.image.alt : ''}](${node.image.url})`,
+    bodyVideo: ({node}: any) => {
+      const {url, title} = node
+      return url
+        ? title
+          ? `<Video url="${url}" title="${title}" />`
+          : `<Video url="${url}" />`
+        : ''
+    },
+    callout: ({node}: any) => {
+      const {body} = node
+      return `${BlocksToMarkdown(body)}`
+    },
+    divider: () => `---`,
+  },
+  marks: {
+    internalLink: ({mark, children}: any) => {
+      const {slug = {}} = mark
+      const href = `/${slug.current}`
+      return `[${children}](${href})`
+    },
+    link: ({mark, children}: any) => {
+      // Read https://css-tricks.com/use-target_blank/
+      const {blank, href} = mark
+      return blank
+        ? `<a href="${href}" target="_blank" rel="noopener">${children}</a>`
+        : `[${children}](${href})`
+    },
+    externalLink: ({mark, children}: any) => {
+      const {blank, href} = mark
+      return blank
+        ? `<a href="${href}" target="_blank" rel="noopener">${children}</a>`
+        : `[${children}](${href})`
+    },
+    emoji: ({mark, children}: any) => {
+      return `${children}`
+    },
+    undefined: () => {
+      return ''
+    },
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1518,6 +1518,9 @@ importers:
       '@next/env':
         specifier: ^12.2.2
         version: 12.3.4
+      '@sanity/block-content-to-markdown':
+        specifier: ^0.0.5
+        version: 0.0.5
       '@skillrecordings/scripts':
         specifier: workspace:*
         version: link:../../packages/scripts
@@ -14145,7 +14148,6 @@ packages:
       '@sanity/image-url': 0.140.22
       hyperscript: 2.0.2
       object-assign: 4.1.1
-    dev: false
 
   /@sanity/block-content-to-hyperscript@3.0.0:
     resolution: {integrity: sha512-uoXWLdFY5LqO8A9sFJqnZWWDCBC+0r3Egeh0bwKQ2EK2Vil5L40iJGNXMZhDB8BnvH+6B4155SU8Q3vY59T6pA==}
@@ -14160,7 +14162,6 @@ packages:
     resolution: {integrity: sha512-wnBfusG67TU2+MXcDSNDtEdE5MMYXQ9t5hHtU+0dQ2MUHPbF6FfX0nfX0IvjfNWGpMEniCOtmJR0k71maO9zYA==}
     dependencies:
       '@sanity/block-content-to-hyperscript': 2.0.10
-    dev: false
 
   /@sanity/block-content-to-react@3.0.0(react@18.2.0):
     resolution: {integrity: sha512-oHPLlIsulsnL3ITs93RIvUPBI6nAeoSFOUf16vX4T7z4wWywxP39N1DF9mAx2tV6Kjr1fJAx5GF7zfiMXYLaqA==}
@@ -14397,7 +14398,6 @@ packages:
 
   /@sanity/generate-help-url@0.140.0:
     resolution: {integrity: sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw==}
-    dev: false
 
   /@sanity/generate-help-url@3.0.0:
     resolution: {integrity: sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA==}
@@ -14433,7 +14433,6 @@ packages:
   /@sanity/image-url@0.140.22:
     resolution: {integrity: sha512-CAmQZnj+KM7FSEYiWlIGDit072syicYuAw0w7R2ctMzHiZ4p9mE/g6dBnYqrqFUrw2J+GpJgPt+RVspKP8vdqA==}
     engines: {node: '>=10.0.0'}
-    dev: false
 
   /@sanity/image-url@1.0.2:
     resolution: {integrity: sha512-C4+jb2ny3ZbMgEkLd7Z3C75DsxcTEoE+axXQJsQ75ou0AKWGdVsP351hqK6mJUUxn5HCSlu3vznoh7Yljye4cQ==}
@@ -19038,7 +19037,6 @@ packages:
 
   /browser-split@0.0.0:
     resolution: {integrity: sha512-CNXO3AXAS1H/kOGQkPjucm1161/XoF3aVkMfujqwk85XN/D/MkQMvoB81lXyX/2rerZS+hPAYYRR3mAW05awjQ==}
-    dev: false
 
   /browserify-zlib@0.1.4:
     resolution: {integrity: sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==}
@@ -19496,7 +19494,6 @@ packages:
     resolution: {integrity: sha512-zqR0uW+VsLtyQhixBhkdQ+z6B8+Y8HTh28kdSVjJ4zTTKM7Xz2asAQSya9VI6m/34F6N6Ktm0mrchKB+E5a8Xw==}
     dependencies:
       indexof: 0.0.1
-    dev: false
 
   /class-utils@0.3.6:
     resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==}
@@ -24374,7 +24371,6 @@ packages:
     engines: {node: '>=4.2'}
     dependencies:
       class-list: 0.1.1
-    dev: false
 
   /html-encoding-sniffer@1.0.2:
     resolution: {integrity: sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==}
@@ -24610,7 +24606,6 @@ packages:
       browser-split: 0.0.0
       class-list: 0.1.1
       html-element: 2.3.1
-    dev: false
 
   /hyphenate-style-name@1.0.4:
     resolution: {integrity: sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==}
@@ -24693,7 +24688,6 @@ packages:
 
   /indexof@0.0.1:
     resolution: {integrity: sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==}
-    dev: false
 
   /infer-owner@1.0.4:
     resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}


### PR DESCRIPTION
I based this off of @vojtaholik's script 🙌 -- https://github.com/skillrecordings/products/blob/main/apps/epic-web/migrations/pt-to-md.ts

All fields that were Portable Text and were switched to Markdown have now been migrated so that the Sanity studio can render those documents.

![itysl motorcycle](https://media2.giphy.com/media/3oz8xwsGcaZWWB8KyY/giphy.gif?cid=d1fd59ab9ub5lhqi8wmht59yi3gttuy3zlbn0ylvs2oqhin7&ep=v1_gifs_search&rid=giphy.gif&ct=g)