### PR TITLE
feat(badass): markdown for the Articles

### DIFF
--- a/apps/badass/schemas/documents/article.tsx
+++ b/apps/badass/schemas/documents/article.tsx
@@ -80,6 +80,22 @@ export default defineType({
       // validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'articleHeaderImage',
+      title: 'Article Header Image: NEW',
+      type: 'externalImage',
+    }),
+    defineField({
+      name: 'markdownBody',
+      title: 'Article Body (markdown): NEW',
+      type: 'markdown',
+      // validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'shareCardImage',
+      title: 'Share Card Image: NEW',
+      type: 'externalImage',
+    }),
+    defineField({
       name: 'image',
       title: 'Image',
       type: 'image',

--- a/apps/badass/src/components/card.tsx
+++ b/apps/badass/src/components/card.tsx
@@ -143,7 +143,7 @@ const Card: React.FC<CardProps> = ({
                 </div>
               )}
               {description && (
-                <h3 className="text-neutral-200 leading-normal md:leading-[1.25] mt-4 text-center text-base md:text-xl font-medium opacity-80">
+                <h3 className="text-neutral-200 leading-normal md:leading-[1.25] mt-4 text-center text-base md:text-xl font-medium opacity-80 line-clamp-2">
                   {description}
                 </h3>
               )}

--- a/apps/badass/src/components/card.tsx
+++ b/apps/badass/src/components/card.tsx
@@ -128,8 +128,8 @@ const Card: React.FC<CardProps> = ({
           {type === 'article' && (
             <>
               {authorName && authorAvatarUrl && (
-                <div className="flex space-x-2 md:space-x-4 items-center mt-5 md:mt-6">
-                  <div className="w-9 h-9 md:w-12 md:h-12 rounded-full overflow-hidden">
+                <div className="flex space-x-2 items-center mt-5 md:mt-6">
+                  <div className="w-10 h-10 rounded-full overflow-hidden">
                     <Image
                       src={authorAvatarUrl}
                       alt={authorName}

--- a/apps/badass/src/components/landing/articles.tsx
+++ b/apps/badass/src/components/landing/articles.tsx
@@ -17,6 +17,7 @@ const Articles: React.FC<ArticlesProps> = ({articles, className = ''}) => {
     (a, b) =>
       new Date(b._createdAt).getTime() - new Date(a._createdAt).getTime(),
   )[0]
+  console.log({latestArticle})
   const restArticles = articles
     .filter((article) => article.slug !== latestArticle.slug)
     .splice(0, 4)
@@ -52,8 +53,8 @@ const Articles: React.FC<ArticlesProps> = ({articles, className = ''}) => {
               href={`/${latestArticle.slug}`}
               type="article"
               ctaText="View"
-              authorName="Joel Hooks"
-              authorAvatarUrl="/joel-hooks.jpg"
+              authorName={latestArticle.author}
+              authorAvatarUrl={latestArticle.authorAvatar}
               featuredCardColor={latestArticle.card_color}
             />
           )}

--- a/apps/badass/src/components/landing/articles.tsx
+++ b/apps/badass/src/components/landing/articles.tsx
@@ -9,9 +9,10 @@ import {ButtonSecondary} from 'components/buttons'
 
 type ArticlesProps = {
   articles: Article[]
+  className?: string
 }
 
-const Articles: React.FC<ArticlesProps> = ({articles}) => {
+const Articles: React.FC<ArticlesProps> = ({articles, className = ''}) => {
   const latestArticle = articles.sort(
     (a, b) =>
       new Date(b._createdAt).getTime() - new Date(a._createdAt).getTime(),
@@ -24,7 +25,7 @@ const Articles: React.FC<ArticlesProps> = ({articles}) => {
       title="Badass Articles"
       subtitle="Our Key Lessons Learned Along the Way"
       subtitleClassName="md:max-w-[450px] lg:max-w-[500px] xl:max-w-none"
-      className="mt-14 md:mt-[60px] lg:mt-36"
+      className={className}
       renderAdditionalComponent={() => (
         <>
           <ButtonSecondary href="/articles" size="small" className="lg:hidden">

--- a/apps/badass/src/components/landing/articles.tsx
+++ b/apps/badass/src/components/landing/articles.tsx
@@ -92,14 +92,14 @@ const Articles: React.FC<ArticlesProps> = ({articles, className = ''}) => {
                     <div className="flex space-x-2 lg:space-x-4 items-center">
                       <div className="rounded-full overflow-hidden">
                         <Image
-                          src="/joel-hooks.jpg"
-                          alt="Joel Hooks"
+                          src={article.authorAvatar}
+                          alt={article.author}
                           width={40}
                           height={40}
                         />
                       </div>
                       <div className="text-white opacity-80 uppercase font-mono tracking-[0.16px]">
-                        Joel Hooks
+                        {article.author}
                       </div>
                     </div>
                     <ButtonSecondary

--- a/apps/badass/src/components/landing/podcasts.tsx
+++ b/apps/badass/src/components/landing/podcasts.tsx
@@ -114,7 +114,7 @@ const calculateActiveSlidesPerView = () => {
   return activeSlidesPerView
 }
 
-const Podcasts: React.FC<PodcastsProps> = ({podcasts, className}) => {
+const Podcasts: React.FC<PodcastsProps> = ({podcasts, className = ''}) => {
   const [currentSlide, setCurrentSlide] = React.useState(0)
   const [loaded, setLoaded] = React.useState(false)
   const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>({

--- a/apps/badass/src/components/mdx/components/decorated-list.tsx
+++ b/apps/badass/src/components/mdx/components/decorated-list.tsx
@@ -1,18 +1,21 @@
 export type DecoratedListProps = {
   color: 'yellow' | 'blue'
   type: 'flash' | 'something'
+  reducedSpacing?: boolean
 }
 
 const DecoratedList: React.FC<React.PropsWithChildren<DecoratedListProps>> = ({
   children,
   color,
   type,
+  reducedSpacing = false,
 }) => {
   return (
     <ul
       data-decorated-list=""
       data-decorated-list-color={color}
       data-decorated-list-type={type}
+      data-reduced-spacing={reducedSpacing}
       className="not-prose"
     >
       {children}

--- a/apps/badass/src/components/mdx/components/floated-image.tsx
+++ b/apps/badass/src/components/mdx/components/floated-image.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image'
+
+export type FloatedImageProps = {
+  src: string
+  width: number
+  height: number
+  alt?: string
+  floatSide: 'left' | 'right'
+}
+
+const FloatedImage: React.FC<FloatedImageProps> = ({
+  src,
+  width,
+  height,
+  alt = '',
+  floatSide,
+}) => {
+  return (
+    <div
+      data-floated-image=""
+      data-floated-image-side={floatSide}
+      className="not-prose"
+    >
+      <Image src={src} width={width} height={height} alt={alt} />
+    </div>
+  )
+}
+
+export default FloatedImage

--- a/apps/badass/src/components/mdx/components/index.ts
+++ b/apps/badass/src/components/mdx/components/index.ts
@@ -68,3 +68,5 @@ export {
   default as DecoratedList,
   type DecoratedListProps,
 } from './decorated-list'
+
+export {default as FloatedImage, type FloatedImageProps} from './floated-image'

--- a/apps/badass/src/components/mdx/index.tsx
+++ b/apps/badass/src/components/mdx/index.tsx
@@ -36,6 +36,8 @@ import {
   EmbedVideoProps,
   DecoratedList,
   DecoratedListProps,
+  FloatedImage,
+  FloatedImageProps,
 } from './components'
 
 const mdxComponents = {
@@ -202,11 +204,23 @@ const mdxComponents = {
     children,
     color,
     type,
+    reducedSpacing,
   }: React.PropsWithChildren<DecoratedListProps>) => {
     return (
-      <DecoratedList color={color} type={type}>
+      <DecoratedList color={color} type={type} reducedSpacing={reducedSpacing}>
         {children}
       </DecoratedList>
+    )
+  },
+  FloatedImage: ({src, width, height, alt, floatSide}: FloatedImageProps) => {
+    return (
+      <FloatedImage
+        src={src}
+        width={width}
+        height={height}
+        alt={alt}
+        floatSide={floatSide}
+      />
     )
   },
 }

--- a/apps/badass/src/lib/articles.ts
+++ b/apps/badass/src/lib/articles.ts
@@ -30,6 +30,11 @@ export const ArticleSchema = z.object({
   summary: z.any().array().nullable().optional(),
   state: z.enum(['published', 'draft']),
   card_color: z.enum(['red', 'green']),
+  // new fields below
+  // TODO: clean up types
+  markdownBody: z.string().nullable(),
+  articleHeaderImage: z.string().nullable().optional(),
+  shareCardImage: z.string().nullable().optional(),
 })
 
 export const ArticlesSchema = z.array(ArticleSchema)
@@ -58,7 +63,10 @@ export const getAllArticles = async (): Promise<Article[]> => {
           "subtitle": shareCardDetails.subtitle,
           "image": shareCardDetails.image.url
         },
-        card_color
+        card_color,
+        markdownBody,
+        "articleHeaderImage": articleHeaderImage.url,
+        "shareCardImage": shareCardImage.url
   }`)
 
   return ArticlesSchema.parse(articles)
@@ -92,7 +100,10 @@ export const getArticle = async (
           "subtitle": shareCardDetails.subtitle,
           "image": shareCardDetails.image.url
         },
-        card_color
+        card_color,
+        markdownBody,
+        "articleHeaderImage": articleHeaderImage.url,
+        "shareCardImage": shareCardImage.url
     }`,
     {slug: `${slug}`},
   )

--- a/apps/badass/src/pages/[article].tsx
+++ b/apps/badass/src/pages/[article].tsx
@@ -1,10 +1,20 @@
 import React from 'react'
 import {GetStaticPaths, GetStaticProps} from 'next'
+import serializeMdx from '@skillrecordings/skill-lesson/markdown/serialize-mdx'
+import {type MDXRemoteSerializeResult} from 'next-mdx-remote'
+
 import ArticleTemplate from 'templates/article-template'
 import {Article, getAllArticles, getArticle} from 'lib/articles'
 
 export const getStaticProps: GetStaticProps = async ({params}) => {
   const article = await getArticle(params?.article as string)
+  const articleBodySerialized = article?.markdownBody
+    ? await serializeMdx(article.markdownBody, {
+        syntaxHighlighterOptions: {
+          theme: 'one-dark-pro',
+        },
+      })
+    : null
 
   if (!article) {
     return {
@@ -15,6 +25,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   return {
     props: {
       article,
+      articleBodySerialized,
     },
     revalidate: 10,
   }
@@ -35,12 +46,19 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
 
 type ArticlePageProps = {
   article: Article
+  articleBodySerialized: MDXRemoteSerializeResult
 }
 
 const ArticlePage: React.FC<React.PropsWithChildren<ArticlePageProps>> = ({
   article,
+  articleBodySerialized,
 }) => {
-  return <ArticleTemplate article={article} />
+  return (
+    <ArticleTemplate
+      article={article}
+      articleBodySerialized={articleBodySerialized}
+    />
+  )
 }
 
 export default ArticlePage

--- a/apps/badass/src/pages/articles.tsx
+++ b/apps/badass/src/pages/articles.tsx
@@ -33,7 +33,7 @@ const Articles: React.FC<React.PropsWithChildren<ArticlesProps>> = ({
                 return (
                   <Card
                     key={article._id}
-                    imageUrl={article.externalImage}
+                    imageUrl={article.articleHeaderImage}
                     title={article.title}
                     authorName={article.author}
                     authorAvatarUrl={article.authorAvatar}

--- a/apps/badass/src/pages/confirm.tsx
+++ b/apps/badass/src/pages/confirm.tsx
@@ -8,11 +8,10 @@ import {type Podcast, getAllPodcastEpisodes} from 'lib/podcast'
 import {type Article, getAllArticles} from 'lib/articles'
 
 import Layout from 'components/layout'
-import ContentSection from 'components/content-section'
-import Card from 'components/card'
-import {ButtonPrimary, ButtonSecondary} from 'components/buttons'
+import {ButtonPrimary} from 'components/buttons'
 import CaseStudies from 'components/landing/case-studies'
 import Podcasts from 'components/landing/podcasts'
+import Articles from 'components/landing/articles'
 
 import 'keen-slider/keen-slider.min.css'
 
@@ -20,62 +19,6 @@ type ConfirmationPageProps = {
   caseStudies: CaseStudy[]
   podcasts: Podcast[]
   articles: Article[]
-}
-
-type ArticlesProps = {
-  articles: Article[]
-}
-
-const Articles: React.FC<ArticlesProps> = ({articles}) => {
-  const latestArticles = articles
-    .sort(
-      (a, b) =>
-        new Date(b._createdAt).getTime() - new Date(a._createdAt).getTime(),
-    )
-    .slice(0, 2)
-  return (
-    <ContentSection
-      title="Badass Articles"
-      subtitle="Our Key Lessons Learned Along the Way"
-      subtitleClassName="md:max-w-[450px] lg:max-w-[500px] xl:max-w-none"
-      renderAdditionalComponent={() => (
-        <>
-          <ButtonSecondary href="/articles" size="small" className="lg:hidden">
-            View All Articles
-          </ButtonSecondary>
-          <ButtonSecondary
-            href="/articles"
-            size="middle"
-            className="hidden lg:inline-flex"
-          >
-            View All Articles
-          </ButtonSecondary>
-        </>
-      )}
-    >
-      <div className="mt-6 md:mt-10 lg:mt-20 gap-y-2 md:gap-y-0 md:gap-x-4 lg:gap-x-16 flex flex-col md:flex-row items-center">
-        <div className="grid md:grid-cols-2 gap-4">
-          {latestArticles.map((article) => {
-            console.log({image: article.image})
-            return (
-              <Card
-                key={article._id}
-                imageUrl={article.externalImage}
-                title={article.title}
-                description={article.description}
-                href={`/${article.slug}`}
-                type="article"
-                ctaText="View"
-                authorName="Joel Hooks"
-                authorAvatarUrl="/joel-hooks.jpg"
-                featuredCardColor={article.card_color}
-              />
-            )
-          })}
-        </div>
-      </div>
-    </ContentSection>
-  )
 }
 
 const DontMissUpdates = () => {

--- a/apps/badass/src/pages/index.tsx
+++ b/apps/badass/src/pages/index.tsx
@@ -39,7 +39,10 @@ const LandingPage: React.FC<LandingPageProps> = ({
           <CaseStudies caseStudies={caseStudies} />
           <OtherProducts />
           <Podcasts podcasts={podcasts} className="mt-14 md:mt-16 lg:mt-36" />
-          <Articles articles={articles} />
+          <Articles
+            articles={articles}
+            className="mt-14 md:mt-[60px] lg:mt-36"
+          />
         </section>
         <CallToActionForm content={genericCallToActionContent} />
       </main>

--- a/apps/badass/src/server/og-image.server.tsx
+++ b/apps/badass/src/server/og-image.server.tsx
@@ -62,10 +62,10 @@ export default async function handleCreateOgImage(req: NextRequest) {
                 </div>
               </div>
             </div>
-            <div tw="flex flex-col items-center w-[880px] text-center">
+            <div tw="flex flex-col items-center w-[880px]">
               {title && (
                 <h2
-                  tw="text-8xl text-white"
+                  tw="text-7xl text-white"
                   style={{
                     fontFamily: 'Espiritu Regular',
                   }}

--- a/apps/badass/src/styles/mdx-components.css
+++ b/apps/badass/src/styles/mdx-components.css
@@ -7,11 +7,18 @@
     @apply text-center text-neutral-200 mb-6 md:mb-10 lg:mb-12;
   }
 }
+
 [data-template-case-study='epic-react'],
 [data-template-case-study='testing-accessibility'],
 [data-template-case-study='total-typescript'] {
   a {
     @apply text-badass-green-500;
+  }
+}
+
+[data-template-article] {
+  a {
+    @apply text-badass-green-500 font-bold;
   }
 }
 
@@ -357,7 +364,10 @@
 
 /* DecoratedList */
 [data-decorated-list] {
-  @apply text-gray-200 space-y-9 my-14 list-["w"] pl-8;
+  @apply text-gray-200 space-y-6 md:space-y-9 my-12 list-["w"] pl-8;
+  &[data-reduced-spacing='true'] {
+    @apply space-y-2;
+  }
   li {
     @apply relative pl-4;
     &::marker {
@@ -366,5 +376,19 @@
   }
   &[data-decorated-list-color='yellow'] li::marker {
     @apply text-badass-yellow-500;
+  }
+  &[data-decorated-list-color='white'] li::marker {
+    @apply text-white;
+  }
+}
+
+/* FloatedImage */
+[data-floated-image] {
+  @apply w-1/2 mb-4;
+  &[data-floated-image-side='left'] {
+    @apply float-left mr-4;
+  }
+  &[data-floated-image-side='right'] {
+    @apply float-right ml-4;
   }
 }

--- a/apps/badass/src/templates/article-template.tsx
+++ b/apps/badass/src/templates/article-template.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import cx from 'classnames'
+import {type MDXRemoteSerializeResult} from 'next-mdx-remote'
+import MDX from '@skillrecordings/skill-lesson/markdown/mdx'
 import {PortableText, toPlainText} from '@portabletext/react'
 import {LinkedIn, Twitter} from '@skillrecordings/react'
 import {CalendarIcon} from '@heroicons/react/outline'
@@ -14,43 +16,97 @@ import {genericCallToActionContent} from '../components/landing-content'
 import MuxVideo from '@mux/mux-player-react'
 import Balancer from 'react-wrap-balancer'
 import type {Article} from 'lib/articles'
+import mdxComponents from 'components/mdx'
 
 type ArticleTemplateProps = {
   article: Article
+  articleBodySerialized: MDXRemoteSerializeResult
+}
+
+type HeaderProps = {
+  // TODO fix types
+  imageUrl: string | null | undefined
+  title: string
+  author: string
+  authorAvatar: string
+  publishedDate: string
+}
+
+const Header: React.FC<HeaderProps> = ({
+  imageUrl,
+  title,
+  author,
+  authorAvatar,
+  publishedDate,
+}) => {
+  return (
+    <header className="flex flex-col md:flex-row items-center max-w-5xl mx-auto w-full px-5 lg:space-x-12">
+      <div className="w-full max-w-[400px] lg:max-w-none lg:w-[440px] shrink-0">
+        {imageUrl && (
+          <Image
+            src={imageUrl}
+            alt="article header image"
+            aria-hidden="true"
+            width={880}
+            height={880}
+          />
+        )}
+      </div>
+      <div className="w-full grow">
+        <h3
+          data-header-label=""
+          className="text-badass-cyan-500 font-script text-2xl md:text-3xl lg:text-[2.5rem]"
+        >
+          Article
+        </h3>
+        <h2 className="font-heading text-3xl md:text-4xl lg:text-5xl leading-tight md:leading-tight lg:leading-tight mt-2">
+          <Balancer>{title}</Balancer>
+        </h2>
+        <div className="mt-4 lg:mt-6 flex items-center space-x-2">
+          {authorAvatar && author && (
+            <div className="w-10 h-10 overflow-hidden rounded-full">
+              <Image src={authorAvatar} alt={author} width={80} height={80} />
+            </div>
+          )}
+          <div className="font-mono uppercase opacity-70 text-xs lg:text-sm xl:text-base">
+            {author} &middot; {format(new Date(publishedDate), 'dd MMMM, y')}
+          </div>
+        </div>
+      </div>
+    </header>
+  )
 }
 
 const ArticleTemplate: React.FC<
   React.PropsWithChildren<ArticleTemplateProps>
-> = ({article}) => {
+> = ({article, articleBodySerialized}) => {
   const {
     title,
     description,
     body,
-    _createdAt: date,
+    _createdAt: publishedDate,
     video,
     image,
     externalImage,
-    shareCardDetails,
+    author,
+    authorAvatar,
+    // TODO: cleanup unused fields from the scheme
+    // shareCardDetails,
+    articleHeaderImage,
+    shareCardImage,
   } = article
-  const {
-    title: shareCardTitle,
-    subtitle: shareCardSubtitle,
-    image: shareCardImage,
-  } = shareCardDetails
+  // const {
+  //   title: shareCardTitle,
+  //   subtitle: shareCardSubtitle,
+  //   image: shareCardImage,
+  // } = shareCardDetails
 
   const shortDescription =
     description || (body && toPlainText(body).substring(0, 157) + '...')
 
-  const shareCardUrl =
-    shareCardTitle && shareCardSubtitle
-      ? `${process.env.NEXT_PUBLIC_URL}/api/og-image/?title=${encodeURI(
-          shareCardTitle,
-        )}&subtitle=${encodeURI(shareCardSubtitle)}${
-          shareCardImage || image ? `&image=${shareCardImage || image}` : ''
-        }`
-      : shareCardImage && shareCardImage
-
-  const shareCardUrlFallback = `https://badass-ogimage.vercel.app/api/card?title=${title}`
+  const shareCardUrlFallback = `${
+    process.env.NEXT_PUBLIC_URL
+  }/api/og-image/?title=${encodeURI(title)}`
 
   return (
     <Layout
@@ -59,48 +115,81 @@ const ArticleTemplate: React.FC<
         title,
         description: shortDescription,
         type: 'article',
-        date,
+        publishedDate,
         article: {
-          publishedTime: date,
+          publishedTime: publishedDate,
         },
         url: `${process.env.NEXT_PUBLIC_URL}/${article.slug}`,
         ogImage: {
-          url: shareCardUrl || shareCardUrlFallback,
+          url: shareCardImage || shareCardUrlFallback,
         },
       }}
     >
-      <Header title={title} date={date} image={externalImage} />
-      <main className="pb-10">
-        <div className="">
-          <div className="px-5 pb-16 pt-10 md:pt-16 lg:px-0">
-            {video ? (
-              <div className="mx-auto w-full max-w-screen-md pb-5">
-                <MuxVideo
-                  className="aspect-video w-full"
-                  playbackId={video.muxPlaybackId}
-                  streamType="on-demand"
-                />
+      {articleBodySerialized ? (
+        <>
+          <Header
+            title={title}
+            imageUrl={articleHeaderImage}
+            author={author}
+            authorAvatar={authorAvatar}
+            publishedDate={publishedDate}
+          />
+          <main data-template-article="" className="pb-10">
+            <div className="max-w-screen-md lg:max-w-[880px] lg:px-14 mx-auto w-full">
+              <div className="md:pt-16 pt-10 lg:px-0 px-5 pb-16">
+                <article className="prose lg:prose-xl sm:prose-lg md:prose-code:text-sm max-w-none prose-p:text-neutral-200 prose-pre:prose-code:bg-transparent prose-code:bg-white/20 prose-code:px-1 prose-code:py-0.5 prose-code:rounded lg:prose-code:text-[78%] sm:prose-code:text-[80%] mb-2 font-medium">
+                  <MDX
+                    components={mdxComponents}
+                    contents={articleBodySerialized}
+                  />
+                </article>
               </div>
-            ) : null}
-            <article className="mx-auto w-full max-w-screen-md prose sm:prose-lg lg:prose-xl first-letter:float-left first-letter:-mt-0.5 first-letter:pr-3 first-letter:font-expanded first-letter:text-6xl first-letter:text-badass-pink-500 prose-p:text-neutral-200 prose-code:rounded prose-code:bg-white/20 prose-code:px-1 prose-code:py-0.5 prose-pre:prose-code:bg-transparent sm:prose-code:text-[80%] md:prose-code:text-sm lg:prose-code:text-[78%]">
-              <PortableText value={body} components={PortableTextComponents} />
-            </article>
-            {video?.transcript ? (
-              <section className="w-full max-w-screen-md mx-auto mt-16 md:mt-24">
-                <h2 className="font-heading text-3xl leading-tight sm:text-4xl sm:leading-tight text-center">
-                  Full Transcript
-                </h2>
-                <div className="prose sm:prose-base prose-sm prose-p:text-neutral-300 mt-12">
+            </div>
+          </main>
+        </>
+      ) : (
+        <>
+          <ArticleHeader
+            title={title}
+            publishedDate={publishedDate}
+            image={externalImage}
+          />
+          <main className="pb-10">
+            <div className="">
+              <div className="px-5 pb-16 pt-10 md:pt-16 lg:px-0">
+                {video ? (
+                  <div className="mx-auto w-full max-w-screen-md pb-5">
+                    <MuxVideo
+                      className="aspect-video w-full"
+                      playbackId={video.muxPlaybackId}
+                      streamType="on-demand"
+                    />
+                  </div>
+                ) : null}
+                <article className="mx-auto w-full max-w-screen-md prose sm:prose-lg lg:prose-xl first-letter:float-left first-letter:-mt-0.5 first-letter:pr-3 first-letter:font-expanded first-letter:text-6xl first-letter:text-badass-pink-500 prose-p:text-neutral-200 prose-code:rounded prose-code:bg-white/20 prose-code:px-1 prose-code:py-0.5 prose-pre:prose-code:bg-transparent sm:prose-code:text-[80%] md:prose-code:text-sm lg:prose-code:text-[78%]">
                   <PortableText
-                    value={video.transcript}
+                    value={body}
                     components={PortableTextComponents}
                   />
-                </div>
-              </section>
-            ) : null}
-          </div>
-        </div>
-      </main>
+                </article>
+                {video?.transcript ? (
+                  <section className="w-full max-w-screen-md mx-auto mt-16 md:mt-24">
+                    <h2 className="font-heading text-3xl leading-tight sm:text-4xl sm:leading-tight text-center">
+                      Full Transcript
+                    </h2>
+                    <div className="prose sm:prose-base prose-sm prose-p:text-neutral-300 mt-12">
+                      <PortableText
+                        value={video.transcript}
+                        components={PortableTextComponents}
+                      />
+                    </div>
+                  </section>
+                ) : null}
+              </div>
+            </div>
+          </main>
+        </>
+      )}
       <CallToActionForm content={genericCallToActionContent} />
     </Layout>
   )
@@ -108,13 +197,13 @@ const ArticleTemplate: React.FC<
 
 export default ArticleTemplate
 
-const Header: React.FC<
+const ArticleHeader: React.FC<
   React.PropsWithChildren<{
     title: string
-    date: string
+    publishedDate: string
     image?: any
   }>
-> = ({title, date, image}) => {
+> = ({title, publishedDate, image}) => {
   return (
     <header className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-center px-5 pb-10 pt-5 md:flex-row">
       {image && (
@@ -143,10 +232,12 @@ const Header: React.FC<
           )}
         >
           <Author />
-          <time dateTime={date} className="flex items-center">
+          <time dateTime={publishedDate} className="flex items-center">
             <CalendarIcon aria-hidden="true" className="w-5" />{' '}
             <span className="sr-only">published on </span>
-            <span className="pl-1">{format(new Date(date), 'dd MMMM, y')}</span>
+            <span className="pl-1">
+              {format(new Date(publishedDate), 'dd MMMM, y')}
+            </span>
           </time>
         </div>
       </div>


### PR DESCRIPTION
This adds `markdownBody` field Article schema (besides some others like `shareCardImage` and `articleHeaderImage`), couple of new mdx components.
Also I've added chatGPT-generated short descriptions for the articles that missed it.
Currently only two articles have been rewritten in mdx:

1. [5 Early Decisions of a Course Business](https://badass-turbo-66t5erj3n-skillrecordings.vercel.app/5-early-decisions-of-a-course-business)
2. [The Process](https://badass-turbo-66t5erj3n-skillrecordings.vercel.app/the-process)

There is some garbage left commented out, I will clean it up after rewrite rest of articles to markdown (and create few more mdx components for that).

![Writing Zombieorpheus GIF by zoefannet](https://github.com/skillrecordings/products/assets/1519448/f244ce95-df6d-4101-aeb3-274d415fef7f)
