### PR TITLE
feat(er-next): adjust articles index and article template

### DIFF
--- a/apps/epic-react/src/@types/mdx-articles.ts
+++ b/apps/epic-react/src/@types/mdx-articles.ts
@@ -1,0 +1,21 @@
+import {MDXRemoteSerializeResult} from 'next-mdx-remote'
+
+export interface FrontMatter {
+  title: string
+  slug: string
+  date: string
+  image: string
+  socialImage: string
+  imageAlt: string
+  excerpt: string
+  keywords?: string[] | null
+}
+
+export interface Article {
+  title: string
+  slug: string
+  date: string
+  excerpt: string
+  image: string
+  imageAlt: string
+}

--- a/apps/epic-react/src/components/divider.tsx
+++ b/apps/epic-react/src/components/divider.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import {motion} from 'framer-motion'
+
+const Divider = ({className = ''}: {className?: string}) => (
+  <>
+    <motion.div
+      className={`mx-auto w-10 overflow-hidden rounded-lg ${className}`}
+      initial={{opacity: 0, y: 0}}
+      animate={{opacity: 1, y: 0}}
+      transition={{type: 'spring', mass: 0.2, damping: 80, delay: 0.2}}
+    >
+      <motion.svg
+        animate={{x: [0, -16]}}
+        transition={{
+          repeat: Infinity,
+          repeatType: 'loop',
+          duration: 1.5,
+          ease: 'linear',
+        }}
+        className="mx-auto w-24 text-[#9eddf8]"
+        width="123"
+        height="16"
+        viewBox="0 0 123 16"
+      >
+        <polyline
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="4"
+          points="652.5 379 662.5 369 672.5 379 682.5 369 692.5 379 702.5 369 712.5 379 722.5 369 732.5 379 742.5 369 752.5 379 762.5 369 772.5 379"
+          transform="translate(-651 -366)"
+        />
+      </motion.svg>
+    </motion.div>
+  </>
+)
+
+export default Divider

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/app.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/app.js
@@ -1,0 +1,102 @@
+import * as React from 'react'
+import {useApp} from './provider'
+import {Post as Class} from './post-class'
+import {Post as Ref} from './post-ref'
+import {Post as Default} from './post-default'
+import {Post as ClassFix} from './post-class-fix'
+
+function Posts({Post, currentPost, onPostClick}) {
+  const {posts} = useApp()
+  return (
+    <div>
+      <div className="inline-block overflow-hidden rounded-md">
+        {posts.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => onPostClick(p)}
+            className={`px-3 py-1 ${
+              p.id === currentPost?.id
+                ? 'bg-blue-500 text-white'
+                : 'bg-background hover:bg-gray-200'
+            } transition-all duration-150 ease-in-out`}
+          >
+            {p.title}
+          </button>
+        ))}
+      </div>
+      <div>{currentPost ? <Post post={currentPost} /> : null}</div>
+    </div>
+  )
+}
+
+function App() {
+  const {posts} = useApp()
+  const [currentPost, setCurrentPost] = React.useState(posts[0])
+  return (
+    <>
+      <div>
+        <div>
+          <a href="https://github.com/kentcdodds/react-and-stale-closures">
+            Code on GitHub
+          </a>
+        </div>
+      </div>
+      <div className="prose prose-sm mt-4 grid w-full max-w-none grid-cols-1 gap-4 rounded-lg bg-gray-100 px-5 pb-5 sm:grid-cols-2 sm:gap-8 sm:px-8 sm:pb-8">
+        <div>
+          <h3>
+            <span role="img" aria-label="x">
+              ❌
+            </span>{' '}
+            The Old Default with Classes
+          </h3>
+          <Posts
+            Post={Class}
+            currentPost={currentPost}
+            onPostClick={(p) => setCurrentPost(p)}
+          />
+        </div>
+        <div>
+          <h3>
+            <span role="img" aria-label="check">
+              ✅
+            </span>{' '}
+            The New Default with Hooks
+          </h3>
+          <Posts
+            Post={Default}
+            currentPost={currentPost}
+            onPostClick={(p) => setCurrentPost(p)}
+          />
+        </div>
+        <div>
+          <h3>
+            <span role="img" aria-label="x">
+              ❌
+            </span>{' '}
+            Simulating The Old Default with Hooks
+          </h3>
+          <Posts
+            Post={Ref}
+            currentPost={currentPost}
+            onPostClick={(p) => setCurrentPost(p)}
+          />
+        </div>
+        <div>
+          <h3>
+            <span role="img" aria-label="check">
+              ✅
+            </span>{' '}
+            Simulating The New Default with Classes
+          </h3>
+          <Posts
+            Post={ClassFix}
+            currentPost={currentPost}
+            onPostClick={(p) => setCurrentPost(p)}
+          />
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default App

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/index.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/index.js
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import App from './app'
+import {AppProvider} from './provider'
+
+const Demo = () => (
+  <AppProvider>
+    <App />
+  </AppProvider>
+)
+
+export default Demo

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/initial-data.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/initial-data.js
@@ -1,0 +1,33 @@
+const authors = [
+  {id: 'a123', name: 'Geordi'},
+  {id: 'a234', name: 'Barkley'},
+  {id: 'a345', name: 'Crusher'},
+]
+const posts = [
+  {
+    id: 'p123',
+    authorId: 'a123',
+    title: 'Post 1',
+    content: 'This is post number 1',
+  },
+  {
+    id: 'p234',
+    authorId: 'a234',
+    title: 'Post 2',
+    content: 'This is post number 2',
+  },
+  {
+    id: 'p345',
+    authorId: 'a234',
+    title: 'Post 3',
+    content: 'This is post number 3',
+  },
+]
+const likes = [
+  {id: 'l123', ownerId: 'a123', postId: 'p123'},
+  {id: 'l234', ownerId: 'a123', postId: 'p234'},
+]
+
+const user = authors[0]
+
+export {posts, likes, authors, user}

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-class-fix.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-class-fix.js
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import {AppContext} from './provider'
+import {canLike} from './utils'
+import {PostView} from './post-view'
+
+class Post extends React.Component {
+  static contextType = AppContext
+  handleLikeClick = async () => {
+    const {post} = this.props
+    const {user, toggleLike} = this.context
+    if (!(await canLike(post, user))) return
+
+    toggleLike(post)
+  }
+  render() {
+    return (
+      <PostView post={this.props.post} onLikeClick={this.handleLikeClick} />
+    )
+  }
+}
+
+export {Post}

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-class.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-class.js
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import {AppContext} from './provider'
+import {canLike} from './utils'
+import {PostView} from './post-view'
+
+class Post extends React.Component {
+  static contextType = AppContext
+  handleLikeClick = async () => {
+    if (!(await canLike(this.props.post, this.context.user))) return
+
+    this.context.toggleLike(this.props.post)
+  }
+  render() {
+    return (
+      <PostView post={this.props.post} onLikeClick={this.handleLikeClick} />
+    )
+  }
+}
+
+export {Post}

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-default.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-default.js
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import {useApp} from './provider'
+import {canLike} from './utils'
+import {PostView} from './post-view'
+
+function Post({post}) {
+  const {user, toggleLike} = useApp()
+
+  async function handleLikeClick() {
+    if (!(await canLike(post, user))) return
+
+    toggleLike(post)
+  }
+
+  return <PostView post={post} onLikeClick={handleLikeClick} />
+}
+
+export {Post}

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-ref.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-ref.js
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import {useApp} from './provider'
+import {canLike} from './utils'
+import {PostView} from './post-view'
+
+function Post({post}) {
+  const {user, toggleLike} = useApp()
+
+  const postRef = React.useRef(post)
+  React.useEffect(() => {
+    postRef.current = post
+  })
+
+  async function handleLikeClick() {
+    if (!(await canLike(postRef.current, user))) return
+
+    toggleLike(postRef.current)
+  }
+
+  return <PostView post={post} onLikeClick={handleLikeClick} />
+}
+
+export {Post}

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-view.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/post-view.js
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import {useApp} from './provider'
+
+function PostView({post, onLikeClick}) {
+  const {authors, user, likes} = useApp()
+
+  const author = authors.find(({id}) => id === post.authorId)
+  const postLikes = likes.filter(({postId}) => postId === post.id)
+  const userLiked = postLikes.some((l) => l.ownerId === user.id)
+
+  return (
+    <article className="mt-2 rounded-md bg-background p-4">
+      <h4 className="prose-reset text-2xl font-bold">{post.title}</h4>
+      <div className="text-gray-600">by {author.name}</div>
+      <p>{post.content}</p>
+      <div className="border-t border-gray-200 pt-4">
+        <button
+          onClick={onLikeClick}
+          title={userLiked ? 'Unlike this post' : 'Like this post'}
+          className="rounded-md bg-red-200 bg-opacity-25 px-3 py-1 transition-all duration-150 ease-in-out hover:bg-red-500 hover:bg-opacity-25"
+        >
+          {userLiked ? '❤️' : '♡'} {postLikes.length}
+        </button>
+      </div>
+    </article>
+  )
+}
+
+export {PostView}

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/provider.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/provider.js
@@ -1,0 +1,47 @@
+import * as React from 'react'
+import * as initialData from './initial-data'
+
+const AppContext = React.createContext()
+
+function AppProvider(props) {
+  const [authors] = React.useState(initialData.authors)
+  const [user] = React.useState(initialData.user)
+  const [posts] = React.useState(initialData.posts)
+  const [likes, setLikes] = React.useState(initialData.likes)
+
+  function toggleLike(post) {
+    const userLiked = likes.some(
+      (l) => l.ownerId === user.id && l.postId === post.id,
+    )
+    if (userLiked) unlikePost(post)
+    else likePost(post)
+  }
+
+  function likePost(post) {
+    console.log('liking', post.title)
+    setLikes([
+      ...likes,
+      {id: `l${likes.length + 1}`, ownerId: user.id, postId: post.id},
+    ])
+  }
+
+  function unlikePost(post) {
+    console.log('unliking', post.title)
+    setLikes(
+      likes.filter((l) => !(l.ownerId === user.id && l.postId === post.id)),
+    )
+  }
+
+  return (
+    <AppContext.Provider
+      value={{authors, user, posts, likes, toggleLike}}
+      {...props}
+    />
+  )
+}
+
+function useApp() {
+  return React.useContext(AppContext)
+}
+
+export {AppProvider, useApp, AppContext}

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/setupTests.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/setupTests.js
@@ -1,0 +1,1 @@
+// import '@testing-library/jest-dom/extend-expect'

--- a/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/utils.js
+++ b/apps/epic-react/src/components/mdx-components/how-react-uses-closures-to-avoid-bugs/utils.js
@@ -1,0 +1,6 @@
+async function canLike() {
+  await new Promise((r) => setTimeout(r, 3000))
+  return true
+}
+
+export {canLike}

--- a/apps/epic-react/src/components/mdx-components/index.tsx
+++ b/apps/epic-react/src/components/mdx-components/index.tsx
@@ -1,0 +1,7 @@
+import Demo from './how-react-uses-closures-to-avoid-bugs'
+
+const mdxComponents = {
+  Demo: () => <Demo />,
+}
+
+export default mdxComponents

--- a/apps/epic-react/src/content/articles/how-react-uses-closures-to-avoid-bugs.mdx
+++ b/apps/epic-react/src/content/articles/how-react-uses-closures-to-avoid-bugs.mdx
@@ -44,8 +44,6 @@ So, in the demo below, try this:
 2. Before the 3 seconds time is up, change the post selection
 3. Observe differences
 
-import Demo from '../../components/how-react-uses-closures-to-avoid-bugs'
-
 <Demo />
 
 You should observe that with the broken examples (like "The Old Default with

--- a/apps/epic-react/src/pages/[article].tsx
+++ b/apps/epic-react/src/pages/[article].tsx
@@ -3,10 +3,11 @@ import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
 import {GetStaticPaths, GetStaticProps} from 'next'
-import ArticleTemplate from '@/templates/article-template'
 import {MDXRemoteSerializeResult} from 'next-mdx-remote'
 import serializeMDX from '@skillrecordings/skill-lesson/markdown/serialize-mdx'
+
 import {type FrontMatter, type Article} from '@/@types/mdx-articles'
+import ArticleTemplate from '@/templates/article-template'
 
 export interface ArticlePageProps {
   allArticles: Article[]

--- a/apps/epic-react/src/pages/articles.tsx
+++ b/apps/epic-react/src/pages/articles.tsx
@@ -1,14 +1,24 @@
 import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
-import Layout from '@/components/app/layout'
 import {GetStaticProps, NextPage} from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
+
 import {type Article} from '@/@types/mdx-articles'
+import Layout from '@/components/app/layout'
+import Divider from '@/components/divider'
 
 interface ArticlesPageProps {
   articles: Article[]
+}
+
+const formattedDate = (date: string) => {
+  const newDate = new Date(date)
+  return newDate.toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  })
 }
 
 const ArticlesPage: NextPage<ArticlesPageProps> = ({articles}) => {
@@ -23,24 +33,39 @@ const ArticlesPage: NextPage<ArticlesPageProps> = ({articles}) => {
       }}
     >
       <main className="mx-auto w-full max-w-screen-lg px-5">
-        <h1>Articles</h1>
-        <ul className="grid grid-cols-2 gap-8">
+        <h1 className="text-center text-2xl font-bold leading-tight sm:text-3xl lg:text-4xl">
+          Epic React Articles
+        </h1>
+        <Divider className="mb-16 mt-10" />
+        <ul className="grid gap-5 sm:gap-8 md:grid-cols-2">
           {articles.map((article, index) => (
-            <li key={index}>
-              <Link
-                href={article.slug}
-                className="block h-full border border-white p-4"
-              >
-                <h2>{article.title}</h2>
-                <p>{article.excerpt}</p>
-                <Image
-                  src={`/articles-images${article.image}`}
-                  alt={`Cover image for ${article.title}`}
-                  width={2280}
-                  height={1080}
-                />
-                <p>Date: {article.date}</p>
-              </Link>
+            <li key={index} className="flex">
+              <article>
+                <Link
+                  href={article.slug}
+                  className="flex h-full flex-col items-center justify-between overflow-hidden rounded-lg border-2 border-[#f0f2f7] duration-200 hover:scale-105 hover:shadow-xl dark:border-[#132035]"
+                >
+                  <header className="relative aspect-[2/1] w-full shrink-0">
+                    <Image
+                      src={`/articles-images${article.image}`}
+                      alt={article.title}
+                      fill
+                      sizes="(max-width: 768px) 690px, 460px"
+                    />
+                  </header>
+                  <section className="flex h-full flex-col px-5 py-5 sm:px-8 sm:py-10">
+                    <h2 className="pb-5 text-xl font-semibold leading-tight sm:text-2xl">
+                      {article.title}
+                    </h2>
+                    <div className="prose opacity-75 transition-opacity duration-200 ease-in-out hover:opacity-100">
+                      <p>{article.excerpt}</p>
+                    </div>
+                  </section>
+                  <footer className="w-full px-5 pb-5 text-left sm:px-8 sm:pb-8">
+                    <span>{formattedDate(article.date)}</span>
+                  </footer>
+                </Link>
+              </article>
             </li>
           ))}
         </ul>

--- a/apps/epic-react/src/pages/articles.tsx
+++ b/apps/epic-react/src/pages/articles.tsx
@@ -5,17 +5,10 @@ import Layout from '@/components/app/layout'
 import {GetStaticProps, NextPage} from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
-
-interface ArticleFrontmatter {
-  title: string
-  slug: string
-  date: string
-  excerpt: string
-  image: string
-}
+import {type Article} from '@/@types/mdx-articles'
 
 interface ArticlesPageProps {
-  articles: ArticleFrontmatter[]
+  articles: Article[]
 }
 
 const ArticlesPage: NextPage<ArticlesPageProps> = ({articles}) => {
@@ -76,6 +69,7 @@ export const getStaticProps: GetStaticProps = async () => {
         date: formattedDate,
         excerpt: data.excerpt,
         image: data.image,
+        imageAlt: data.imageAlt,
         slug: filename.replace(/\.mdx$/, ''),
       }
     })

--- a/apps/epic-react/src/styles/globals.css
+++ b/apps/epic-react/src/styles/globals.css
@@ -56,7 +56,7 @@
     --radius: 0.5rem;
   }
   .dark {
-    --background: 224 71% 4%;
+    --background: 219, 50%, 11%;
     --foreground: 213 31% 91%;
 
     --muted: 223 47% 11%;

--- a/apps/epic-react/src/templates/article-template.tsx
+++ b/apps/epic-react/src/templates/article-template.tsx
@@ -1,21 +1,17 @@
-import React from 'react'
-import Layout from '@/components/app/layout'
-import {ArticleJsonLd} from '@skillrecordings/next-seo'
-import {useRouter} from 'next/router'
-import {getIsoDate} from '@/utils/get-iso-date'
-import AuthorImage from '../../public/instructor.png'
-import {type FrontMatter, type Article} from '@/@types/mdx-articles'
-import {format} from 'date-fns'
+import * as React from 'react'
+import Link from 'next/link'
 import Image from 'next/image'
-import {PrimaryNewsletterCta} from '@/components/primary-newsletter-cta'
-import Share from '@/components/share'
-import {useConvertkit} from '@skillrecordings/skill-lesson/hooks/use-convertkit'
-import {track} from '@skillrecordings/skill-lesson/utils/analytics'
-import Balancer from 'react-wrap-balancer'
-import config from '@/config'
+import {useRouter} from 'next/router'
 import {MDXRemoteSerializeResult} from 'next-mdx-remote'
 import MDX from '@skillrecordings/skill-lesson/markdown/mdx'
+import {useConvertkit} from '@skillrecordings/skill-lesson/hooks/use-convertkit'
+import {ArticleJsonLd} from '@skillrecordings/next-seo'
+
+import {getIsoDate} from '@/utils/get-iso-date'
 import {getOgImage} from '@/utils/get-og-image'
+import config from '@/config'
+import {type FrontMatter, type Article} from '@/@types/mdx-articles'
+import Layout from '@/components/app/layout'
 import Divider from '@/components/divider'
 import mdxComponents from '@/components/mdx-components'
 
@@ -25,6 +21,43 @@ interface ArticleTemplateProps {
   frontMatter: FrontMatter
 }
 
+const YouMightAlsoLike: React.FC<{articles: Article[]}> = ({articles}) => {
+  return (
+    <section>
+      <h3 className="mb-8 text-xs uppercase text-gray-700 opacity-75">
+        YOU MIGHT ALSO LIKE
+      </h3>
+      <ul className="grid gap-8 leading-relaxed md:grid-cols-2">
+        {articles.map((article: Article) => {
+          return (
+            <li key={article.slug} className="flex min-h-[120px]">
+              <Link
+                href={`/${article.slug}`}
+                className="flex w-full transform flex-col items-center justify-center overflow-hidden rounded-lg border-2 border-gray-200 text-center transition-all duration-200 ease-in-out hover:scale-105 hover:shadow-xl sm:flex-row sm:text-left"
+              >
+                <div className="relative h-full w-full shrink-0 overflow-hidden sm:w-[45%]">
+                  <Image
+                    src={`/articles-images${article.image}`}
+                    alt={article.imageAlt}
+                    fill
+                    sizes="(max-width: 768px) 690px, 460px"
+                    className="object-cover"
+                  />
+                </div>
+                <div className="w-full p-6 sm:p-5">
+                  <h3 className="text-lg font-semibold leading-tight">
+                    {article.title}
+                  </h3>
+                </div>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}
+
 const ArticleTemplate: React.FC<ArticleTemplateProps> = ({
   allArticles,
   frontMatter,
@@ -32,7 +65,15 @@ const ArticleTemplate: React.FC<ArticleTemplateProps> = ({
 }) => {
   console.log({allArticles})
   const router = useRouter()
-  const {title, excerpt, socialImage, image, imageAlt = '', date} = frontMatter
+  const {
+    title,
+    excerpt,
+    socialImage,
+    image,
+    imageAlt = '',
+    date,
+    slug,
+  } = frontMatter
   const isoDate = getIsoDate(date)
   const ogImage = socialImage
     ? {url: socialImage as string}
@@ -41,6 +82,7 @@ const ArticleTemplate: React.FC<ArticleTemplateProps> = ({
   const author = config.author
   const url = `${process.env.NEXT_PUBLIC_URL}${router.asPath}`
   const {subscriber, loadingSubscriber} = useConvertkit()
+  const restArticles = allArticles.filter((article) => article.slug !== slug)
 
   return (
     <Layout
@@ -79,6 +121,7 @@ const ArticleTemplate: React.FC<ArticleTemplateProps> = ({
           <MDX contents={mdx} components={{...mdxComponents}} />
         </div>
         <Divider className="my-40" />
+        <YouMightAlsoLike articles={restArticles} />
       </main>
     </Layout>
   )

--- a/apps/epic-react/src/templates/article-template.tsx
+++ b/apps/epic-react/src/templates/article-template.tsx
@@ -4,8 +4,7 @@ import {ArticleJsonLd} from '@skillrecordings/next-seo'
 import {useRouter} from 'next/router'
 import {getIsoDate} from '@/utils/get-iso-date'
 import AuthorImage from '../../public/instructor.png'
-import {type Article} from '@/lib/articles'
-import {type FrontMatter, type ArticleProps} from '../pages/[article]'
+import {type FrontMatter, type Article} from '@/@types/mdx-articles'
 import {format} from 'date-fns'
 import Image from 'next/image'
 import {PrimaryNewsletterCta} from '@/components/primary-newsletter-cta'
@@ -17,10 +16,23 @@ import config from '@/config'
 import {MDXRemoteSerializeResult} from 'next-mdx-remote'
 import MDX from '@skillrecordings/skill-lesson/markdown/mdx'
 import {getOgImage} from '@/utils/get-og-image'
+import Divider from '@/components/divider'
+import mdxComponents from '@/components/mdx-components'
 
-const ArticleTemplate: React.FC<ArticleProps> = ({frontMatter, mdx}) => {
+interface ArticleTemplateProps {
+  allArticles: Article[]
+  mdx: MDXRemoteSerializeResult
+  frontMatter: FrontMatter
+}
+
+const ArticleTemplate: React.FC<ArticleTemplateProps> = ({
+  allArticles,
+  frontMatter,
+  mdx,
+}) => {
+  console.log({allArticles})
   const router = useRouter()
-  const {title, excerpt, socialImage, image, date} = frontMatter
+  const {title, excerpt, socialImage, image, imageAlt = '', date} = frontMatter
   const isoDate = getIsoDate(date)
   const ogImage = socialImage
     ? {url: socialImage as string}
@@ -49,9 +61,24 @@ const ArticleTemplate: React.FC<ArticleProps> = ({frontMatter, mdx}) => {
         description={pageDescription}
         url={url}
       />
-      {/* <TableOfContents article={article} /> */}
-      <main className="prose mx-auto w-full max-w-3xl px-5 py-8 text-white md:prose-lg prose-code:break-words md:py-16 md:prose-code:break-normal">
-        <MDX contents={mdx} />
+      <main className="mx-auto w-full max-w-3xl px-5 py-8 md:py-16">
+        <h1 className="mx-auto mb-4 mt-24 max-w-screen-md px-5 text-center text-3xl font-bold leading-tight sm:px-0 sm:text-4xl">
+          {title}
+        </h1>
+        <h3 className="mb-10 text-center text-sm opacity-75">by {author}</h3>
+        <Divider />
+        <div className="mx-auto mt-16 max-w-screen-lg overflow-hidden rounded-none lg:rounded-lg">
+          <Image
+            src={`/articles-images${image}`}
+            alt={imageAlt}
+            width={2280}
+            height={1080}
+          />
+        </div>
+        <div className="prose mt-8 text-white md:prose-lg prose-code:break-words md:prose-code:break-normal">
+          <MDX contents={mdx} components={{...mdxComponents}} />
+        </div>
+        <Divider className="my-40" />
       </main>
     </Layout>
   )


### PR DESCRIPTION
This adds minimal styles to the articles index, adds `YOU MIGHT ALSO LIKE` component (the list of  other articles) and one MDX component that is used in one of the articles.

<details>
  <summary>Articles</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/c444b27e-6d54-41ab-b4b9-77057e811e16">
</details>
<details>
  <summary>Article</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/acbea5e2-b39a-44ff-9630-df3045d3b41c">
</details>

![Gary V New Post GIF by ONE37pm](https://github.com/skillrecordings/products/assets/1519448/9f0fa594-b1f2-4ad0-bf90-06c9e61abbd3)


