### PR TITLE
fix(TJS-61): testing javascript course completion certificate

### DIFF
--- a/apps/testing-javascript/src/components/landing/access-your-course.tsx
+++ b/apps/testing-javascript/src/components/landing/access-your-course.tsx
@@ -13,7 +13,7 @@ import {trpc} from '@/trpc/trpc.client'
 import {z} from 'zod'
 import flatten from 'lodash/flatten'
 
-const INTREVIEWS_PLAYLIST_SLUG = 'expert-interviews-module'
+const INTERVIEWS_PLAYLIST_SLUG = 'expert-interviews-module'
 
 const AccessYourCourse: React.FunctionComponent<{
   product: SanityProduct
@@ -49,7 +49,7 @@ const AccessYourCourse: React.FunctionComponent<{
       )
       .filter((playlist) => {
         const [playlistSlug] = playlist
-        return playlistSlug !== INTREVIEWS_PLAYLIST_SLUG
+        return playlistSlug !== INTERVIEWS_PLAYLIST_SLUG
       })
 
     courseCompleted = lessonsByPlaylistSlug.every((playlistLessons) => {

--- a/apps/testing-javascript/src/pages/api/skill/[...skillRecordings].ts
+++ b/apps/testing-javascript/src/pages/api/skill/[...skillRecordings].ts
@@ -2,7 +2,7 @@ import SkillRecordings, {
   type SkillRecordingsOptions,
   defaultPaymentOptions,
   StripeProvider,
-} from '@skillrecordings/skill-api/src'
+} from '@skillrecordings/skill-api'
 import {nextAuthOptions} from '../auth/[...nextauth]'
 
 const paymentOptions = defaultPaymentOptions({

--- a/apps/testing-javascript/src/pages/api/skill/[...skillRecordings].ts
+++ b/apps/testing-javascript/src/pages/api/skill/[...skillRecordings].ts
@@ -1,16 +1,16 @@
 import SkillRecordings, {
   type SkillRecordingsOptions,
-  // defaultPaymentOptions,
-  // StripeProvider,
-} from '@skillrecordings/skill-api'
+  defaultPaymentOptions,
+  StripeProvider,
+} from '@skillrecordings/skill-api/src'
 import {nextAuthOptions} from '../auth/[...nextauth]'
 
-// const paymentOptions = defaultPaymentOptions({
-//   stripeProvider: StripeProvider({
-//     stripeSecretKey: process.env.STRIPE_SECRET_TOKEN,
-//     apiVersion: '2020-08-27',
-//   }),
-// })
+const paymentOptions = defaultPaymentOptions({
+  stripeProvider: StripeProvider({
+    stripeSecretKey: process.env.STRIPE_SECRET_TOKEN,
+    apiVersion: '2020-08-27',
+  }),
+})
 
 export const skillOptions: SkillRecordingsOptions = {
   site: {
@@ -18,7 +18,7 @@ export const skillOptions: SkillRecordingsOptions = {
     supportEmail: process.env.NEXT_PUBLIC_SUPPORT_EMAIL,
   },
   nextAuthOptions,
-  // paymentOptions,
+  paymentOptions,
 }
 
 export default SkillRecordings(skillOptions)

--- a/apps/testing-javascript/src/pages/api/skill/[...skillRecordings].ts
+++ b/apps/testing-javascript/src/pages/api/skill/[...skillRecordings].ts
@@ -1,16 +1,16 @@
 import SkillRecordings, {
   type SkillRecordingsOptions,
-  defaultPaymentOptions,
-  StripeProvider,
+  // defaultPaymentOptions,
+  // StripeProvider,
 } from '@skillrecordings/skill-api'
 import {nextAuthOptions} from '../auth/[...nextauth]'
 
-const paymentOptions = defaultPaymentOptions({
-  stripeProvider: StripeProvider({
-    stripeSecretKey: process.env.STRIPE_SECRET_TOKEN,
-    apiVersion: '2020-08-27',
-  }),
-})
+// const paymentOptions = defaultPaymentOptions({
+//   stripeProvider: StripeProvider({
+//     stripeSecretKey: process.env.STRIPE_SECRET_TOKEN,
+//     apiVersion: '2020-08-27',
+//   }),
+// })
 
 export const skillOptions: SkillRecordingsOptions = {
   site: {
@@ -18,7 +18,7 @@ export const skillOptions: SkillRecordingsOptions = {
     supportEmail: process.env.NEXT_PUBLIC_SUPPORT_EMAIL,
   },
   nextAuthOptions,
-  paymentOptions,
+  // paymentOptions,
 }
 
 export default SkillRecordings(skillOptions)

--- a/apps/testing-javascript/src/templates/lesson-template.tsx
+++ b/apps/testing-javascript/src/templates/lesson-template.tsx
@@ -43,6 +43,9 @@ const LessonTemplate = () => {
       exerciseSlug={router.query.lesson as string}
       handleContinue={customContinueHandler}
       handlePlayFromBeginning={customPlayFromBeginningHandler}
+      onModuleEnded={async () => {
+        addProgressMutation.mutate({lessonSlug: router.query.lesson as string})
+      }}
     >
       <div className="container max-w-6xl pb-8 pt-4 md:pb-12 md:pt-6 lg:pb-16">
         <main className="relative mx-auto w-full items-start border-t border-transparent 2xl:flex 2xl:max-w-none 2xl:border-gray-800">


### PR DESCRIPTION
This does two things:
1. Allows last lesson in the module to get completed
2. Fixes the `courseCompleted` calculation function so that "Download Certificate" appears after all lesson get completed now.

About the person who reported about this issue - I think we should let him know he needs to rewatch last lessons in each of the modules to get them completed and get certificate download link eventually

![CleanShot 2024-02-29 at 21 22 39](https://github.com/skillrecordings/products/assets/1519448/5be4403f-23f0-4543-8b7f-e86d83c8c630)

![season 3 certificate GIF](https://github.com/skillrecordings/products/assets/1519448/37873b73-ff94-4d30-b2e6-c08f0ce71c07)
