### PR TITLE
feat(tt): add automation via inngest to create a product in sanity + db + stripe

### DIFF
--- a/apps/total-typescript/package.json
+++ b/apps/total-typescript/package.json
@@ -14,6 +14,7 @@
     "dev:sanity": "sanity dev",
     "dev:setup": "vercel env pull .env.local && sed -i.bak '/^VERCEL/d' .env.local",
     "dev:stripe": "./scripts/check-stripe && stripe listen --forward-to localhost:3016/api/skill/webhook/stripe",
+    "dev:inngest": "pnpx inngest-cli@latest dev -u http://localhost:3016/api/inngest",
     "lint": "eslint src/**/*.{ts,tsx} --fix && tsc --noEmit",
     "start": "next start -p 3016",
     "test": "jest"

--- a/apps/total-typescript/seed_data/data.Products.essentials-workshop.00001.sql
+++ b/apps/total-typescript/seed_data/data.Products.essentials-workshop.00001.sql
@@ -1,0 +1,15 @@
+INSERT INTO Product (id, name, productType, status) VALUES
+('tt_product_7a0524b6-1edb-4588-9484-743dd7bb95c4', "TypeScript Pro Essentials", 'self-paced',1);
+
+
+
+INSERT INTO Price (id, productId, nickname, status, unitAmount ) VALUES
+('tt_price_a805bc8b-b0a1-4e53-8653-696be7a6b549', 'tt_product_7a0524b6-1edb-4588-9484-743dd7bb95c4', 'TypeScript Pro Essentials', 1, 250);
+
+
+INSERT INTO MerchantProduct (id, merchantAccountId, productId, status, identifier) 
+VALUES ('tt_merchant_product_137e3deb-20bd-4879-bbce-ded76a679f70', "tt_cc7acfa7-f60b-4315-ae51-3cbd305e23ae", 'tt_product_7a0524b6-1edb-4588-9484-743dd7bb95c4', 1, "prod_PtXc4OPWrQgjgM");
+
+
+INSERT INTO MerchantPrice (id, merchantProductId, merchantAccountId, status, priceId, identifier ) VALUES
+('tt_merchant_price_52b11009-41c6-4123-84b8-07386096d7fd', 'tt_merchant_product_137e3deb-20bd-4879-bbce-ded76a679f70', 'tt_cc7acfa7-f60b-4315-ae51-3cbd305e23ae', 1, "tt_price_a805bc8b-b0a1-4e53-8653-696be7a6b549", "price_1P3kXdAozSgJZBRPclm4z8GB");

--- a/apps/total-typescript/src/inngest/functions/sanity/product/index.ts
+++ b/apps/total-typescript/src/inngest/functions/sanity/product/index.ts
@@ -1,0 +1,76 @@
+import groq from 'groq'
+import z from 'zod'
+import {sanityProductCreated} from './sanity-product-created'
+import {sanityProductUpdated} from './sanity-product-updated'
+import {sanityProductDeleted} from './sanity-product-deleted'
+import {sanityWriteClient} from '@/utils/sanity-server'
+
+export const sanityProductFunctions = [
+  sanityProductCreated,
+  sanityProductUpdated,
+  sanityProductDeleted,
+]
+
+export const loadSanityProduct = async (
+  id: string,
+  query = groq`*[_type == "product" && _id == $id][0] {
+          _id,
+          productId,
+          unitAmount,
+          title,
+          "slug": slug.current,
+          quantityAvailable,
+          state,
+          type,
+          upgradableTo[]->{
+            _id,
+            productId
+          },
+          features[]{
+            value,
+            icon
+          },
+          image{
+            url
+          }
+    }`,
+) => {
+  const sanityProductData = await sanityWriteClient.fetch(query, {id})
+  return BaseSanityProductSchema.parse(sanityProductData)
+}
+
+export const BaseSanityProductSchema = z.object({
+  _id: z.string(),
+  title: z.string(),
+  slug: z.string(),
+  state: z.enum(['draft', 'active', 'unavailable']).default('draft'),
+  unitAmount: z.number().default(0),
+  quantityAvailable: z.number().default(-1),
+  type: z
+    .enum(['self-paced', 'live'])
+    .default('self-paced')
+    .nullable()
+    .optional(),
+  productId: z.string().nullable().optional(),
+  upgradableTo: z
+    .array(z.object({productId: z.string()}))
+    .nullable()
+    .optional(),
+  features: z
+    .array(
+      z.object({
+        value: z.string(),
+        icon: z.string(),
+      }),
+    )
+    .nullable()
+    .optional(),
+  image: z
+    .object({
+      url: z.string(),
+    })
+    .nullable()
+    .optional(),
+})
+
+export type BaseSanityProduct = z.infer<typeof BaseSanityProductSchema>

--- a/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-created.ts
+++ b/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-created.ts
@@ -1,0 +1,206 @@
+import {inngest} from '@/inngest/inngest.server'
+import {v4} from 'uuid'
+import {prisma} from '@skillrecordings/database'
+import {loadSanityProduct} from './index'
+import {sanityWriteClient} from '@/utils/sanity-server'
+import {SANITY_WEBHOOK_EVENT} from '../sanity-inngest-events'
+import {paymentOptions} from '@/pages/api/skill/[...skillRecordings]'
+import {NonRetriableError} from 'inngest'
+
+const stripe = paymentOptions.providers.stripe?.paymentClient
+
+export const sanityProductCreated = inngest.createFunction(
+  {id: `product-create`, name: 'Create Product in Database'},
+  {
+    event: SANITY_WEBHOOK_EVENT,
+    if: 'event.data.event == "product.create"',
+  },
+  async ({event, step}) => {
+    if (!stripe) {
+      throw new NonRetriableError('Payment provider (Stripe) is missing')
+    }
+
+    const sanityProduct = await step.run('get sanity product', async () => {
+      return loadSanityProduct(event.data._id)
+    })
+
+    const {
+      title,
+      quantityAvailable,
+      unitAmount,
+      slug,
+      image,
+      features,
+      upgradableTo,
+      state,
+      type,
+    } = sanityProduct
+
+    const productStatus = state === 'active' ? 1 : 0
+
+    const product = await step.run('create product in database', async () => {
+      const newProductId = v4()
+      return await prisma.product.create({
+        data: {
+          id: newProductId,
+          name: title,
+          quantityAvailable,
+          status: productStatus,
+          productType: type,
+        },
+      })
+    })
+
+    await step.run('update productId in sanity', async () => {
+      return await sanityWriteClient
+        .patch(event.data._id)
+        .set({
+          productId: product.id,
+          ...(!features && {features: getDefaultProductFeatures()}),
+        })
+        .commit()
+    })
+
+    const price = await step.run('create price in database', async () => {
+      const newPriceId = v4()
+      return await prisma.price.create({
+        data: {
+          id: newPriceId,
+          unitAmount,
+          productId: product.id,
+          nickname: title,
+        },
+      })
+    })
+
+    const merchantAccount = await step.run('get merchant account', async () => {
+      return await prisma.merchantAccount.findFirst({
+        where: {
+          label: 'stripe',
+        },
+      })
+    })
+
+    if (merchantAccount) {
+      const stripeProduct = await step.run(
+        'create stripe product',
+        async () => {
+          return await stripe.products.create({
+            name: product.name,
+            ...(image && {images: [image.url]}),
+            metadata: {
+              slug,
+            },
+          })
+        },
+      )
+
+      const stripePrice = await step.run('create stripe price', async () => {
+        return await stripe.prices.create({
+          product: stripeProduct.id,
+          unit_amount: Math.floor(Number(unitAmount) * 100),
+          currency: 'usd',
+          nickname: title,
+          metadata: {
+            slug,
+          },
+        })
+      })
+
+      const merchantProduct = await step.run(
+        'create merchant product in database',
+        async () => {
+          const newMerchantProductId = v4()
+          return await prisma.merchantProduct.create({
+            data: {
+              id: newMerchantProductId,
+              productId: product.id,
+              merchantAccountId: merchantAccount.id,
+              identifier: stripeProduct.id,
+              status: 1,
+            },
+          })
+        },
+      )
+
+      const merchantPrice = await step.run(
+        'create merchant price in database',
+        async () => {
+          const newMerchantPriceId = v4()
+          return await prisma.merchantPrice.create({
+            data: {
+              id: newMerchantPriceId,
+              merchantProductId: merchantProduct.id,
+              priceId: price.id,
+              merchantAccountId: merchantAccount.id,
+              identifier: stripePrice.id,
+              status: 1,
+            },
+          })
+        },
+      )
+
+      if (upgradableTo) {
+        await step.run('create product upgrades', async () => {
+          return await prisma.upgradableProducts.createMany({
+            data: upgradableTo.map((upgradeToProduct) => ({
+              upgradableFromId: product.id,
+              upgradableToId: upgradeToProduct.productId,
+            })),
+          })
+        })
+      }
+
+      return {
+        product,
+        merchantProduct,
+        merchantPrice,
+        price,
+        stripeProduct,
+        stripePrice,
+      }
+    } else {
+      throw new Error('No merchant account found')
+    }
+  },
+)
+
+const getDefaultProductFeatures = () =>
+  [
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M6.75146 12.1765C6.58598 12.1764 6.42728 12.1107 6.31028 11.9936L3.1902 8.87356C3.1306 8.81599 3.08306 8.74714 3.05036 8.671C3.01765 8.59487 3.00044 8.51299 2.99972 8.43013C2.999 8.34728 3.01479 8.26511 3.04616 8.18842C3.07754 8.11173 3.12387 8.04205 3.18247 7.98346C3.24106 7.92487 3.31073 7.87854 3.38742 7.84716C3.46411 7.81579 3.54628 7.8 3.62913 7.80072C3.71199 7.80144 3.79387 7.81865 3.87001 7.85135C3.94614 7.88406 4.015 7.9316 4.07256 7.9912L6.6641 10.5821L11.8547 3.08518C11.9004 3.01568 11.9595 2.95603 12.0287 2.90973C12.0978 2.86343 12.1754 2.83142 12.2571 2.81557C12.3388 2.79972 12.4228 2.80036 12.5042 2.81745C12.5856 2.83453 12.6628 2.86773 12.7311 2.91507C12.7995 2.96242 12.8578 3.02296 12.9024 3.09314C12.9471 3.16332 12.9773 3.24172 12.9912 3.32373C13.0051 3.40574 13.0025 3.48971 12.9835 3.57069C12.9645 3.65168 12.9295 3.72805 12.8806 3.79531L7.26441 11.9075C7.21268 11.9831 7.14494 12.0464 7.06599 12.0929C6.98705 12.1394 6.89884 12.1679 6.80763 12.1765C6.78891 12.1765 6.77018 12.1765 6.75146 12.1765Z" fill="#3A80F5"/> </svg>',
+      value: '1 Self-Paced Workshop',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M8 8.00001C9.364 9.36401 11.068 10.727 12.773 10.727C14.279 10.727 15.5 9.50601 15.5 8.00001C15.5 6.49401 14.279 5.27301 12.773 5.27301C11.068 5.27301 9.364 6.63601 8 8.00001ZM8 8.00001C6.636 6.63601 4.932 5.27301 3.227 5.27301C1.721 5.27301 0.5 6.49401 0.5 8.00001C0.5 9.50601 1.721 10.727 3.227 10.727C4.932 10.727 6.636 9.36401 8 8.00001Z" stroke="#3A80F5" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"/> </svg>',
+      value: 'Lifetime Access',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M9.5 15.5V10.5H14.5" stroke="#3A80F5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/> <path d="M9.5 15.5H1.5V0.5H14.5V10.5L9.5 15.5Z" stroke="#3A80F5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/> </svg>',
+      value: 'Customizable invoice',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <g clip-path="url(#clip0_664_2048)"> <path d="M4.5 15.5H11.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M6.5 3.5L11.5 6.5L6.5 9.5V3.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M15.5 0.5H0.5V12.5H15.5V0.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </g> <defs> <clipPath id="clip0_664_2048"> <rect width="16" height="16" fill="white"/> </clipPath> </defs> </svg>',
+      value: 'Streaming 4K Video',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M8.5 13.5H15.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M0.5 1.5L6.5 7.5L0.5 13.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </svg>',
+      value: '30 Interactive Exercises',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <g clip-path="url(#clip0_664_2054)"> <path d="M8 15.5C12.1421 15.5 15.5 12.1421 15.5 8C15.5 3.85786 12.1421 0.5 8 0.5C3.85786 0.5 0.5 3.85786 0.5 8C0.5 12.1421 3.85786 15.5 8 15.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M6.833 5.738C6.50006 5.57448 6.13286 5.49288 5.762 5.5C3.976 5.5 3.5 6.81 3.5 8C3.5 9.19 3.976 10.5 5.762 10.5C6.13286 10.5071 6.50006 10.4255 6.833 10.262" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M11.833 5.738C11.5001 5.57448 11.1329 5.49288 10.762 5.5C8.976 5.5 8.5 6.81 8.5 8C8.5 9.19 8.976 10.5 10.762 10.5C11.1329 10.5071 11.5001 10.4255 11.833 10.262" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </g> <defs> <clipPath id="clip0_664_2054"> <rect width="16" height="16" fill="white"/> </clipPath> </defs> </svg>',
+      value: 'English Transcripts & Subtitles',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M3 14.5L13 1.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M4.5 6.5C5.88071 6.5 7 5.38071 7 4C7 2.61929 5.88071 1.5 4.5 1.5C3.11929 1.5 2 2.61929 2 4C2 5.38071 3.11929 6.5 4.5 6.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M11.5 14.5C12.8807 14.5 14 13.3807 14 12C14 10.6193 12.8807 9.5 11.5 9.5C10.1193 9.5 9 10.6193 9 12C9 13.3807 10.1193 14.5 11.5 14.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </svg>',
+      value: 'Progress Tracking',
+    },
+    {
+      icon: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"> <path d="M8.5 13.5V10.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M6.5 13.5H10.5C11.0304 13.5 11.5391 13.7107 11.9142 14.0858C12.2893 14.4609 12.5 14.9696 12.5 15.5H4.5C4.5 14.9696 4.71071 14.4609 5.08579 14.0858C5.46086 13.7107 5.96957 13.5 6.5 13.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M12.5 1.5H15.5V4.5C15.5 5.29565 15.1839 6.05871 14.6213 6.62132C14.0587 7.18393 13.2956 7.5 12.5 7.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M4.5 1.5H1.5V4.5C1.5 5.29565 1.81607 6.05871 2.37868 6.62132C2.94129 7.18393 3.70435 7.5 4.5 7.5" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> <path d="M4.5 0.5H12.5V6.5C12.5 7.56087 12.0786 8.57828 11.3284 9.32843C10.5783 10.0786 9.56087 10.5 8.5 10.5C7.43913 10.5 6.42172 10.0786 5.67157 9.32843C4.92143 8.57828 4.5 7.56087 4.5 6.5V0.5Z" stroke="#3A80F5" stroke-linecap="round" stroke-linejoin="round"/> </svg>',
+      value: 'Completion Certificate',
+    },
+  ].map((feature) => ({
+    ...feature,
+    _key: v4(),
+    _type: 'feature',
+  }))

--- a/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-deleted.ts
+++ b/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-deleted.ts
@@ -1,0 +1,154 @@
+import {inngest} from '@/inngest/inngest.server'
+import {prisma} from '@skillrecordings/database'
+import {SANITY_WEBHOOK_EVENT} from '../sanity-inngest-events'
+import {paymentOptions} from '@/pages/api/skill/[...skillRecordings]'
+import {NonRetriableError} from 'inngest'
+
+const stripe = paymentOptions.providers.stripe?.paymentClient
+
+export const sanityProductDeleted = inngest.createFunction(
+  {id: `product-delete`, name: 'Deactivate Product in Database'},
+  {
+    event: SANITY_WEBHOOK_EVENT,
+    if: 'event.data.event == "product.delete"',
+  },
+  async ({event, step}) => {
+    if (!stripe) {
+      throw new NonRetriableError('Payment provider (Stripe) is missing')
+    }
+
+    const {productId} = event.data
+
+    if (!productId) {
+      throw new Error(`Product id not found`)
+    }
+
+    const product = await step.run('get product in database', async () => {
+      return await prisma.product.findUnique({
+        where: {
+          id: productId,
+        },
+        include: {
+          prices: true,
+        },
+      })
+    })
+
+    if (!product) {
+      throw new Error(`Product not found [${productId}]`)
+    }
+
+    await step.run('deactivate product', async () => {
+      return await prisma.product.update({
+        where: {
+          id: productId,
+        },
+        data: {
+          status: 0,
+          name: `(DEACTIVATED) ${product.name}`,
+        },
+      })
+    })
+
+    await step.run('deactivate prices', async () => {
+      return await Promise.all(
+        product.prices.map(async (price) => {
+          return await prisma.price.update({
+            where: {
+              id: price.id,
+            },
+            data: {
+              status: 0,
+              nickname: `(DEACTIVATED) ${price.nickname}`,
+            },
+          })
+        }),
+      )
+    })
+
+    const merchantProduct = await step.run('get merchant product', async () => {
+      return await prisma.merchantProduct.findFirst({
+        where: {
+          productId,
+        },
+        include: {
+          merchantPrices: true,
+        },
+      })
+    })
+
+    if (!merchantProduct) {
+      throw new Error(
+        `Merchant Product not found for product id [${productId}]`,
+      )
+    }
+
+    await step.run('deactivate merchant product', async () => {
+      return await prisma.merchantProduct.update({
+        where: {
+          id: merchantProduct.id,
+        },
+        data: {
+          status: 0,
+        },
+      })
+    })
+
+    await step.run('deactivate merchant prices', async () => {
+      return await Promise.all(
+        merchantProduct.merchantPrices.map(async (merchantPrice) => {
+          return await prisma.merchantPrice.update({
+            where: {
+              id: merchantPrice.id,
+            },
+            data: {
+              status: 0,
+            },
+          })
+        }),
+      )
+    })
+
+    const stripeProduct = await step.run('get stripe product', async () => {
+      if (!merchantProduct?.identifier) {
+        throw new Error('Merchant Product not found')
+      }
+      return await stripe.products.retrieve(merchantProduct.identifier)
+    })
+
+    await step.run('deactivate stripe product', async () => {
+      return await stripe.products.update(stripeProduct.id, {
+        active: false,
+      })
+    })
+
+    await step.run('delete product upgrades', async () => {
+      return await prisma.upgradableProducts.deleteMany({
+        where: {
+          OR: [
+            {
+              upgradableFromId: product.id,
+            },
+            {
+              upgradableToId: product.id,
+            },
+          ],
+        },
+      })
+    })
+
+    await step.run('deactivate all stripe prices', async () => {
+      return await Promise.all(
+        merchantProduct.merchantPrices.map(async (merchantPrice) => {
+          if (merchantPrice.identifier) {
+            return stripe.prices.update(merchantPrice.identifier, {
+              active: false,
+            })
+          } else {
+            return Promise.resolve()
+          }
+        }),
+      )
+    })
+  },
+)

--- a/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-updated.ts
+++ b/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-updated.ts
@@ -1,0 +1,257 @@
+import {inngest} from '@/inngest/inngest.server'
+import {prisma} from '@skillrecordings/database'
+import {v4} from 'uuid'
+import {loadSanityProduct} from './index'
+import {SANITY_WEBHOOK_EVENT} from '../sanity-inngest-events'
+import {paymentOptions} from '@/pages/api/skill/[...skillRecordings]'
+import {NonRetriableError} from 'inngest'
+
+const stripe = paymentOptions.providers.stripe?.paymentClient
+
+export const sanityProductUpdated = inngest.createFunction(
+  {
+    id: `product-update`,
+    name: 'Update Product in Database',
+    concurrency: 1,
+    debounce: {
+      key: 'event.data._id + "-" + event.data.event',
+      period: '30s',
+    },
+  },
+  {
+    event: SANITY_WEBHOOK_EVENT,
+    if: 'event.data.event == "product.update"',
+  },
+  async ({event, step}) => {
+    if (!stripe) {
+      throw new NonRetriableError('Payment provider (Stripe) is missing')
+    }
+
+    const sanityProduct = await step.run('get sanity product', async () => {
+      return loadSanityProduct(event.data._id)
+    })
+
+    const {
+      productId,
+      title,
+      quantityAvailable,
+      unitAmount,
+      slug,
+      image,
+      upgradableTo,
+      state,
+      type,
+    } = sanityProduct
+
+    if (!productId) {
+      throw new Error(`Product id not found`)
+    }
+
+    const product = await step.run('get product in database', async () => {
+      return await prisma.product.findUnique({
+        where: {
+          id: productId,
+        },
+        include: {
+          prices: true,
+        },
+      })
+    })
+
+    if (!product) {
+      throw new Error(`Product not found [${productId}]`)
+    }
+
+    const merchantProduct = await step.run('get merchant product', async () => {
+      return await prisma.merchantProduct.findFirst({
+        where: {
+          productId,
+        },
+      })
+    })
+
+    if (!merchantProduct) {
+      throw new Error(
+        `Merchant Product not found for product id [${productId}]`,
+      )
+    }
+
+    const currentProductUpgrades = await step.run(
+      'get product upgrades',
+      async () => {
+        return await prisma.upgradableProducts.findMany({
+          where: {
+            upgradableFromId: product.id,
+          },
+        })
+      },
+    )
+
+    const upgradeToIds = upgradableTo?.map(
+      (upgradeToProduct) => upgradeToProduct.productId,
+    )
+    const currentProductUpgradeIds = currentProductUpgrades?.map(
+      (currentProductUpgrade) => currentProductUpgrade.upgradableToId,
+    )
+    const upgradeToIdsMatch = upgradeToIds?.every((id) =>
+      currentProductUpgradeIds?.includes(id),
+    )
+
+    if (!upgradeToIdsMatch) {
+      await step.run('delete product upgrades', async () => {
+        return await prisma.upgradableProducts.deleteMany({
+          where: {
+            upgradableFromId: product.id,
+          },
+        })
+      })
+
+      if (upgradableTo) {
+        await step.run('create product upgrades', async () => {
+          return await prisma.upgradableProducts.createMany({
+            data: upgradableTo.map((upgradeToProduct) => ({
+              upgradableFromId: product.id,
+              upgradableToId: upgradeToProduct.productId,
+            })),
+          })
+        })
+      }
+    }
+
+    const stripeProduct = await step.run('get stripe product', async () => {
+      if (!merchantProduct?.identifier) {
+        throw new Error('Merchant Product not found')
+      }
+      return await stripe.products.retrieve(merchantProduct.identifier)
+    })
+
+    const priceChanged = !product.prices
+      .map((price) => Number(price.unitAmount))
+      .includes(unitAmount)
+
+    if (priceChanged) {
+      const currentMerchantPrice = await step.run(
+        'get current merchant price',
+        async () => {
+          return await prisma.merchantPrice.findFirst({
+            where: {
+              priceId: product.prices[0].id,
+            },
+          })
+        },
+      )
+
+      const currentStripePrice = await step.run(
+        'get stripe price',
+        async () => {
+          if (!currentMerchantPrice?.identifier) {
+            throw new Error('Merchant Price not found')
+          }
+          return await stripe.prices.retrieve(currentMerchantPrice.identifier)
+        },
+      )
+
+      const newStripePrice = await step.run(
+        'create new stripe price',
+        async () => {
+          return await stripe.prices.create({
+            unit_amount: Math.floor(Number(unitAmount) * 100),
+            currency: 'usd',
+            product: stripeProduct.id,
+            active: true,
+          })
+        },
+      )
+
+      await step.run('set stripeProduct default price', async () => {
+        return await stripe.products.update(stripeProduct.id, {
+          default_price: newStripePrice.id,
+        })
+      })
+
+      await step.run('create new merchant price', async () => {
+        const newMerchantPriceId = v4()
+        return await prisma.merchantPrice.create({
+          data: {
+            id: newMerchantPriceId,
+            merchantProductId: merchantProduct.id,
+            priceId: product.prices[0].id,
+            merchantAccountId: merchantProduct.merchantAccountId,
+            identifier: newStripePrice.id,
+            status: 1,
+          },
+        })
+      })
+
+      if (currentMerchantPrice) {
+        await step.run('deactivate old merchant price', async () => {
+          return await prisma.merchantPrice.update({
+            where: {
+              id: currentMerchantPrice.id,
+            },
+            data: {
+              status: 0,
+            },
+          })
+        })
+      }
+
+      await step.run('update price in database', async () => {
+        return await prisma.price.update({
+          where: {
+            id: product.prices[0].id,
+          },
+          data: {
+            nickname: title,
+            unitAmount,
+          },
+        })
+      })
+
+      if (currentStripePrice) {
+        await step.run('deactivate stripe price', async () => {
+          return await stripe.prices.update(currentStripePrice.id, {
+            active: false,
+          })
+        })
+      }
+    }
+
+    const updatedStripeProduct = await step.run(
+      'update stripe product',
+      async () => {
+        return await stripe.products.update(stripeProduct.id, {
+          name: title,
+          active: true,
+          ...(image && {images: [image.url]}),
+          metadata: {
+            slug,
+          },
+        })
+      },
+    )
+
+    const updatedProduct = await step.run(
+      'update product in database',
+      async () => {
+        return await prisma.product.update({
+          where: {
+            id: product.id,
+          },
+          data: {
+            name: title,
+            quantityAvailable,
+            status: state === 'active' ? 1 : 0,
+            productType: type,
+          },
+          include: {
+            prices: true,
+            merchantProducts: true,
+          },
+        })
+      },
+    )
+
+    return {updatedProduct, updatedStripeProduct}
+  },
+)

--- a/apps/total-typescript/src/inngest/functions/sanity/sanity-inngest-events.ts
+++ b/apps/total-typescript/src/inngest/functions/sanity/sanity-inngest-events.ts
@@ -1,0 +1,13 @@
+type SanityEventData = {
+  _type: string
+  _id: string
+  event: string
+  productId?: string | null
+}
+
+export const SANITY_WEBHOOK_EVENT = 'sanity/webhook'
+
+export type SanityWebhookEvent = {
+  name: typeof SANITY_WEBHOOK_EVENT
+  data: SanityEventData
+}

--- a/apps/total-typescript/src/inngest/inngest-config.ts
+++ b/apps/total-typescript/src/inngest/inngest-config.ts
@@ -1,7 +1,8 @@
 import {inngest} from '@/inngest/inngest.server'
 import {userCreated} from '@/inngest/functions/user/user-created'
+import {sanityProductFunctions} from '@/inngest/functions/sanity/product'
 
 export const inngestConfig = {
   client: inngest,
-  functions: [userCreated],
+  functions: [userCreated, ...sanityProductFunctions],
 }

--- a/apps/total-typescript/src/inngest/inngest.server.ts
+++ b/apps/total-typescript/src/inngest/inngest.server.ts
@@ -5,8 +5,14 @@ import {
   UserCreated,
 } from '@skillrecordings/skill-lesson/inngest/events'
 
+import {
+  SANITY_WEBHOOK_EVENT,
+  SanityWebhookEvent,
+} from './functions/sanity/sanity-inngest-events'
+
 export type IngestEvents = {
   [USER_CREATED_EVENT]: UserCreated
+  [SANITY_WEBHOOK_EVENT]: SanityWebhookEvent
 }
 
 export const inngest = new Inngest({


### PR DESCRIPTION
This incorporates the automation from Epic Web to create, update, and delete products in Sanity. These operations are then reflected in both our database and Stripe.

<img width="1133" alt="Screenshot 2024-04-19 at 3 26 53 PM" src="https://github.com/skillrecordings/products/assets/43156646/6f7313db-4e80-427f-b217-897623874072">

![automatic](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHAxc2RhbzlnMXZqdml2dDh2dWVtM3Bwb2pubm5iZHFud3A2aGZyYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/GtezXBzyy9pxUb8Gso/giphy.gif)