### PR TITLE
fix: pass productIds to validateCoupon

### DIFF
--- a/apps/devrel-fyi/src/pages/index.tsx
+++ b/apps/devrel-fyi/src/pages/index.tsx
@@ -71,7 +71,7 @@ const Home: NextPage<{
 
   // TODO: should we move the coupon call down into `<Pricing>` so that it
   // can be called separate for each product?
-  const productId = products[0].productId
+  const productId = products[0]?.productId
 
   const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
     commerceProps?.couponFromCode,

--- a/apps/devrel-fyi/src/pages/index.tsx
+++ b/apps/devrel-fyi/src/pages/index.tsx
@@ -69,9 +69,14 @@ const Home: NextPage<{
       productId: defaultProduct?.productId,
     })
 
+  // TODO: should we move the coupon call down into `<Pricing>` so that it
+  // can be called separate for each product?
+  const productId = products[0].productId
+
   const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
     commerceProps?.couponFromCode,
     {
+      id: productId,
       image: {
         url: 'https://res.cloudinary.com/epic-web/image/upload/v1695972887/coupon_2x.png',
         width: 132,

--- a/apps/epic-react/src/pages/index.tsx
+++ b/apps/epic-react/src/pages/index.tsx
@@ -61,9 +61,14 @@ const Home: NextPage<{
       productId: defaultProduct?.productId,
     })
 
+  // TODO: should we move the coupon call down into `<Pricing>` so that it
+  // can be called separate for each product?
+  const productId = products[0]?.productId
+
   const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
     commerceProps?.couponFromCode,
     {
+      id: productId,
       image: {
         url: 'https://res.cloudinary.com/epic-web/image/upload/v1695972887/coupon_2x.png',
         width: 132,

--- a/apps/epic-web/src/pages/buy.tsx
+++ b/apps/epic-web/src/pages/buy.tsx
@@ -54,6 +54,7 @@ const BuyPage: React.FC<
   const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
     couponFromCode,
     {
+      id: products[0].productId,
       image: {
         url: 'https://res.cloudinary.com/epic-web/image/upload/v1695972887/coupon_2x.png',
         width: 132,

--- a/apps/epic-web/src/pages/index.tsx
+++ b/apps/epic-web/src/pages/index.tsx
@@ -69,6 +69,7 @@ const Index: NextPage<{
   const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
     commerceProps?.couponFromCode,
     {
+      id: product.productId,
       image: {
         url: 'https://res.cloudinary.com/epic-web/image/upload/v1695972887/coupon_2x.png',
         width: 132,

--- a/apps/epic-web/src/templates/event-template.tsx
+++ b/apps/epic-web/src/templates/event-template.tsx
@@ -87,6 +87,7 @@ const EventTemplate: React.FC<
   const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
     commerceProps.couponFromCode,
     {
+      id: product.productId,
       image: {
         url: 'https://res.cloudinary.com/epic-web/image/upload/v1695972887/coupon_2x.png',
         width: 132,

--- a/apps/pro-aws/src/pages/index.tsx
+++ b/apps/pro-aws/src/pages/index.tsx
@@ -58,7 +58,7 @@ const Home: NextPage<{
 
   // TODO: should we move the coupon call down into `<Pricing>` so that it
   // can be called separate for each product?
-  const productId = products[0].productId
+  const productId = products[0]?.productId
 
   const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
     commerceProps?.couponFromCode,

--- a/apps/pro-aws/src/pages/index.tsx
+++ b/apps/pro-aws/src/pages/index.tsx
@@ -56,9 +56,14 @@ const Home: NextPage<{
       productId: defaultProduct?.productId,
     })
 
+  // TODO: should we move the coupon call down into `<Pricing>` so that it
+  // can be called separate for each product?
+  const productId = products[0].productId
+
   const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
     commerceProps?.couponFromCode,
     {
+      id: productId,
       image: {
         url: 'https://res.cloudinary.com/epic-web/image/upload/v1695972887/coupon_2x.png',
         width: 132,

--- a/packages/skill-api/src/core/services/redeem-golden-ticket.ts
+++ b/packages/skill-api/src/core/services/redeem-golden-ticket.ts
@@ -42,7 +42,7 @@ export async function redeemGoldenTicket({
     } = params
     const {findOrCreateUser, getCouponWithBulkPurchases} = getSdk()
 
-    const {email: baseEmail, couponId, sendEmail = true} = req.body
+    const {email: baseEmail, couponId, sendEmail = true, productIds} = req.body
 
     if (!baseEmail) throw new Error(`invaild-email-${baseEmail}`)
 
@@ -51,7 +51,7 @@ export async function redeemGoldenTicket({
 
     const coupon = await getCouponWithBulkPurchases(couponId)
 
-    const couponValidation = validateCoupon(coupon)
+    const couponValidation = validateCoupon(coupon, productIds)
 
     if (coupon && couponValidation.isRedeemable) {
       // if the Coupon is the Bulk Coupon of a Bulk Purchase,

--- a/packages/skill-lesson/path-to-purchase/handle-self-redeem.ts
+++ b/packages/skill-lesson/path-to-purchase/handle-self-redeem.ts
@@ -14,11 +14,15 @@ type CallbackParams =
 export async function handleSelfRedeem(
   email: string,
   bulkCouponId: string,
+  productId: string | undefined,
   callback: (params: CallbackParams) => void,
 ) {
+  const productIds = productId ? [productId] : []
+
   const {purchase: redeemedPurchase} = await redeemFullPriceCoupon({
     email,
     couponId: bulkCouponId,
+    productIds,
     sendEmail: false,
   })
   if (redeemedPurchase && !redeemedPurchase.error) {

--- a/packages/skill-lesson/path-to-purchase/redeem-dialog.tsx
+++ b/packages/skill-lesson/path-to-purchase/redeem-dialog.tsx
@@ -16,6 +16,7 @@ interface RedeemDialogProps {
   open: boolean
   couponId: string
   product?: {
+    id: string
     image?: {
       url: string
       width: number
@@ -29,6 +30,9 @@ interface RedeemDialogProps {
 const RedeemDialog = ({open = false, couponId, product}: RedeemDialogProps) => {
   const {data: session} = useSession()
   const router = useRouter()
+
+  const productIds: string[] = product?.id ? [product.id] : []
+
   const formik = useFormik({
     initialValues: {
       email: session?.user?.email || '',
@@ -38,6 +42,7 @@ const RedeemDialog = ({open = false, couponId, product}: RedeemDialogProps) => {
       const {purchase, redeemingForCurrentUser} = await redeemFullPriceCoupon({
         email,
         couponId,
+        productIds,
       })
 
       if (purchase.error) {

--- a/packages/skill-lesson/path-to-purchase/redeem-full-price-coupon.ts
+++ b/packages/skill-lesson/path-to-purchase/redeem-full-price-coupon.ts
@@ -1,10 +1,12 @@
 export async function redeemFullPriceCoupon({
   email,
   couponId,
+  productIds,
   sendEmail = true,
 }: {
   email: string
   couponId: string
+  productIds: string[]
   sendEmail?: boolean
 }) {
   return await fetch(`/api/skill/redeem/coupon`, {
@@ -12,6 +14,7 @@ export async function redeemFullPriceCoupon({
     body: JSON.stringify({
       email,
       couponId,
+      productIds,
       sendEmail,
     }),
     headers: {

--- a/packages/skill-lesson/path-to-purchase/use-coupon.tsx
+++ b/packages/skill-lesson/path-to-purchase/use-coupon.tsx
@@ -10,6 +10,7 @@ type CouponValidator = {
 export function useCoupon(
   coupon?: CouponValidator,
   product?: {
+    id: string
     image?: {
       url: string
       width: number

--- a/packages/skill-lesson/team/index.tsx
+++ b/packages/skill-lesson/team/index.tsx
@@ -97,6 +97,7 @@ const InviteTeam: React.FC<React.PropsWithChildren<InviteTeamProps>> = ({
                   setPersonalPurchase(redeemedPurchase)
                   setSelfRedemptionSucceeded(true)
                 }}
+                productId={purchase.product.id}
                 disabled={!hasRedemptionsLeft}
               />
             </div>

--- a/packages/skill-lesson/team/self-redeem-button.tsx
+++ b/packages/skill-lesson/team/self-redeem-button.tsx
@@ -10,9 +10,10 @@ const SelfRedeemButton: React.FC<
     bulkCouponId: string
     onSuccess: (redeemedPurchase: Purchase) => void
     disabled: boolean
+    productId?: string
     className?: string
   }>
-> = ({userEmail, bulkCouponId, onSuccess, disabled, children}) => {
+> = ({userEmail, bulkCouponId, onSuccess, disabled, productId, children}) => {
   const [isLoading, setIsLoading] = React.useState(false)
   return (
     <Button
@@ -22,7 +23,7 @@ const SelfRedeemButton: React.FC<
       onClick={() => {
         if (userEmail) {
           setIsLoading(true)
-          handleSelfRedeem(userEmail, bulkCouponId, (params) => {
+          handleSelfRedeem(userEmail, bulkCouponId, productId, (params) => {
             if (params.status === 'success') {
               onSuccess(params.redeemedPurchase)
             } else {

--- a/packages/skill-lesson/video/video-overlays.tsx
+++ b/packages/skill-lesson/video/video-overlays.tsx
@@ -673,6 +673,7 @@ const InviteTeam: React.FC<{
             disabled={Boolean(purchaseDetails?.existingPurchase)}
             userEmail={session?.user?.email}
             bulkCouponId={purchaseDetails?.purchase?.bulkCoupon?.id}
+            productId={product?.productId}
             onSuccess={(redeemedPurchase) => {
               if (redeemedPurchase) {
                 refetchAbility()


### PR DESCRIPTION
The `validateCoupon` function now accepts a `productIds` array for validating coupons that are restricted to a certain product ID (https://github.com/skillrecordings/products/pull/1360). The `redeem-golden-ticket` flow was not passing along a list of product IDs to that function which meant that any coupon restricted to a product ID was coming out as invalid (`coupon-not-valid-for-product`).

This was also going to impact redemption of seats for team/bulk purchases.

More details on this in roam: https://roamresearch.com/#/app/egghead/page/muT11DK4o

![redemption](https://media4.giphy.com/media/McgngZjwkjZXUOmoYt/giphy.gif?cid=d1fd59abk3tj6fmdgec4xuuovv7uhwokxfvawsm9vtuye99z&ep=v1_gifs_search&rid=giphy.gif&ct=g)