### PR TITLE
fix: fallback to empty array if no pricing

### DIFF
--- a/apps/epic-react/src/pages/index.tsx
+++ b/apps/epic-react/src/pages/index.tsx
@@ -27,7 +27,7 @@ const defaultProductId = process.env.NEXT_PUBLIC_DEFAULT_PRODUCT_ID
 export const getStaticProps: GetStaticProps = async () => {
   const defaultProduct = await getProduct(defaultProductId as string)
   const pricing = await getPricing()
-  const products = pricing && pricing.products
+  const products = (pricing && pricing.products) || []
   const availableBonuses = await getAvailableBonuses()
   const landingPage = await getPage('landing-page')
   const landingCopy = landingPage?.body


### PR DESCRIPTION
I'll work on a more long-term fix, but in the meantime this will avoid the error if there are no pricing/products.

![image](https://github.com/skillrecordings/products/assets/694063/c9ff2e09-bcaf-4fe2-ba5a-e1906e1c2971)

![super bowl](https://media1.giphy.com/media/NIQukcLkdno9O3j9dc/giphy.gif?cid=d1fd59ab45bfysgklh213vcecy81jxce6h7rtci0fw5pqpoc&ep=v1_gifs_search&rid=giphy.gif&ct=g)