### PR TITLE
fix(tt): pass restricted productId to useCoupon

### DIFF
--- a/apps/total-typescript/src/pages/buy.tsx
+++ b/apps/total-typescript/src/pages/buy.tsx
@@ -35,8 +35,28 @@ const Buy: React.FC<React.PropsWithChildren<CommerceProps>> = ({
   const {scrollYProgress} = useScroll()
   const y = useTransform(scrollYProgress, [0, 1], [0, -100])
 
-  const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} =
-    useCoupon(couponFromCode)
+  const restrictedToProduct = couponFromCode?.restrictedToProductId
+    ? products.find(
+        (product) => product.productId === couponFromCode.restrictedToProductId,
+      )
+    : undefined
+
+  const productMetadata = restrictedToProduct
+    ? {
+        ...restrictedToProduct,
+        id: restrictedToProduct.productId,
+        image: {
+          ...restrictedToProduct.image,
+          width: 132,
+          height: 112,
+        },
+      }
+    : undefined
+
+  const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
+    couponFromCode,
+    productMetadata,
+  )
 
   const couponId =
     couponIdFromCoupon || (validCoupon ? couponFromCode?.id : undefined)

--- a/apps/total-typescript/src/templates/home-template.tsx
+++ b/apps/total-typescript/src/templates/home-template.tsx
@@ -30,8 +30,29 @@ export const HomeTemplate: React.FC<
   allowPurchase,
 }) => {
   const skillLevel = useSkillLevel(level)
-  const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} =
-    useCoupon(couponFromCode)
+
+  const restrictedToProduct = couponFromCode?.restrictedToProductId
+    ? products.find(
+        (product) => product.productId === couponFromCode.restrictedToProductId,
+      )
+    : undefined
+
+  const productMetadata = restrictedToProduct
+    ? {
+        ...restrictedToProduct,
+        id: restrictedToProduct.productId,
+        image: {
+          ...restrictedToProduct.image,
+          width: 132,
+          height: 112,
+        },
+      }
+    : undefined
+
+  const {redeemableCoupon, RedeemDialogForCoupon, validCoupon} = useCoupon(
+    couponFromCode,
+    productMetadata,
+  )
   const couponId =
     couponIdFromCoupon || (validCoupon ? couponFromCode?.id : undefined)
   const sortedProductsByName = products.sort((a, b) => {


### PR DESCRIPTION
This is a good temporary fix that follows suit with #1374 and #1373. Once these fixes are in place and we have a little time, a more comprehensive refactoring of this bit of coupon logic is called for.

![succession](https://media3.giphy.com/media/XDuJUONwqsLoQAe4hL/giphy.gif?cid=d1fd59abod5mzlx9ojh7xraubu905kl9zm6setzg0tkc9r5i&ep=v1_gifs_search&rid=giphy.gif&ct=g)