### PR TITLE
feat: add endpoint for requesting user magic link

### DIFF
--- a/packages/skill-api/src/core/services/create-magic-link.ts
+++ b/packages/skill-api/src/core/services/create-magic-link.ts
@@ -1,0 +1,84 @@
+import {z} from 'zod'
+import {IncomingRequest, OutgoingResponse} from '../index'
+import {SkillRecordingsHandlerParams} from '../types'
+import {createVerificationUrl} from '../../server'
+
+class AuthorizationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ValidationError'
+  }
+}
+
+const requireSkillSecret = (req: IncomingRequest): void => {
+  try {
+    const verifySkillSecretHeader = z
+      .object({skillSecretInHeader: z.string(), skillSecret: z.string()})
+      .transform(({skillSecretInHeader, skillSecret}, ctx) => {
+        if (skillSecret !== skillSecretInHeader)
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Unauthorized request to skill-api',
+          })
+      })
+
+    verifySkillSecretHeader.parse({
+      skillSecretInHeader: req.headers['x-skill-secret'],
+      skillSecret: process.env.SKILL_SECRET,
+    })
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      throw new AuthorizationError(error.message)
+    }
+
+    throw error
+  }
+}
+
+export async function createMagicLink({
+  params,
+}: {
+  params: SkillRecordingsHandlerParams
+}): Promise<OutgoingResponse> {
+  try {
+    const {req} = params
+    requireSkillSecret(req)
+
+    const email = z.string().parse(req.query.email)
+
+    const {nextAuthOptions} = params.options
+
+    const verificationDetails = await createVerificationUrl({
+      email,
+      nextAuthOptions,
+    })
+
+    if (!verificationDetails) {
+      return {
+        status: 200,
+        body: {message: 'Unable to create the verification URL'},
+      }
+    }
+
+    return {
+      status: 200,
+      body: {
+        url: verificationDetails.url,
+      },
+    }
+  } catch (error: any) {
+    if (error instanceof AuthorizationError) {
+      return {
+        status: 401,
+        body: {
+          error: 'Unauthorized',
+        },
+      }
+    } else {
+      return {
+        status: 500,
+        body: {error: true, message: error.message},
+      }
+    }
+  }
+}

--- a/packages/skill-api/src/router.ts
+++ b/packages/skill-api/src/router.ts
@@ -16,6 +16,7 @@ import {updateName} from './core/services/update-name'
 import {transferPurchase} from './core/services/transfer-purchase'
 import {stripeRefund} from './core/services/process-refund'
 import {processSanityWebhooks} from './core/services/process-sanity-webhooks'
+import {createMagicLink} from './core/services/create-magic-link'
 
 export type SkillRecordingsAction =
   | 'send-feedback'
@@ -33,6 +34,7 @@ export type SkillRecordingsAction =
   | 'transfer'
   | 'nameUpdate'
   | 'refund'
+  | 'create-magic-link'
 
 export type SkillRecordingsProvider = 'stripe' | 'sanity'
 
@@ -95,6 +97,8 @@ export async function actionRouter({
         return await transferPurchase({params})
       case 'refund':
         return await stripeRefund({params})
+      case 'create-magic-link':
+        return await createMagicLink({params})
     }
   }
 


### PR DESCRIPTION
This PR adds an internal-use (authenticated against `SKILL_SECRET`) endpoint for requesting a magic link on behalf of a user. It makes use of the existing Verification URL logic that hooks into NextAuth.

Example of calling this `api/skill/create-magic-link` endpoint via a REST client with an `email` param and the `x-skill-secret` header:

![CleanShot 2024-02-06 at 12 05 55@2x](https://github.com/skillrecordings/products/assets/694063/57588221-70a4-41d7-aa25-dcfe503268b6)


![magic link](https://media3.giphy.com/media/8qD9cHJtwqvBHixkcz/giphy.gif?cid=d1fd59absfjw7ierdljkv9kn4qfrsf6o1542tjevo40gnsd6&ep=v1_gifs_search&rid=giphy.gif&ct=g)