### PR TITLE
[epic-web] Pluralize "spot" string for `availability?.quantityAvailable`

### DIFF
--- a/packages/skill-lesson/path-to-purchase/pricing.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing.tsx
@@ -33,6 +33,7 @@ import {buildStripeCheckoutPath} from '../utils/build-stripe-checkout-path'
 import Countdown from 'react-countdown'
 import {get, snakeCase} from 'lodash'
 import {setConvertkitSubscriberFields} from '@skillrecordings/convertkit-sdk'
+import pluralize from 'pluralize'
 
 const getNumericValue = (
   value: string | number | Decimal | undefined,
@@ -312,7 +313,11 @@ export const Pricing: React.FC<React.PropsWithChildren<PricingProps>> = ({
                       ? null
                       : isSoldOut
                       ? 'Sold out'
-                      : `${availability?.quantityAvailable} spots left.`}
+                      : `${pluralize(
+                          'spot',
+                          availability?.quantityAvailable,
+                          true,
+                        )} left.`}
                   </div>
                 )}
               <p data-name-badge="">{name}</p>


### PR DESCRIPTION
attn @kentcdodds
—

Fix plural typo when only 1 quantity is present

<img src="https://github.com/skillrecordings/products/assets/5913254/4b4933bb-3b6d-4e18-abc9-eefb3567280e" width="350" />

I couldn't manage to spin up the repo locally even after installing all the deps, but here is a proof of concept:

![](https://github.com/skillrecordings/products/assets/5913254/a5716e86-5e2a-47dc-bc97-3401f62d7511)