### PR TITLE
Add `User.fields` JSON column for metadata

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -260,6 +260,7 @@ model User {
   deviceAccessTokens      DeviceAccessToken[]    @relation("User")
   comments                Comment[]
   roles                   String                 @default("User")
+  fields                  Json?
 }
 
 model VerificationToken {


### PR DESCRIPTION
We expect to initially use this to store app-specific values like when
Epic React gets a user's discord ID to connect them to the discord
server.

I noticed, at least with SQL, that initially adding a value to a `null` JSON field is slightly tricky. It requires calling `coalesce` on `fields` in anticipation that it is `null` so that it can be an empty object instead:

```SQL
update User set fields = json_set(coalesce(fields, '{}'), '$.discord_id', 'discord_123') where id = '...';
```

Otherwise, the `json_set` function quietly declines to update the `fields` column when it is initially null.

This may be smoothed over with Prisma, I haven't evaluated that yet.

### Next steps

- [ ] Create Deploy Requests for each of the prod databases

### Integrating these changes

Once you pull these changes down locally, you'll need to do the following:

- `pnpm -w generate` to regenerate the Prisma schema with this change.
- `pnpm db:push` from any app whose local DB is running to update the schema

![set](https://media3.giphy.com/media/9abKiBeFs0SZYt0KI6/giphy.gif?cid=d1fd59abqoqtphobyuj48zyztjqfm1bmq0td0bxq73wplox0&ep=v1_gifs_search&rid=giphy.gif&ct=g)