### PR TITLE
feat(tjs): remove download interviews link

### DIFF
--- a/apps/testing-javascript/src/components/landing/interviews.tsx
+++ b/apps/testing-javascript/src/components/landing/interviews.tsx
@@ -154,18 +154,6 @@ const Interviews: React.FunctionComponent<{
           })}
         </div>
       )}
-      {proTestingPurchased && (
-        <div className="mt-12 text-center">
-          <a
-            href={process.env.NEXT_PUBLIC_PRINTABLES_DOWNLOAD_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-tt-medium text-2xl text-blue-600 hover:underline"
-          >
-            Download All Interviews
-          </a>
-        </div>
-      )}
     </section>
   )
 }


### PR DESCRIPTION
we aren't supporting downloads of video content for TJS at this time and
that link wasn't downloading the right thing anyway.

![stop all the down](https://media2.giphy.com/media/l71kleRwrkxxK/giphy.gif?cid=d1fd59abqok4dq8li3dqxes4lss90ottr8akis5jce2t3mf5&ep=v1_gifs_search&rid=giphy.gif&ct=g)
