### PR TITLE
feat(tjs): add logging for 500 error

### DIFF
--- a/packages/skill-api/src/core/services/process-stripe-webhook.ts
+++ b/packages/skill-api/src/core/services/process-stripe-webhook.ts
@@ -63,6 +63,8 @@ export async function receiveInternalStripeWebhooks({
       paymentOptions: _paymentOptions,
     })
   } catch (error: any) {
+    console.log(`webhook/stripe-internal error: ${error.message}`)
+
     return {
       status: 500,
       body: {error: true, message: error.message},

--- a/packages/skill-api/src/server/send-server-email.ts
+++ b/packages/skill-api/src/server/send-server-email.ts
@@ -93,6 +93,8 @@ export async function sendServerEmail({
     (provider) => provider.id === 'email',
   )
 
+  console.log('%%% about to sendVerificationRequest %%%')
+
   await sendVerificationRequest({
     identifier: email,
     url,


### PR DESCRIPTION
Trying to understand what exactly the error is that is resulting in 500 errors for `api/skill/webhook/stripe-internal`.

![500](https://media3.giphy.com/media/ATxVdsdpJ609i/giphy.gif?cid=d1fd59abpuvwnzm4jqsjqy1hmk6er3za9j3w9ohig9l0p9b1&ep=v1_gifs_search&rid=giphy.gif&ct=g)