### PR TITLE
refactor(er): tweak Learn page

### DIFF
--- a/apps/epic-react/src/pages/learn.tsx
+++ b/apps/epic-react/src/pages/learn.tsx
@@ -22,17 +22,12 @@ export const getServerSideProps: GetServerSideProps = async ({req, query}) => {
 }
 
 const ResourceLink: React.FC<{
-  _id: string
   title: string
   workshopSlug: string
   resourceSlug: string
-}> = ({_id, title, workshopSlug, resourceSlug}) => {
+}> = ({title, workshopSlug, resourceSlug}) => {
   return (
-    <Link
-      key={_id}
-      href={`/workshops/${workshopSlug}/${resourceSlug}`}
-      className="block"
-    >
+    <Link href={`/workshops/${workshopSlug}/${resourceSlug}`} className="block">
       {title}
     </Link>
   )
@@ -46,6 +41,8 @@ const Learn: React.FC<{workshops: any[]; bonuses: any[]}> = ({
 
   const workshops = WorkshopSchema.array().parse(unparsedWorkshops)
   const bonuses = BonusSchema.array().parse(unparsedBonuses)
+
+  console.log({workshops})
 
   return (
     <Layout
@@ -73,7 +70,7 @@ const Learn: React.FC<{workshops: any[]; bonuses: any[]}> = ({
                       if (resource._type === 'explainer') {
                         return (
                           <ResourceLink
-                            _id={resource._id}
+                            key={resource._id}
                             title={resource.title}
                             workshopSlug={workshop.slug.current}
                             resourceSlug={resource.slug}
@@ -81,28 +78,14 @@ const Learn: React.FC<{workshops: any[]; bonuses: any[]}> = ({
                         )
                       }
 
-                      if (resource._type === 'section') {
-                        const sectionResources = resource.resources || []
+                      if (resource._type === 'section' && resource?.resources) {
                         return (
-                          <>
-                            <h4 className="text-1xl font-bold">
-                              Section: {resource.title}
-                            </h4>
-                            <ul>
-                              {sectionResources.map((sectionResource) => {
-                                return (
-                                  <li>
-                                    <ResourceLink
-                                      _id={sectionResource._id}
-                                      title={sectionResource.title}
-                                      workshopSlug={workshop.slug.current}
-                                      resourceSlug={sectionResource.slug}
-                                    />
-                                  </li>
-                                )
-                              })}
-                            </ul>
-                          </>
+                          <ResourceLink
+                            key={resource._id}
+                            title={resource.title}
+                            workshopSlug={workshop.slug.current}
+                            resourceSlug={resource.resources[0].slug}
+                          />
                         )
                       }
                     })}


### PR DESCRIPTION
This tweaks workshop content output so that instead of showing section title and output all section's lessons now we show just link with section title as label that redirects to the first it's lesson (like current EpicReact does)

<details>
  <summary>Before:</summary>
  <img width="1000" src="https://github.com/skillrecordings/products/assets/1519448/9900f775-1277-43fb-a477-ed3194382010">
</details>
<details>
  <summary>After:</summary>
  <img width="1000" src="https://github.com/skillrecordings/products/assets/1519448/6f8ca95d-c7aa-4d71-b75c-e164d31ff4bf">
</details>

![Url Redirecting GIF by Derek Tee](https://github.com/skillrecordings/products/assets/1519448/747a8d62-48c7-46e8-8327-fb452de85589)


