### PR TITLE
jb/fetch module progress for epic react

### DIFF
--- a/packages/skill-lesson/lib/module-progress.ts
+++ b/packages/skill-lesson/lib/module-progress.ts
@@ -1,6 +1,4 @@
-import {getModule} from './modules'
-import {Section} from '../schemas/section'
-import {Lesson} from '../schemas/lesson'
+import {getModuleStructure} from './modules'
 import {LessonProgress, prisma} from '@skillrecordings/database'
 import {sortBy, uniqBy} from 'lodash'
 import {ModuleProgressSchema} from '../video/module-progress'
@@ -16,16 +14,16 @@ export async function getModuleProgress({
   moduleSlug: string
   userId: string
 }) {
-  const module = await getModule(moduleSlug)
+  const module = await getModuleStructure(moduleSlug)
 
   const allModuleLessons =
     module.sections.length > 0
       ? module.sections
-          .filter((section: Section) => section?.lessons?.length)
-          .flatMap((section: Section) => section.lessons)
+          .filter((section) => section?.lessons?.length)
+          .flatMap((section) => section.lessons)
       : module.lessons
 
-  const lessonIds = allModuleLessons.map((lesson: Lesson) => lesson._id)
+  const lessonIds = allModuleLessons.map((lesson) => lesson._id)
 
   const moduleLessonProgress = await prisma.lessonProgress.findMany({
     where: {
@@ -41,7 +39,7 @@ export async function getModuleProgress({
     'lessonId',
   )
 
-  const moduleProgressLessons = allModuleLessons.map((lesson: Lesson) => {
+  const moduleProgressLessons = allModuleLessons.map((lesson) => {
     return {
       id: lesson._id,
       slug: lesson.slug,
@@ -56,10 +54,10 @@ export async function getModuleProgress({
   })
 
   const moduleProgressSections = module.sections
-    .filter((section: Section) => section.lessons)
-    .map((section: Section) => {
+    .filter((section) => section.lessons)
+    .map((section) => {
       const sectionProgressLessons =
-        section.lessons?.map((lesson: Lesson) => {
+        section.lessons?.map((lesson) => {
           return {
             id: lesson._id,
             slug: lesson.slug,
@@ -94,7 +92,7 @@ export async function getModuleProgress({
       }
     })
 
-  const hasEmptySection = module.sections.some((section: Section) => {
+  const hasEmptySection = module.sections.some((section) => {
     return !section.lessons
   })
 

--- a/packages/skill-lesson/lib/modules.ts
+++ b/packages/skill-lesson/lib/modules.ts
@@ -15,7 +15,8 @@ const SectionSchema = CoreResourceSchema.merge(
 )
 const ResourceSchema = CoreResourceSchema.merge(
   z.object({
-    resources: CoreResourceSchema.array(),
+    _type: z.string(),
+    resources: CoreResourceSchema.array().optional(),
   }),
 )
 const ModuleSchema = CoreResourceSchema.merge(
@@ -25,6 +26,8 @@ const ModuleSchema = CoreResourceSchema.merge(
     resources: ResourceSchema.array(),
   }),
 )
+
+export type ResourceStructure = z.infer<typeof ResourceSchema>
 
 const toQuotedList = (identifiers: string[]): string => {
   return identifiers.map((identifier) => `'${identifier}'`).join(', ')
@@ -55,6 +58,7 @@ const moduleStructureQuery = groq`*[_type == "module" && slug.current == $slug][
     lessonTypes,
   )}]]->{
     _id,
+    _type,
     title,
     "slug": slug.current,
     (_type == 'section') => {


### PR DESCRIPTION
This PR makes a minimal set of adjustments to the module progress file to preserve how the traditional `module -> section -> lesson` structure gets processed while now also supporting the epic-react `module -> lesson/section -> lesson` structure.

- feat: switch to leaner, zod-typed module lookup
- feat: transition module-progress to use resources

![structure](https://media2.giphy.com/media/lr0tVaj10oIlrujjHR/giphy.gif?cid=d1fd59abcpi5qery15c3zmkl0g5r8qc13iavfxpjr2lmqc25&ep=v1_gifs_search&rid=giphy.gif&ct=g)