### PR TITLE
Dynamically pluralize "spot" string instances

### DIFF
--- a/apps/epic-web/src/components/app/navigation.tsx
+++ b/apps/epic-web/src/components/app/navigation.tsx
@@ -1061,9 +1061,8 @@ export const Banner: React.FC<{
                 New live event scheduled!
               </strong>{' '}
               <span>
-                {activeEvent.quantityAvailable}{' '}
-                {pluralize('spot', activeEvent.quantityAvailable)} left for{' '}
-                {activeEvent.event.title} workshop.
+                {pluralize('spot', activeEvent.quantityAvailable, true)} left
+                for {activeEvent.event.title} workshop.
               </span>
             </p>
             <div className="flex-shrink-0 rounded bg-white px-2 py-0.5 font-semibold text-primary shadow-md">

--- a/apps/epic-web/src/pages/events/index.tsx
+++ b/apps/epic-web/src/pages/events/index.tsx
@@ -206,11 +206,15 @@ const Events: React.FC<{events: Event[]}> = ({events}) => {
                           'Sold out'
                         ) : isUpcoming ? (
                           <>
-                            {availability?.quantityAvailable ?? (
+                            {availability?.quantityAvailable ? (
+                              `${pluralize(
+                                'spot',
+                                availability.quantityAvailable,
+                                true,
+                              )} left`
+                            ) : (
                               <Spinner className="w-3" />
-                            )}{' '}
-                            {pluralize('spot', availability?.quantityAvailable)}{' '}
-                            left
+                            )}
                           </>
                         ) : (
                           <div className="rounded bg-gray-100 px-3 py-1.5 dark:bg-gray-900">


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR was opened in response to commits [2d1e497](https://github.com/skillrecordings/products/commit/2d1e497ad88b2199d7fb3492b0c301a2b11cee30) and [44c83b6](https://github.com/skillrecordings/products/commit/44c83b6277791633c944514a0638b78c7901fa44), following my effort in https://github.com/skillrecordings/products/pull/1509.
>
> **`apps/epic-web/src/components/app/navigation.tsx`** :: 🛠️ Improvement
> Moves the quantity into the JS expression to remove redundancy
>
> **`apps/epic-web/src/pages/events/index.tsx`** :: 🐞 Bug fix
> The current implementation will show `<Spinner /> spots left` when `availability?.quantityAvailable` is falsy, rather than only the spinner.

attn @kentcdodds @vojtaholik @Creeland
—

* Fix plural typo when only 1 quantity is present
   
   ![](https://github.com/skillrecordings/products/assets/5913254/e0c849f9-6c48-428b-ad89-e6714bfa10b6)
* Improve instance where explicit number can be replaced for 3rd pluralize arg

Related
* https://github.com/skillrecordings/products/pull/1509
* Commit https://github.com/skillrecordings/products/commit/2d1e497ad88b2199d7fb3492b0c301a2b11cee30 by @vojtaholik