### PR TITLE
fix: pass in restricted product ID to coupon modal

### DIFF
--- a/apps/testing-javascript/src/components/pricing-section.tsx
+++ b/apps/testing-javascript/src/components/pricing-section.tsx
@@ -29,8 +29,28 @@ const PricingSection: React.FC<{
   },
   className,
 }) => {
-  const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} =
-    useCoupon(couponFromCode)
+  const restrictedToProduct = couponFromCode?.restrictedToProductId
+    ? products.find(
+        (product) => product.productId === couponFromCode.restrictedToProductId,
+      )
+    : undefined
+
+  const productMetadata = restrictedToProduct
+    ? {
+        ...restrictedToProduct,
+        id: restrictedToProduct.productId,
+        image: {
+          ...restrictedToProduct.image,
+          width: 132,
+          height: 112,
+        },
+      }
+    : undefined
+
+  const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
+    couponFromCode,
+    productMetadata,
+  )
 
   const couponId =
     couponIdFromCoupon || (validCoupon ? couponFromCode?.id : undefined)

--- a/apps/testing-javascript/src/pages/index.tsx
+++ b/apps/testing-javascript/src/pages/index.tsx
@@ -145,7 +145,28 @@ const Home: React.FC<
     }
   }, [router])
 
-  const {redeemableCoupon, RedeemDialogForCoupon} = useCoupon(couponFromCode)
+  const restrictedToProduct = couponFromCode?.restrictedToProductId
+    ? products.find(
+        (product) => product.productId === couponFromCode.restrictedToProductId,
+      )
+    : undefined
+
+  const productMetadata = restrictedToProduct
+    ? {
+        ...restrictedToProduct,
+        id: restrictedToProduct.productId,
+        image: {
+          ...restrictedToProduct.image,
+          width: 132,
+          height: 112,
+        },
+      }
+    : undefined
+
+  const {redeemableCoupon, RedeemDialogForCoupon} = useCoupon(
+    couponFromCode,
+    productMetadata,
+  )
 
   return (
     <Layout>

--- a/packages/skill-lesson/path-to-purchase/redeem-dialog.tsx
+++ b/packages/skill-lesson/path-to-purchase/redeem-dialog.tsx
@@ -22,7 +22,7 @@ interface RedeemDialogProps {
       width: number
       height: number
     }
-    title: string
+    title?: string
     description?: string
   }
 }

--- a/packages/skill-lesson/path-to-purchase/use-coupon.tsx
+++ b/packages/skill-lesson/path-to-purchase/use-coupon.tsx
@@ -16,7 +16,7 @@ export function useCoupon(
       width: number
       height: number
     }
-    title: string
+    title?: string
     description?: string
   },
 ) {


### PR DESCRIPTION
If the coupon is restricted to a specific product, then we need to pass down that product ID as part of the metadata so that the `validateCoupon` check can verify the match. 

Ultimately there is some refactoring that needs to happen in this coupon flow, but for now this is a fix that will re-enable coupons for TJS.

![succession](https://media4.giphy.com/media/oxU4aYICwH4Aymx1jt/giphy.gif?cid=d1fd59absldp9wgoaxuxgmqp3m1g5fluf5h32ma42jckrngl&ep=v1_gifs_search&rid=giphy.gif&ct=g)