### PR TITLE
feat: add index to LessonProgress.completedAt

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -34,6 +34,7 @@ model LessonProgress {
   user          User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index(fields: [userId, lessonId])
+  @@index([completedAt(sort: Desc)])
 }
 
 model Account {


### PR DESCRIPTION
_Note: currently working on setting up a couple pscale deploy requests_

This will help speed up queries that are ordering LessonProgress results
by completedAt date.

![completed](https://media1.giphy.com/media/UtEUhkfriklonVdweC/giphy.gif?cid=d1fd59abfbz42tu278oo6vverqox2385wi9cb95818j8beuq&ep=v1_gifs_search&rid=giphy.gif&ct=g)