### PR TITLE
feat(badass): markdown for the Articles (tweaks)

### DIFF
--- a/apps/badass/src/components/card.tsx
+++ b/apps/badass/src/components/card.tsx
@@ -143,7 +143,7 @@ const Card: React.FC<CardProps> = ({
                 </div>
               )}
               {description && (
-                <h3 className="text-neutral-200 leading-normal md:leading-[1.25] mt-4 text-center text-base md:text-xl font-medium opacity-80 line-clamp-2">
+                <h3 className="text-neutral-200 leading-[normal] md:leading-[1.75] mt-4 text-center text-base md:text-xl font-medium opacity-80 line-clamp-2">
                   {description}
                 </h3>
               )}

--- a/apps/badass/src/components/landing/articles.tsx
+++ b/apps/badass/src/components/landing/articles.tsx
@@ -17,7 +17,6 @@ const Articles: React.FC<ArticlesProps> = ({articles, className = ''}) => {
     (a, b) =>
       new Date(b._createdAt).getTime() - new Date(a._createdAt).getTime(),
   )[0]
-  console.log({latestArticle})
   const restArticles = articles
     .filter((article) => article.slug !== latestArticle.slug)
     .splice(0, 4)

--- a/apps/badass/src/components/mdx/components/accented-title.tsx
+++ b/apps/badass/src/components/mdx/components/accented-title.tsx
@@ -1,11 +1,26 @@
+import Link from 'next/link'
+
 export type AccentedTitleProps = {
   text: string
   color?: string
-  balanced?: boolean
+  href?: string
 }
 
-const AccentedTitle: React.FC<AccentedTitleProps> = ({text, color}) => {
-  return (
+const AccentedTitle: React.FC<AccentedTitleProps> = ({text, color, href}) => {
+  return href ? (
+    <Link
+      href={href}
+      data-accented-title=""
+      data-accented-title-color={color || ''}
+      className="not-prose hover:brightness-75 duration-200"
+    >
+      {text && (
+        <div data-accented-title-wrapper="">
+          <h3 data-accented-title-text="">{text}</h3>
+        </div>
+      )}
+    </Link>
+  ) : (
     <div
       data-accented-title=""
       data-accented-title-color={color || ''}

--- a/apps/badass/src/components/mdx/index.tsx
+++ b/apps/badass/src/components/mdx/index.tsx
@@ -142,8 +142,8 @@ const mdxComponents = {
       />
     )
   },
-  AccentedTitle: ({text, color, balanced}: AccentedTitleProps) => {
-    return <AccentedTitle text={text} color={color} balanced={balanced} />
+  AccentedTitle: ({text, color, href}: AccentedTitleProps) => {
+    return <AccentedTitle text={text} color={color} href={href} />
   },
   AccentedSubtitle: ({
     children,

--- a/apps/badass/src/templates/article-template.tsx
+++ b/apps/badass/src/templates/article-template.tsx
@@ -59,7 +59,7 @@ const Header: React.FC<HeaderProps> = ({
         >
           Article
         </h3>
-        <h2 className="font-heading text-3xl md:text-4xl lg:text-5xl leading-tight md:leading-tight lg:leading-tight mt-2">
+        <h2 className="font-heading text-3xl md:text-4xl lg:text-[2.5rem] leading-tight md:leading-tight lg:leading-[1.2] mt-2">
           <Balancer>{title}</Balancer>
         </h2>
         <div className="mt-4 lg:mt-6 flex items-center space-x-2">

--- a/apps/badass/src/templates/article-template.tsx
+++ b/apps/badass/src/templates/article-template.tsx
@@ -125,7 +125,7 @@ const ArticleTemplate: React.FC<
         },
       }}
     >
-      {articleBodySerialized ? (
+      {/* {articleBodySerialized ? (
         <>
           <Header
             title={title}
@@ -148,48 +148,45 @@ const ArticleTemplate: React.FC<
           </main>
         </>
       ) : (
-        <>
-          <ArticleHeader
-            title={title}
-            publishedDate={publishedDate}
-            image={externalImage}
-          />
-          <main className="pb-10">
-            <div className="">
-              <div className="px-5 pb-16 pt-10 md:pt-16 lg:px-0">
-                {video ? (
-                  <div className="mx-auto w-full max-w-screen-md pb-5">
-                    <MuxVideo
-                      className="aspect-video w-full"
-                      playbackId={video.muxPlaybackId}
-                      streamType="on-demand"
-                    />
-                  </div>
-                ) : null}
-                <article className="mx-auto w-full max-w-screen-md prose sm:prose-lg lg:prose-xl first-letter:float-left first-letter:-mt-0.5 first-letter:pr-3 first-letter:font-expanded first-letter:text-6xl first-letter:text-badass-pink-500 prose-p:text-neutral-200 prose-code:rounded prose-code:bg-white/20 prose-code:px-1 prose-code:py-0.5 prose-pre:prose-code:bg-transparent sm:prose-code:text-[80%] md:prose-code:text-sm lg:prose-code:text-[78%]">
+        <> */}
+      <ArticleHeader
+        title={title}
+        publishedDate={publishedDate}
+        image={externalImage}
+      />
+      <main className="pb-10">
+        <div className="">
+          <div className="px-5 pb-16 pt-10 md:pt-16 lg:px-0">
+            {video ? (
+              <div className="mx-auto w-full max-w-screen-md pb-5">
+                <MuxVideo
+                  className="aspect-video w-full"
+                  playbackId={video.muxPlaybackId}
+                  streamType="on-demand"
+                />
+              </div>
+            ) : null}
+            <article className="mx-auto w-full max-w-screen-md prose sm:prose-lg lg:prose-xl first-letter:float-left first-letter:-mt-0.5 first-letter:pr-3 first-letter:font-expanded first-letter:text-6xl first-letter:text-badass-pink-500 prose-p:text-neutral-200 prose-code:rounded prose-code:bg-white/20 prose-code:px-1 prose-code:py-0.5 prose-pre:prose-code:bg-transparent sm:prose-code:text-[80%] md:prose-code:text-sm lg:prose-code:text-[78%]">
+              <PortableText value={body} components={PortableTextComponents} />
+            </article>
+            {video?.transcript ? (
+              <section className="w-full max-w-screen-md mx-auto mt-16 md:mt-24">
+                <h2 className="font-heading text-3xl leading-tight sm:text-4xl sm:leading-tight text-center">
+                  Full Transcript
+                </h2>
+                <div className="prose sm:prose-base prose-sm prose-p:text-neutral-300 mt-12">
                   <PortableText
-                    value={body}
+                    value={video.transcript}
                     components={PortableTextComponents}
                   />
-                </article>
-                {video?.transcript ? (
-                  <section className="w-full max-w-screen-md mx-auto mt-16 md:mt-24">
-                    <h2 className="font-heading text-3xl leading-tight sm:text-4xl sm:leading-tight text-center">
-                      Full Transcript
-                    </h2>
-                    <div className="prose sm:prose-base prose-sm prose-p:text-neutral-300 mt-12">
-                      <PortableText
-                        value={video.transcript}
-                        components={PortableTextComponents}
-                      />
-                    </div>
-                  </section>
-                ) : null}
-              </div>
-            </div>
-          </main>
-        </>
-      )}
+                </div>
+              </section>
+            ) : null}
+          </div>
+        </div>
+      </main>
+      {/* </>
+      )} */}
       <CallToActionForm content={genericCallToActionContent} />
     </Layout>
   )


### PR DESCRIPTION
This PR add some tweaks for template and mdx components.
Also markdown for the article has got disabled (temporarily) while I'm converting the rest of the articles (to avoid confusing users that might read articles at the moment).

![giphy](https://github.com/skillrecordings/products/assets/1519448/b278939f-846e-4351-a4ea-d85b25273e3f)
