### PR TITLE
feat: exclude coupon if not for productId

### DIFF
--- a/packages/commerce-server/src/format-prices-for-product.test.ts
+++ b/packages/commerce-server/src/format-prices-for-product.test.ts
@@ -107,15 +107,6 @@ test('does not apply restricted coupon to other product', async () => {
   const ONE_OFF_COUPON_FROM_CODE = 'one-off-coupon-from-code-id'
   const ONE_OFF_MERCHANT_COUPON_ID = 'one-off-merchant-coupon-id'
 
-  // const mockProductOne = {
-  //   id: OTHER_PRODUCT_ID,
-  //   name: 'basic',
-  //   createdAt: new Date(),
-  //   key: 'hey',
-  //   status: 1,
-  //   quantityAvailable: -1,
-  // }
-
   const mockOneOffCoupon = {
     id: ONE_OFF_COUPON_FROM_CODE,
     merchantCouponId: ONE_OFF_MERCHANT_COUPON_ID,

--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -221,6 +221,7 @@ export async function formatPricesForProduct(
       productId: product.id,
       purchaseToBeUpgraded: upgradeFromPurchase,
       autoApplyPPP,
+      usedCoupon,
     })
 
   const fireFixedDiscountForIndividualUpgrade = async () => {


### PR DESCRIPTION
there are many pages where we show pricing for multiple products (e.g.
when there are different tiers) and the coupon coming from a coupon code
is only relevant to one of those products. Ensure that the price gets
calculated correctly for each by restricting the coupon to its product.

### Before

![image](https://github.com/skillrecordings/products/assets/694063/85de625b-378b-4acb-b0cc-c7470e1d3ae4)


### After

<img width="1199" alt="CleanShot 2024-01-22 at 12 10 24@2x" src="https://github.com/skillrecordings/products/assets/694063/b6a525a6-654b-40f9-974d-a6e3bcd497c6">


![relevant](https://media1.giphy.com/media/fSpp0P2VYGMkzPi5Tq/giphy.gif?cid=d1fd59abjxb887bwfwz4oyziuwl9w2r09gyzc7meprag7zfz&ep=v1_gifs_search&rid=giphy.gif&ct=g)