### PR TITLE
feat(tt): look up section slug for module/lesson

### DIFF
--- a/apps/epic-react/src/lib/bonuses.ts
+++ b/apps/epic-react/src/lib/bonuses.ts
@@ -84,8 +84,8 @@ const bonusesQuery = groq`*[_type == "module" && moduleType == 'bonus'] | order(
 
 export const getAllBonuses = async () => await sanityClient.fetch(bonusesQuery)
 
-export const getBonus = async (slug: string) =>
-  await sanityClient.fetch(
+export const getBonus = async (slug: string) => {
+  const result = await sanityClient.fetch(
     groq`*[_type == "module" && moduleType == 'bonus' && slug.current == $slug][0]{
         "id": _id,
         _type,
@@ -132,5 +132,8 @@ export const getBonus = async (slug: string) =>
     }`,
     {slug: `${slug}`},
   )
+
+  return BonusSchema.parse(result)
+}
 
 export type Bonus = z.infer<typeof BonusSchema>

--- a/apps/epic-react/src/lib/workshops.ts
+++ b/apps/epic-react/src/lib/workshops.ts
@@ -24,7 +24,7 @@ const workshopsForProductQuery = groq`*[_type == "product" && productId == $prod
         explainerType
       },
       (_type == 'section') => {
-        "resources": resources[@->._type in ['explainer', 'exercise']]->{
+        "lessons": resources[@->._type in ['explainer', 'exercise']]->{
           _id,
           _type,
           _updatedAt,
@@ -247,7 +247,9 @@ export const getWorkshop = async (slug: string) => {
     {slug: `${slug}`},
   )
 
-  return WorkshopSchema.parse(result)
+  return WorkshopSchema.merge(z.object({github: z.string()}))
+    .passthrough()
+    .parse(result)
 }
 
 export type Workshop = z.infer<typeof WorkshopSchema>

--- a/apps/epic-react/src/lib/workshops.ts
+++ b/apps/epic-react/src/lib/workshops.ts
@@ -129,7 +129,7 @@ export const WorkshopSchema = z.object({
       title: z.string(),
       slug: z.string(),
       explainerType: z.string().optional(),
-      resources: z
+      lessons: z
         .array(
           z.object({
             _id: z.string(),
@@ -152,8 +152,8 @@ export const getAllWorkshops = async () => {
   return WorkshopSchema.array().parse(result)
 }
 
-export const getWorkshop = async (slug: string) =>
-  await sanityClient.fetch(
+export const getWorkshop = async (slug: string) => {
+  const result = await sanityClient.fetch(
     groq`*[_type == "module" && moduleType == 'workshop' && slug.current == $slug][0]{
         "id": _id,
         _type,
@@ -167,6 +167,7 @@ export const getWorkshop = async (slug: string) =>
         workshopApp,
         ogImage,
         description,
+        _createdAt,
         _updatedAt,
         "testimonials": resources[@->._type == 'testimonial']->{
           _id,
@@ -245,5 +246,8 @@ export const getWorkshop = async (slug: string) =>
     }`,
     {slug: `${slug}`},
   )
+
+  return WorkshopSchema.parse(result)
+}
 
 export type Workshop = z.infer<typeof WorkshopSchema>

--- a/apps/epic-react/src/pages/learn.tsx
+++ b/apps/epic-react/src/pages/learn.tsx
@@ -174,7 +174,7 @@ const WorkshopItem = ({module}: {module: Module}) => {
             )
           }
 
-          if (resource._type === 'section' && resource?.resources) {
+          if (resource._type === 'section' && resource?.lessons) {
             const isCompleted = Boolean(
               moduleProgress &&
                 isResourceCompleted(
@@ -188,7 +188,7 @@ const WorkshopItem = ({module}: {module: Module}) => {
                 key={resource._id}
                 title={resource.title}
                 workshopSlug={module.slug.current}
-                resourceSlug={resource.resources[0].slug}
+                resourceSlug={resource.lessons[0].slug}
                 isCompleted={isCompleted}
               />
             )


### PR DESCRIPTION
there is no `sectionSlug` in the URL path params, so we were always getting `null` when trying to look up the `section`.

this adds a reverse lookup of the `section` based on the lesson's slug and the list of `resources` on the `module`

![lookup](https://media2.giphy.com/media/JiSq1nl9ghJsKG82bY/giphy.gif?cid=d1fd59ab9jvovpbdsncz11l3wxdgg0thhv4zwyw0y4b9r35w&ep=v1_gifs_search&rid=giphy.gif&ct=g)