### PR TITLE
feat(tt): add `chapterResource` document to Sanity schema

### DIFF
--- a/apps/total-typescript/schemas/deskStructure.ts
+++ b/apps/total-typescript/schemas/deskStructure.ts
@@ -12,8 +12,8 @@ import exercises from './structure/exercises'
 import sections from './structure/sections'
 import links from './structure/links'
 import emails from './structure/emails'
-
 import videoResources from './structure/videoResources'
+import chapterResources from './structure/chapterResources'
 
 const hiddenDocTypes = (listItem: any) =>
   ![
@@ -31,6 +31,7 @@ const hiddenDocTypes = (listItem: any) =>
     'linkResource',
     'interview',
     'email',
+    'chapterResource',
   ].includes(listItem.getId())
 
 export default (S: any) =>
@@ -46,6 +47,7 @@ export default (S: any) =>
       tips(S),
       bonuses(S),
       chapters(S),
+      chapterResources(S),
       emails(S),
       S.divider(),
       videoResources(S),

--- a/apps/total-typescript/schemas/documents/chapterResource.tsx
+++ b/apps/total-typescript/schemas/documents/chapterResource.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react'
+import {MdBook} from 'react-icons/md'
+
+export default {
+  name: 'chapterResource',
+  type: 'document',
+  title: 'Chapter Resource',
+  icon: MdBook,
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      validation: (Rule) => Rule.required(),
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+    },
+    {
+      name: 'state',
+      title: 'Current State',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+      initialValue: 'draft',
+      options: {
+        list: [
+          {title: 'draft', value: 'draft'},
+          {title: 'published', value: 'published'},
+        ],
+      },
+    },
+    {
+      name: 'resources',
+      title: 'Resources',
+      type: 'array',
+      of: [{type: 'linkResource'}, {type: 'tweet'}],
+    },
+    {
+      name: 'body',
+      title: 'Body',
+      type: 'markdown',
+    },
+    {
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+    },
+    {
+      name: 'concepts',
+      title: 'Concepts',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{type: 'concept'}],
+        },
+      ],
+    },
+    {
+      name: 'description',
+      title: 'Short Description',
+      description: 'Used as a short "SEO" summary on Twitter cards etc.',
+      type: 'text',
+      validation: (Rule) => Rule.max(160),
+    },
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      media: 'image.asset.url',
+    },
+    prepare(selection) {
+      const {title, media} = selection
+      console.log({selection})
+      return {
+        title,
+        media: media && <img src={media} alt={title} />,
+      }
+    },
+  },
+}

--- a/apps/total-typescript/schemas/documents/module.tsx
+++ b/apps/total-typescript/schemas/documents/module.tsx
@@ -73,6 +73,7 @@ export default {
             {title: 'Explainer', type: 'explainer'},
             {title: 'Interview', type: 'interview'},
             {title: 'Testimonial', type: 'testimonial'},
+            {title: 'Chapter Resource', type: 'chapterResource'},
             {type: 'linkResource'},
             {title: 'CTA', type: 'cta'},
           ],

--- a/apps/total-typescript/schemas/index.ts
+++ b/apps/total-typescript/schemas/index.ts
@@ -14,6 +14,7 @@ import product from './documents/product'
 import article from './documents/article'
 import concept from './documents/concept'
 import email from './documents/email'
+import chapterResource from './documents/chapterResource'
 // —— objects
 // body
 import body from './objects/body'
@@ -54,6 +55,7 @@ export const schemaTypes = [
   article,
   concept,
   email,
+  chapterResource,
   // objects
   body,
   bodyVideo,

--- a/apps/total-typescript/schemas/structure/chapterResources.js
+++ b/apps/total-typescript/schemas/structure/chapterResources.js
@@ -1,0 +1,9 @@
+import {MdBook} from 'react-icons/md'
+
+const chapterResource = (S) =>
+  S.listItem()
+    .title('Chapter Resources')
+    .icon(MdBook)
+    .child(S.documentTypeList('chapterResource').title('All chapter resources'))
+
+export default chapterResource

--- a/apps/total-typescript/schemas/structure/chapters.js
+++ b/apps/total-typescript/schemas/structure/chapters.js
@@ -1,9 +1,9 @@
-import {MdBook} from 'react-icons/md'
+import {MdMenuBook} from 'react-icons/md'
 
 const chapters = (S) =>
   S.listItem()
     .title('Chapters')
-    .icon(MdBook)
+    .icon(MdMenuBook)
     .child(
       S.documentTypeList('module')
         .filter('moduleType == "chapter"')


### PR DESCRIPTION
this will allow us to preview chapters from the written TT book.

![sanity screenshot](https://github.com/skillrecordings/products/assets/25487857/ba9b4de2-8b26-4d1b-8ab7-c85521465776)

<img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExenppdG5xbHV3aXo0cXlicnZ1MjFrMjJwc2lhcjh6em00d3Zrc3Y5ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT77Y1T0zY1gR5qe5O/giphy.gif" width="200" alt="gif">