### PR TITLE
Dynamically pluralize "spot" string instances

### DIFF
--- a/apps/epic-web/src/components/app/navigation.tsx
+++ b/apps/epic-web/src/components/app/navigation.tsx
@@ -1061,9 +1061,8 @@ export const Banner: React.FC<{
                 New live event scheduled!
               </strong>{' '}
               <span>
-                {activeEvent.quantityAvailable}{' '}
-                {pluralize('spot', activeEvent.quantityAvailable)} left for{' '}
-                {activeEvent.event.title} workshop.
+                {pluralize('spot', activeEvent.quantityAvailable, true)} left
+                for {activeEvent.event.title} workshop.
               </span>
             </p>
             <div className="flex-shrink-0 rounded bg-white px-2 py-0.5 font-semibold text-primary shadow-md">

--- a/apps/epic-web/src/pages/events/index.tsx
+++ b/apps/epic-web/src/pages/events/index.tsx
@@ -18,6 +18,7 @@ import {cn} from '@skillrecordings/ui/utils/cn'
 import Icon from 'components/icons'
 import {IS_PAST_CONF_24} from 'pages/conf'
 import {formatInTimeZone} from 'date-fns-tz'
+import pluralize from 'pluralize'
 
 export const getStaticProps: GetStaticProps = async (context) => {
   const events = await getAllEvents()
@@ -206,10 +207,15 @@ const Events: React.FC<{events: Event[]}> = ({events}) => {
                           'Sold out'
                         ) : isUpcoming ? (
                           <>
-                            {availability?.quantityAvailable ?? (
+                            {availability?.quantityAvailable ? (
+                              `${pluralize(
+                                'spot',
+                                availability.quantityAvailable,
+                                true,
+                              )} left`
+                            ) : (
                               <Spinner className="w-3" />
-                            )}{' '}
-                            spots left
+                            )}
                           </>
                         ) : (
                           <div className="rounded bg-gray-100 px-3 py-1.5 dark:bg-gray-900">


### PR DESCRIPTION
attn @kentcdodds @vojtaholik
—

* Fix plural typo when only 1 quantity is present
   
   ![](https://github.com/skillrecordings/products/assets/5913254/e0c849f9-6c48-428b-ad89-e6714bfa10b6)
* Improve instance where explicit number can be replaced for 3rd pluralize arg

Related
* https://github.com/skillrecordings/products/pull/1509
* Commit https://github.com/skillrecordings/products/commit/2d1e497ad88b2199d7fb3492b0c301a2b11cee30 by @vojtaholik