### PR TITLE
fix(tt): add missing payment options for TT

### DIFF
--- a/packages/skill-api/src/core/services/process-stripe-webhook.ts
+++ b/packages/skill-api/src/core/services/process-stripe-webhook.ts
@@ -42,9 +42,12 @@ export async function processStripeWebhooks({
       }
     }
 
+    const _paymentOptions = paymentOptions || {
+      stripeCtx: {stripe: defaultStripe},
+    }
     const stripe = paymentOptions?.stripeCtx.stripe || defaultStripe
 
-    if (!paymentOptions || !stripe) {
+    if (!stripe) {
       throw new Error('Stripe client is missing')
     }
 
@@ -78,7 +81,7 @@ export async function processStripeWebhooks({
       if (event.type === 'checkout.session.completed') {
         const {user, purchase, purchaseInfo} = await recordNewPurchase(
           event.data.object.id,
-          paymentOptions,
+          _paymentOptions,
         )
 
         if (!user) throw new Error('no-user-created')


### PR DESCRIPTION
The `paymentOptions` option is only passed by TJS at this point, so other apps should continue to fallback to `defaultStripe`. This particular instance in `process-stripe-webhook` was being too aggressive in throwing an error.

![fix](https://media4.giphy.com/media/l5WY063RdLr0VLNCR9/giphy.gif?cid=d1fd59abago5msnz2tdzuv4yt8y6dgreod2z2nhq1vru90xm&ep=v1_gifs_search&rid=giphy.gif&ct=g)