### PR TITLE
feat(tjs): add more logging for undefined event

### DIFF
--- a/packages/skill-api/src/core/services/process-stripe-webhook.ts
+++ b/packages/skill-api/src/core/services/process-stripe-webhook.ts
@@ -34,6 +34,9 @@ export async function receiveInternalStripeWebhooks({
   params: SkillRecordingsHandlerParams
   paymentOptions: PaymentOptions | undefined
 }): Promise<OutgoingResponse> {
+  let event: any
+  let body: any
+
   try {
     const {
       req,
@@ -56,14 +59,19 @@ export async function receiveInternalStripeWebhooks({
     }
     const stripe = paymentOptions?.stripeCtx.stripe || defaultStripe
 
-    const event: any = req.body.event
+    body = req.body
+    event = req.body.event
 
     return await processStripeWebhook(event, {
       nextAuthOptions,
       paymentOptions: _paymentOptions,
     })
   } catch (error: any) {
-    console.log(`webhook/stripe-internal error: ${error.message}`)
+    console.log(
+      `webhook/stripe-internal error: ${
+        (error.message, JSON.stringify(event), JSON.stringify(body))
+      }`,
+    )
 
     return {
       status: 500,

--- a/packages/skill-api/src/server/send-server-email.ts
+++ b/packages/skill-api/src/server/send-server-email.ts
@@ -78,32 +78,38 @@ export async function sendServerEmail({
   text?: (options: TextEmailParams) => string
   expiresAt?: Date | null
 }) {
-  const verificationDetails = await createVerificationUrl({
-    email,
-    nextAuthOptions,
-    callbackUrl,
-    expiresAt: expiresAt || undefined,
-  })
+  try {
+    const verificationDetails = await createVerificationUrl({
+      email,
+      nextAuthOptions,
+      callbackUrl,
+      expiresAt: expiresAt || undefined,
+    })
 
-  if (!verificationDetails) return
+    if (!verificationDetails) return
 
-  const {url, token, expires} = verificationDetails
+    const {url, token, expires} = verificationDetails
 
-  const emailProvider: any = nextAuthOptions.providers.find(
-    (provider) => provider.id === 'email',
-  )
+    const emailProvider: any = nextAuthOptions.providers.find(
+      (provider) => provider.id === 'email',
+    )
 
-  console.log('%%% about to sendVerificationRequest %%%')
+    console.log('%%% about to sendVerificationRequest %%%')
 
-  await sendVerificationRequest({
-    identifier: email,
-    url,
-    theme: nextAuthOptions.theme || {colorScheme: 'auto'},
-    provider: emailProvider.options,
-    token: token as string,
-    expires,
-    type,
-    html,
-    text,
-  })
+    await sendVerificationRequest({
+      identifier: email,
+      url,
+      theme: nextAuthOptions.theme || {colorScheme: 'auto'},
+      provider: emailProvider.options,
+      token: token as string,
+      expires,
+      type,
+      html,
+      text,
+    })
+  } catch (error: any) {
+    console.log({location: 'sendServerEmail', error})
+
+    throw new Error('Unable to sendVerificationRequest')
+  }
 }


### PR DESCRIPTION
We are seeing in our initial logging that `event.type` is failing because `event` is undefined. Trying to figure out why the event isn't coming through in the request.

![event](https://media4.giphy.com/media/tbSrCf6nP7Iy9ropgF/giphy.gif?cid=d1fd59abzxlnobddu93ksjod1xmgyu1mzqgoqk29uhurzy1a&ep=v1_gifs_search&rid=giphy.gif&ct=g)