### PR TITLE
fix(ew): deleting wrong value to claim a bonus seat 

### DIFF
--- a/apps/epic-web/src/trpc/routers/bonuses.ts
+++ b/apps/epic-web/src/trpc/routers/bonuses.ts
@@ -83,7 +83,6 @@ export const bonusesRouter = router({
               upgradedFromId: z.string().nullable(),
               bulkCouponId: z.string().nullable(),
               redeemedBulkCouponId: z.string().nullable(),
-              merchantPurchaseId: z.string().nullable(),
             })
             .parse({
               id: v4(),
@@ -101,7 +100,6 @@ export const bonusesRouter = router({
               upgradedFromId: null,
               bulkCouponId: null,
               redeemedBulkCouponId: null,
-              merchantPurchaseId: null,
             })
 
           json = await ctx.prisma.purchase.create({data: purchaseData})


### PR DESCRIPTION
Users weren't allowed to claim the Testing JavaScript bonus seat. We had a value in the query that doesn't exist on our database. 

I tested this locally and claimed a seat correctly. 

![delete](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXc4b2VnMHYwOThpN3dkZ2k3N2VqenltamI5ZmJkbTU3Zmphdm5zeiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/KD7Ud1YX1nYRkb2r29/giphy.gif)
