### PR TITLE
deleting the only in test

### DIFF
--- a/packages/commerce-server/src/format-prices-for-product.test.ts
+++ b/packages/commerce-server/src/format-prices-for-product.test.ts
@@ -467,7 +467,7 @@ test('PPP coupon not available for non-ppp purchasers', async () => {
   expect(product.availableCoupons.length).toBe(0)
 })
 
-test.only('multiple purchases applies fixed discount for bundle upgrade', async () => {
+test('multiple purchases applies fixed discount for bundle upgrade', async () => {
   const mockPurchaseOne = {
     totalAmount: new Prisma.Decimal(55),
     id: 'purchase-123',


### PR DESCRIPTION
I accidentally left the `test.only` on my prev PR

![oops](https://media.giphy.com/media/TD6ZvrXfB4xMHUvxxE/giphy-downsized.gif)