### PR TITLE
feat(er): use custom path builder for lesson list

### DIFF
--- a/apps/epic-react/src/templates/lesson-template.tsx
+++ b/apps/epic-react/src/templates/lesson-template.tsx
@@ -34,6 +34,7 @@ import {createAppAbility} from '@skillrecordings/skill-lesson/utils/ability'
 import {isBrowser} from '@skillrecordings/skill-lesson/utils/is-browser'
 import Container from '@/components/app/container'
 import {track} from '@/utils/analytics'
+import {lessonPathBuilder} from '@/utils/lesson-path-builder'
 
 const ExerciseTemplate: React.FC<{
   transcript: any[]
@@ -359,6 +360,7 @@ const LessonList: React.FC<{
         >
           <Collection.Root
             module={module}
+            lessonPathBuilder={lessonPathBuilder}
             resourcesRenderer={(type) => {
               return (
                 <>

--- a/apps/epic-react/src/templates/workshop-template.tsx
+++ b/apps/epic-react/src/templates/workshop-template.tsx
@@ -54,6 +54,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import CertificateForm from '@/certificate/certificate-form'
 import {RxReset} from 'react-icons/rx'
 import pluralize from 'pluralize'
+import {lessonPathBuilder} from '@/utils/lesson-path-builder'
 
 const WorkshopTemplate: React.FC<{
   workshop: Module
@@ -195,7 +196,10 @@ const WorkshopTemplate: React.FC<{
               <div className="-mx-10 mt-10 border-t px-10 pt-8">
                 {moduleProgressStatus === 'success' ? (
                   <>
-                    <Collection.Root module={workshop}>
+                    <Collection.Root
+                      module={workshop}
+                      lessonPathBuilder={lessonPathBuilder}
+                    >
                       <div className="flex w-full items-center justify-between pb-3">
                         <h3 className="text-lg font-semibold">Contents</h3>
                         <Collection.Metadata className="font-mono text-xs font-medium uppercase" />

--- a/apps/epic-react/src/utils/lesson-path-builder.ts
+++ b/apps/epic-react/src/utils/lesson-path-builder.ts
@@ -1,0 +1,17 @@
+import {type Module} from '@skillrecordings/skill-lesson/schemas/module'
+import {type Section} from '@skillrecordings/skill-lesson/schemas/section'
+import {type Lesson} from '@skillrecordings/skill-lesson/schemas/lesson'
+import pluralize from 'pluralize'
+
+export const lessonPathBuilder = (
+  lesson: Lesson,
+  module: Module,
+  section?: Section,
+) => {
+  const pathname = `/${pluralize(module.moduleType)}/[module]/[lesson]`
+  const query = {
+    lesson: lesson.slug,
+    module: module.slug.current,
+  }
+  return {pathname, query}
+}

--- a/packages/skill-lesson/video/collection/index.tsx
+++ b/packages/skill-lesson/video/collection/index.tsx
@@ -49,6 +49,11 @@ type CollectionContextValue = {
     sectionProgress?: SectionProgress,
   ) => React.ReactNode
   resourcesRenderer?: (type?: string) => React.ReactNode
+  lessonPathBuilder: (
+    lesson: LessonType,
+    module: Module,
+    section?: SectionType,
+  ) => {pathname: string; query: {[key: string]: string}}
   path?: string
 }
 const [CollectionProvider, useCollectionContext] =
@@ -64,6 +69,11 @@ interface CollectionProps extends PrimitiveDivProps {
     sectionProgress?: SectionProgress,
   ) => React.ReactNode
   resourcesRenderer?: (type?: string) => React.ReactNode
+  lessonPathBuilder?: (
+    lesson: LessonType,
+    module: Module,
+    section?: SectionType,
+  ) => {pathname: string; query: {[key: string]: string}}
 }
 
 const Collection = React.forwardRef<CollectionElement, CollectionProps>(
@@ -111,6 +121,7 @@ const Collection = React.forwardRef<CollectionElement, CollectionProps>(
         )
       },
       resourcesRenderer,
+      lessonPathBuilder = getLessonHref,
       ...collectionProps
     } = props
     const {sections, lessons} = module
@@ -167,6 +178,7 @@ const Collection = React.forwardRef<CollectionElement, CollectionProps>(
         path={path}
         scope={__scopeCollection}
         resourcesRenderer={resourcesRenderer}
+        lessonPathBuilder={lessonPathBuilder}
       >
         <TooltipProvider>
           {children ? (
@@ -496,8 +508,14 @@ const Lesson = React.forwardRef<LessonElement, LessonProps>(
       scrollContainerRef,
       ...lessonProps
     } = props
-    const {module, checkIconRenderer, lockIconRenderer, path, openedSections} =
-      useCollectionContext(COLLECTION_NAME, __scopeCollection)
+    const {
+      module,
+      checkIconRenderer,
+      lockIconRenderer,
+      path,
+      openedSections,
+      lessonPathBuilder,
+    } = useCollectionContext(COLLECTION_NAME, __scopeCollection)
     const moduleProgress = useModuleProgress()
 
     const useAbilities = () => {
@@ -551,6 +569,8 @@ const Lesson = React.forwardRef<LessonElement, LessonProps>(
     useScrollToActiveLesson(activeElementToScrollTo, scrollContainerRef)
 
     if (!lesson) return null
+
+    const lessonPath = lessonPathBuilder(lesson, module, section)
 
     return (
       <Primitive.li
@@ -609,7 +629,7 @@ const Lesson = React.forwardRef<LessonElement, LessonProps>(
               {isLessonActive && <div ref={scrollElRef} aria-hidden="true" />}
               <Link
                 data-item={lesson._type}
-                href={getLessonHref(lesson, module, section)}
+                href={lessonPath}
                 passHref
                 scroll={activeLesson ? false : true}
               >


### PR DESCRIPTION
This adds an optional `lessonPathBuilder` function to the root `Collection` component so that individual apps can override how those paths are built. This is useful if the path structure of lessons for a specific app differs from the norm. In the case of Epic React v1 we don't use section slugs in the lesson paths. Instead, regardless of whether a lesson is nested in a section or not, we want to render the path as `/workshops/[module-slug]/[lesson-slug]`. This makes overriding the default easy.

This is implemented against https://github.com/skillrecordings/products/pull/1365, but I'm opening as a separate PR to make it easier to review.

![overdrive](https://media2.giphy.com/media/bHG5gzKfPESAGr4Dxg/giphy.gif?cid=d1fd59abxcte8xsll5htvx7hgmm6yntaxtgsa7y7ae4m53is&ep=v1_gifs_search&rid=giphy.gif&ct=g)