### PR TITLE
fix(tt): solution objects don't have an _id

### DIFF
--- a/apps/total-typescript/src/lib/exercises.ts
+++ b/apps/total-typescript/src/lib/exercises.ts
@@ -20,7 +20,7 @@ export const ExerciseSchema = z
           transcript: z.nullable(z.string()).optional(),
           aiTranscript: z.nullable(z.string()).optional(),
         })
-        .merge(ResourceSchema)
+        .merge(ResourceSchema.omit({_id: true}))
         .optional(),
     ),
   })

--- a/packages/skill-lesson/schemas/exercise.ts
+++ b/packages/skill-lesson/schemas/exercise.ts
@@ -1,10 +1,10 @@
 import {ResourceSchema} from './resource'
 import z from 'zod'
-import {LessonResourceSchema} from './lesson'
+import {SolutionResourceSchema} from './lesson'
 
 export const ExerciseSchema = z
   .object({
-    solution: z.nullable(LessonResourceSchema.optional()),
+    solution: z.nullable(SolutionResourceSchema.optional()),
   })
   .merge(ResourceSchema)
 

--- a/packages/skill-lesson/schemas/solution.ts
+++ b/packages/skill-lesson/schemas/solution.ts
@@ -5,6 +5,6 @@ export const SolutionSchema = z
   .object({
     _key: z.string().optional(),
   })
-  .merge(ResourceSchema)
+  .merge(ResourceSchema.omit({_id: true}))
 
 export type Solution = z.infer<typeof SolutionSchema>


### PR DESCRIPTION
The #1365 PR wasn't omitting `_id` for lesson solutions in TT. That resulted in a Zod parse error. This fixes that.

![quick fix](https://media3.giphy.com/media/Z9zo37ooUzwNwzmw4w/giphy.gif?cid=d1fd59ab56bcsbtikn8prci1xif0npv5wmxanw7vyjdupsp5&ep=v1_gifs_search&rid=giphy.gif&ct=g)