### PR TITLE
jb/fix button descriptions for completed modules

### DIFF
--- a/apps/testing-javascript/src/components/playlist/playlist-item.tsx
+++ b/apps/testing-javascript/src/components/playlist/playlist-item.tsx
@@ -13,6 +13,7 @@ import {track} from '@skillrecordings/skill-lesson/utils/analytics'
 import Icon from '@/components/icons'
 import {useModuleProgress} from '@/utils/module-progress'
 import {secondsToFormattedTime} from '@/lib/secondsToFormattedTime'
+import {getNextLessonDetails} from '@/utils/get-next-lesson-details'
 
 const PlaylistItem: React.FC<{
   playlist: SanityDocument
@@ -20,8 +21,25 @@ const PlaylistItem: React.FC<{
 }> = ({playlist, purchased}) => {
   const lessons = playlist?.sections?.[0]?.lessons || []
   const moduleProgress = useModuleProgress()
-  const firstLessonSlug = lessons?.[0].slug
-  const nextLessonSlug = moduleProgress?.nextLesson?.slug
+
+  let nextLessonDetails: ReturnType<typeof getNextLessonDetails>
+
+  {
+    const firstLessonSlug = lessons?.[0].slug
+    const nextLessonSlug = moduleProgress?.nextLesson?.slug
+    const moduleCompleted = moduleProgress?.moduleCompleted || false
+    const completedLessonCount = moduleProgress?.completedLessonCount || 0
+
+    nextLessonDetails = getNextLessonDetails({
+      firstLessonSlug,
+      nextLessonSlug,
+      moduleCompleted,
+      completedLessonCount,
+    })
+  }
+
+  const {nextLessonSlug, buttonText} = nextLessonDetails
+
   return (
     <li className="flex flex-col items-center md:items-start space-y-6 md:space-y-0 md:flex-row md:space-x-8 lg:space-x-12">
       <div className="flex flex-col item-center shrink-0 space-y-4 md:space-y-6 lg:space-y-8">
@@ -152,11 +170,7 @@ const PlaylistItem: React.FC<{
         </div>
         {purchased && (
           <Link
-            href={
-              nextLessonSlug
-                ? `/lessons/${nextLessonSlug}`
-                : `/lessons/${firstLessonSlug}`
-            }
+            href={`/lessons/${nextLessonSlug}`}
             className="space-x-4 inline-flex items-center bg-gray-100 text-black px-6 py-2 rounded-md mt-7 hover:bg-gray-200 duration-100 min-h-[50px]"
             onClick={() => {
               track('clicked view workshop module', {
@@ -165,12 +179,7 @@ const PlaylistItem: React.FC<{
             }}
           >
             <Icon name="play" className="w-[10px] h-[10px]" />
-            <span>
-              {nextLessonSlug && nextLessonSlug !== firstLessonSlug
-                ? 'Continue'
-                : 'Start'}{' '}
-              Watching
-            </span>
+            <span>{buttonText}</span>
           </Link>
         )}
         {playlist?.body && (

--- a/apps/testing-javascript/src/templates/workshop-template.tsx
+++ b/apps/testing-javascript/src/templates/workshop-template.tsx
@@ -8,6 +8,7 @@ import Layout from '@/components/layout'
 import Icon from '@/components/icons'
 import {secondsToFormattedTime} from '@/lib/secondsToFormattedTime'
 import {Module} from '@/@types/'
+import {getNextLessonDetails} from '@/utils/get-next-lesson-details'
 
 const LessonItem: React.FC<{lesson: any; index: number}> = ({
   lesson,
@@ -58,54 +59,6 @@ const LessonItem: React.FC<{lesson: any; index: number}> = ({
       </div>
     </li>
   )
-}
-
-const getNextLessonDetails = ({
-  firstLessonSlug,
-  nextLessonSlug,
-  moduleCompleted,
-  completedLessonCount,
-}: {
-  firstLessonSlug: string
-  nextLessonSlug: string | undefined
-  moduleCompleted: boolean
-  completedLessonCount: number
-}) => {
-  // Three Options Are:
-  //
-  // 1. if the module has been completed
-  //    - 'Watch Again'
-  //    - nextLessonSlug is firstLessonSlug
-  //
-  // 2. if the module has not been started
-  //    - 'Start Watching'
-  //    - nextLessonSlug is firstLessonSlug
-  //
-  // 3. if the module has been started
-  //    - 'Continue Watching'
-  //    - nextLessonSlug is nextLessonSlug
-
-  if (moduleCompleted) {
-    return {
-      status: 'MODULE_COMPLETED' as const,
-      buttonText: 'Watch Again',
-      nextLessonSlug: firstLessonSlug,
-    }
-  }
-
-  if (completedLessonCount > 0) {
-    return {
-      status: 'MODULE_IN_PROGRESS' as const,
-      buttonText: 'Continue Watching',
-      nextLessonSlug,
-    }
-  }
-
-  return {
-    status: 'MODULE_UNSTARTED' as const,
-    buttonText: 'Start Watching',
-    nextLessonSlug: firstLessonSlug,
-  }
 }
 
 const WorkshopTemplate: React.FC<{

--- a/apps/testing-javascript/src/utils/get-next-lesson-details.ts
+++ b/apps/testing-javascript/src/utils/get-next-lesson-details.ts
@@ -1,0 +1,47 @@
+export const getNextLessonDetails = ({
+  firstLessonSlug,
+  nextLessonSlug,
+  moduleCompleted,
+  completedLessonCount,
+}: {
+  firstLessonSlug: string
+  nextLessonSlug: string | undefined
+  moduleCompleted: boolean
+  completedLessonCount: number
+}) => {
+  // Three Options Are:
+  //
+  // 1. if the module has been completed
+  //    - 'Watch Again'
+  //    - nextLessonSlug is firstLessonSlug
+  //
+  // 2. if the module has not been started
+  //    - 'Start Watching'
+  //    - nextLessonSlug is firstLessonSlug
+  //
+  // 3. if the module has been started
+  //    - 'Continue Watching'
+  //    - nextLessonSlug is nextLessonSlug
+
+  if (moduleCompleted) {
+    return {
+      status: 'MODULE_COMPLETED' as const,
+      buttonText: 'Watch Again',
+      nextLessonSlug: firstLessonSlug,
+    }
+  }
+
+  if (completedLessonCount > 0) {
+    return {
+      status: 'MODULE_IN_PROGRESS' as const,
+      buttonText: 'Continue Watching',
+      nextLessonSlug,
+    }
+  }
+
+  return {
+    status: 'MODULE_UNSTARTED' as const,
+    buttonText: 'Start Watching',
+    nextLessonSlug: firstLessonSlug,
+  }
+}


### PR DESCRIPTION
The logic that controlled the Module Watch button was not accounting for the scenario of a user having completed (watch all the lessons) a module. So when there wasn't a _Next Lesson_ for a module, the logic would revert the button text back to 'Start Watching'.

This PR creates a shared helper used across the index and workshop page that accounts for all three scenarios:
- Start Watching
- Continue Watching
- Watch Again

---

- feat(tjs): display logic considers complete module
- feat(tjs): display Watch Again on index as well

### Before

<img width="1055" alt="CleanShot 2024-02-06 at 13 30 39@2x" src="https://github.com/skillrecordings/products/assets/694063/24713b6d-7528-4de0-80c3-87bace5da3ce">


### After

<img width="1052" alt="CleanShot 2024-02-06 at 13 29 15@2x" src="https://github.com/skillrecordings/products/assets/694063/b52058db-a477-4d6b-98ab-cedfe3a5a932">

![watch again](https://media2.giphy.com/media/TCyYUo10qST3T4qV3m/giphy.gif?cid=d1fd59abgv3zhp3s76hp2wo1y071kjn8493sn4925vbbppe7&ep=v1_gifs_search&rid=giphy.gif&ct=g)
