### PR TITLE
feat(er-next): rework navigation menu

### DIFF
--- a/apps/epic-react/src/components/app/navigation/feedback-button.tsx
+++ b/apps/epic-react/src/components/app/navigation/feedback-button.tsx
@@ -14,7 +14,7 @@ import {
 } from '@skillrecordings/ui'
 import {useFeedback} from '@/components/feedback-widget/feedback-context'
 
-export default () => {
+export default ({handlerCloseMenu}: {handlerCloseMenu: () => void}) => {
   const {setIsFeedbackDialogOpen} = useFeedback()
   const isTablet = useMedia('(max-width: 920px)', false)
   return (
@@ -31,6 +31,7 @@ export default () => {
               ),
             )}
             onClick={() => {
+              handlerCloseMenu()
               setIsFeedbackDialogOpen(true)
             }}
           >

--- a/apps/epic-react/src/components/app/navigation/index.tsx
+++ b/apps/epic-react/src/components/app/navigation/index.tsx
@@ -4,13 +4,14 @@ import {useRouter, usePathname} from 'next/navigation'
 import {useSession} from 'next-auth/react'
 import {motion, useScroll, useTransform, useSpring} from 'framer-motion'
 import {useMedia} from 'react-use'
-import {isEmpty, startsWith} from 'lodash'
+import {isEmpty} from 'lodash'
 import cx from 'classnames'
 import {twMerge} from 'tailwind-merge'
 
 import {trpc} from '@/trpc/trpc.client'
 import {isOnlyTeamPurchaser} from '@/utils/is-only-team-purchaser'
 
+import MobileNavigation from '@/components/app/navigation/mobile-navigation'
 import MessageBar from '@/components/app/navigation/message-bar'
 import Logo from '@/components/app/navigation/logo'
 import ThemeToggle from '@/components/app/navigation/theme-toggle'
@@ -53,6 +54,8 @@ const Navigation: React.FC<NavigationProps> = ({navChildren}) => {
     isAuthenticated
   const purchasedOnlyTeam = isOnlyTeamPurchaser(sessionData?.user)
 
+  const handlerCloseMobileMenu = React.useCallback(() => setOpen(false), [])
+
   React.useEffect(() => {
     setMounted(true)
   }, [])
@@ -68,6 +71,7 @@ const Navigation: React.FC<NavigationProps> = ({navChildren}) => {
                 router.push('/?buy')
               }}
               className="flex cursor-pointer rounded-lg bg-blue-500 px-3 py-2 text-white transition-all  duration-150 ease-in-out hover:bg-blue-600"
+              data-navi-item=""
             >
               Buy Epic React
             </button>
@@ -87,6 +91,7 @@ const Navigation: React.FC<NavigationProps> = ({navChildren}) => {
                     },
                   ),
                 )}
+                data-navi-item=""
               >
                 {item.label}
               </Link>
@@ -96,6 +101,7 @@ const Navigation: React.FC<NavigationProps> = ({navChildren}) => {
             <Link
               href="/login"
               className="rounded-lg px-3 py-2 text-text transition-all duration-150 ease-in-out lg:bg-blue-500 lg:text-white lg:hover:bg-blue-600"
+              data-navi-item=""
             >
               Restore Purchases
             </Link>
@@ -108,9 +114,13 @@ const Navigation: React.FC<NavigationProps> = ({navChildren}) => {
               }),
             )}
           >
-            {isAuthenticated && <FeedbackButton />}
-            <ThemeToggle />
-            {isAuthenticated && <LogoutButton />}
+            {isAuthenticated && (
+              <FeedbackButton handlerCloseMenu={handlerCloseMobileMenu} />
+            )}
+            <ThemeToggle handlerCloseMenu={handlerCloseMobileMenu} />
+            {isAuthenticated && (
+              <LogoutButton handlerCloseMenu={handlerCloseMobileMenu} />
+            )}
           </div>
         </>
       )
@@ -195,11 +205,11 @@ const Navigation: React.FC<NavigationProps> = ({navChildren}) => {
                 />
               </motion.svg>
             </button>
-            {isOpen ? (
-              <div className="navigation absolute left-0 top-[3.25rem] mt-1 grid w-full grid-flow-row justify-start p-3">
+            {isOpen && (
+              <MobileNavigation setOpen={setOpen}>
                 <Links isTablet={true} />
-              </div>
-            ) : null}
+              </MobileNavigation>
+            )}
           </>
         ) : (
           <div className="grid grid-flow-col items-center gap-2 text-xs sm:text-base">
@@ -212,19 +222,6 @@ const Navigation: React.FC<NavigationProps> = ({navChildren}) => {
 }
 
 export default Navigation
-
-const MenuPath = (props: any) => (
-  <motion.path
-    fill="transparent"
-    strokeWidth="2"
-    stroke="currentColor"
-    strokeLinecap="round"
-    transition={{
-      type: 'spring',
-    }}
-    {...props}
-  />
-)
 
 export const useAvailableSale = () => {
   const {data} = trpc.pricing.defaultCoupon.useQuery()
@@ -242,6 +239,19 @@ export const useAvailableSale = () => {
 
   return {...data, bannerHeight: data ? 36 : 0}
 }
+
+const MenuPath = (props: any) => (
+  <motion.path
+    fill="transparent"
+    strokeWidth="2"
+    stroke="currentColor"
+    strokeLinecap="round"
+    transition={{
+      type: 'spring',
+    }}
+    {...props}
+  />
+)
 
 const menuItems = [
   {

--- a/apps/epic-react/src/components/app/navigation/index.tsx
+++ b/apps/epic-react/src/components/app/navigation/index.tsx
@@ -1,20 +1,12 @@
 import * as React from 'react'
 import Link from 'next/link'
 import {useRouter, usePathname} from 'next/navigation'
-import {signOut, useSession} from 'next-auth/react'
+import {useSession} from 'next-auth/react'
 import {motion, useScroll, useTransform, useSpring} from 'framer-motion'
 import {useMedia} from 'react-use'
-import {isEmpty} from 'lodash'
+import {isEmpty, startsWith} from 'lodash'
 import cx from 'classnames'
 import {twMerge} from 'tailwind-merge'
-
-import {
-  Button,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@skillrecordings/ui'
 
 import {trpc} from '@/trpc/trpc.client'
 import {isOnlyTeamPurchaser} from '@/utils/is-only-team-purchaser'
@@ -23,7 +15,7 @@ import MessageBar from '@/components/app/navigation/message-bar'
 import Logo from '@/components/app/navigation/logo'
 import ThemeToggle from '@/components/app/navigation/theme-toggle'
 import FeedbackButton from '@/components/app/navigation/feedback-button'
-import {Logout} from '@/components/icons'
+import LogoutButton from '@/components/app/navigation/logout-button'
 import Skeleton from '@/components/skeleton'
 
 type NavigationProps = {
@@ -80,78 +72,32 @@ const Navigation: React.FC<NavigationProps> = ({navChildren}) => {
               Buy Epic React
             </button>
           ) : null}
-          <Link
-            href="/articles"
-            className={twMerge(
-              cx(
-                'rounded-md px-3 py-2 text-text transition-opacity duration-150 ease-in-out hover:opacity-100 sm:opacity-75',
-                {'bg-er-gray-100 sm:opacity-100': location === '/articles'},
-              ),
-            )}
-          >
-            Articles
-          </Link>
-          <Link
-            href="/livestreams"
-            className={twMerge(
-              cx(
-                'rounded-md px-3 py-2 text-text transition-opacity duration-150 ease-in-out hover:opacity-100 sm:opacity-75',
-                {'bg-er-gray-100 sm:opacity-100': location === '/livestreams'},
-              ),
-            )}
-          >
-            Livestreams
-          </Link>
-          <Link
-            href="/podcast/kents-career-path-through-web-development"
-            className={twMerge(
-              cx(
-                'rounded-md px-3 py-2 text-text transition-opacity duration-150 ease-in-out hover:opacity-100 sm:opacity-75',
-                {
-                  'bg-er-gray-100 sm:opacity-100':
-                    location.startsWith('/podcast/'),
-                },
-              ),
-            )}
-          >
-            Podcast
-          </Link>
-          <Link
-            href="/faq"
-            className={twMerge(
-              cx(
-                'rounded-md px-3 py-2 text-text transition-opacity duration-150 ease-in-out hover:opacity-100 sm:opacity-75',
-                {'bg-er-gray-100 sm:opacity-100': location === '/faq'},
-              ),
-            )}
-          >
-            FAQ
-          </Link>
+          {menuItems.map((item) => {
+            return (
+              <Link
+                key={item.label}
+                href={item.slug}
+                className={twMerge(
+                  cx(
+                    'rounded-md px-3 py-2 text-text transition-opacity duration-150 ease-in-out hover:opacity-100 sm:opacity-75',
+                    {
+                      'bg-er-gray-200 sm:opacity-100': location.startsWith(
+                        item.slug,
+                      ),
+                    },
+                  ),
+                )}
+              >
+                {item.label}
+              </Link>
+            )
+          })}
           {sellingLive && !isAuthenticated ? (
             <Link
               href="/login"
               className="rounded-lg px-3 py-2 text-text transition-all duration-150 ease-in-out lg:bg-blue-500 lg:text-white lg:hover:bg-blue-600"
             >
               Restore Purchases
-            </Link>
-          ) : null}
-
-          {isAuthenticated &&
-          !isEmpty(sessionData?.user?.purchases) &&
-          !purchasedOnlyTeam ? (
-            <Link
-              href="/learn"
-              className={twMerge(
-                cx(
-                  'rounded-lg border-transparent px-3 py-2 leading-tight text-text transition-colors duration-150 ease-in-out  md:border md:bg-blue-500 md:text-white md:hover:bg-blue-600',
-                  {
-                    'bg-background text-text sm:opacity-100 md:bg-background md:text-text md:hover:text-white':
-                      location === '/learn',
-                  },
-                ),
-              )}
-            >
-              Modules
             </Link>
           ) : null}
           <div
@@ -163,39 +109,8 @@ const Navigation: React.FC<NavigationProps> = ({navChildren}) => {
             )}
           >
             {isAuthenticated && <FeedbackButton />}
-
             <ThemeToggle />
-
-            {isAuthenticated ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => signOut()}
-                      className={twMerge(
-                        cx(
-                          'w-auto border-none px-3 py-2 text-base text-text transition-opacity duration-150 ease-in-out hover:bg-transparent hover:opacity-100 md:px-2',
-                          {
-                            'opacity-100': isTablet,
-                            'opacity-75': !isTablet,
-                          },
-                        ),
-                      )}
-                    >
-                      {isTablet ? 'Log Out' : <Logout />}
-                      <span className="sr-only">Log out</span>
-                    </Button>
-                  </TooltipTrigger>
-                  {!isTablet && (
-                    <TooltipContent>
-                      <p>Log Out</p>
-                    </TooltipContent>
-                  )}
-                </Tooltip>
-              </TooltipProvider>
-            ) : null}
+            {isAuthenticated && <LogoutButton />}
           </div>
         </>
       )
@@ -327,3 +242,26 @@ export const useAvailableSale = () => {
 
   return {...data, bannerHeight: data ? 36 : 0}
 }
+
+const menuItems = [
+  {
+    label: 'Articles',
+    slug: '/articles',
+  },
+  {
+    label: 'Livestreams',
+    slug: '/livestreams',
+  },
+  {
+    label: 'Podcast',
+    slug: '/podcast',
+  },
+  {
+    label: 'FAQ',
+    slug: '/faq',
+  },
+  {
+    label: 'Modules',
+    slug: '/learn',
+  },
+]

--- a/apps/epic-react/src/components/app/navigation/logout-button.tsx
+++ b/apps/epic-react/src/components/app/navigation/logout-button.tsx
@@ -3,8 +3,9 @@
 import {useMedia} from 'react-use'
 import cx from 'classnames'
 import {twMerge} from 'tailwind-merge'
+import {signOut} from 'next-auth/react'
 
-import {Message} from '@/components/icons'
+import {Logout} from '@/components/icons'
 import {
   Button,
   Tooltip,
@@ -12,10 +13,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@skillrecordings/ui'
-import {useFeedback} from '@/components/feedback-widget/feedback-context'
 
 export default () => {
-  const {setIsFeedbackDialogOpen} = useFeedback()
   const isTablet = useMedia('(max-width: 920px)', false)
   return (
     <TooltipProvider>
@@ -24,23 +23,26 @@ export default () => {
           <Button
             variant="ghost"
             size="icon"
+            onClick={() => signOut()}
             className={twMerge(
               cx(
                 'w-auto border-none px-3 py-2 text-base text-text transition-opacity duration-150 ease-in-out hover:bg-transparent hover:opacity-100 md:px-2',
-                isTablet ? 'opacity-100' : 'opacity-75',
+                {
+                  'opacity-100': isTablet,
+                  'opacity-75': !isTablet,
+                },
               ),
             )}
-            onClick={() => {
-              setIsFeedbackDialogOpen(true)
-            }}
           >
-            {isTablet ? 'Send Feedback' : <Message />}
-            <span className="sr-only">Send Feedback</span>
+            {isTablet ? 'Log Out' : <Logout />}
+            <span className="sr-only">Log out</span>
           </Button>
         </TooltipTrigger>
-        <TooltipContent>
-          <p>Send feedback</p>
-        </TooltipContent>
+        {!isTablet && (
+          <TooltipContent>
+            <p>Log Out</p>
+          </TooltipContent>
+        )}
       </Tooltip>
     </TooltipProvider>
   )

--- a/apps/epic-react/src/components/app/navigation/logout-button.tsx
+++ b/apps/epic-react/src/components/app/navigation/logout-button.tsx
@@ -14,7 +14,7 @@ import {
   TooltipTrigger,
 } from '@skillrecordings/ui'
 
-export default () => {
+export default ({handlerCloseMenu}: {handlerCloseMenu: () => void}) => {
   const isTablet = useMedia('(max-width: 920px)', false)
   return (
     <TooltipProvider>
@@ -23,7 +23,10 @@ export default () => {
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => signOut()}
+            onClick={() => {
+              handlerCloseMenu()
+              signOut()
+            }}
             className={twMerge(
               cx(
                 'w-auto border-none px-3 py-2 text-base text-text transition-opacity duration-150 ease-in-out hover:bg-transparent hover:opacity-100 md:px-2',

--- a/apps/epic-react/src/components/app/navigation/mobile-navigation.tsx
+++ b/apps/epic-react/src/components/app/navigation/mobile-navigation.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+
+interface MobileNavigationProps {
+  setOpen: (isOpen: boolean) => void
+}
+
+const MobileNavigation: React.FC<
+  React.PropsWithChildren<MobileNavigationProps>
+> = ({setOpen, children}) => {
+  const menuHolderRef = React.useRef<HTMLDivElement>(null)
+
+  const clickHandler = React.useCallback(
+    (e: MouseEvent) => {
+      const clickedElement = e.target as HTMLElement
+      const naviItem = clickedElement.closest('[data-navi-item]') as HTMLElement
+      if (naviItem) {
+        setOpen(false)
+      }
+    },
+    [setOpen],
+  )
+
+  React.useEffect(() => {
+    const menuHolder = menuHolderRef.current
+    if (menuHolder) {
+      menuHolder.addEventListener('click', clickHandler)
+    }
+    return () => {
+      if (menuHolder) {
+        menuHolder.removeEventListener('click', clickHandler)
+      }
+    }
+  }, [clickHandler])
+
+  return (
+    <div
+      ref={menuHolderRef}
+      className="navigation absolute left-0 top-[3.25rem] mt-1 grid w-full grid-flow-row justify-start p-3"
+    >
+      {children}
+    </div>
+  )
+}
+
+export default MobileNavigation

--- a/apps/epic-react/src/components/app/navigation/theme-toggle.tsx
+++ b/apps/epic-react/src/components/app/navigation/theme-toggle.tsx
@@ -14,7 +14,7 @@ import {
 } from '@skillrecordings/ui'
 import {Sun, Moon} from '@/components/icons'
 
-export default () => {
+export default ({handlerCloseMenu}: {handlerCloseMenu: () => void}) => {
   const {theme, setTheme} = useTheme()
   const isTablet = useMedia('(max-width: 920px)', false)
   return (
@@ -25,6 +25,7 @@ export default () => {
             variant="outline"
             size="icon"
             onClick={() => {
+              handlerCloseMenu()
               setTheme(theme === 'light' ? 'dark' : 'light')
             }}
             className={twMerge(

--- a/apps/epic-react/src/components/feedback-widget/feedback-dialog.tsx
+++ b/apps/epic-react/src/components/feedback-widget/feedback-dialog.tsx
@@ -10,7 +10,6 @@ const Feedback = () => {
   const handleCloseDialog = () => {
     setIsFeedbackDialogOpen(false, 'navigation')
   }
-  console.log({isFormSubmitted})
   return (
     <FeedbackDialog
       title="Tell me how you feel about it"

--- a/apps/epic-react/src/middleware.ts
+++ b/apps/epic-react/src/middleware.ts
@@ -4,7 +4,7 @@ import {getMiddlewareResponse} from './server/get-middleware-response'
 const PUBLIC_FILE = /\.(.*)$/
 
 export const config = {
-  matcher: ['/', '/podcast'],
+  matcher: ['/', '/login', '/podcast'],
 }
 
 export async function middleware(req: NextRequest) {

--- a/apps/epic-react/src/middleware.ts
+++ b/apps/epic-react/src/middleware.ts
@@ -4,7 +4,7 @@ import {getMiddlewareResponse} from './server/get-middleware-response'
 const PUBLIC_FILE = /\.(.*)$/
 
 export const config = {
-  matcher: ['/'],
+  matcher: ['/', '/podcast'],
 }
 
 export async function middleware(req: NextRequest) {

--- a/apps/epic-react/src/server/get-middleware-response.ts
+++ b/apps/epic-react/src/server/get-middleware-response.ts
@@ -21,5 +21,16 @@ export async function getMiddlewareResponse(req: NextRequest) {
     }
   }
 
+  if (req.nextUrl.pathname === '/podcast') {
+    try {
+      response = redirectToPath(
+        '/podcast/kents-career-path-through-web-development',
+        req,
+      )
+    } catch (error) {
+      return response
+    }
+  }
+
   return response
 }

--- a/apps/epic-react/src/server/get-middleware-response.ts
+++ b/apps/epic-react/src/server/get-middleware-response.ts
@@ -21,6 +21,17 @@ export async function getMiddlewareResponse(req: NextRequest) {
     }
   }
 
+  if (req.nextUrl.pathname === '/login') {
+    try {
+      const user = UserSchema.parse(token)
+      if (user) {
+        response = redirectToPath('/learn', req)
+      }
+    } catch (error) {
+      return response
+    }
+  }
+
   if (req.nextUrl.pathname === '/podcast') {
     try {
       response = redirectToPath(


### PR DESCRIPTION
This PR implements the following:

- `Modules` menu item is now visible for non-logged / non-registered users, they can navigate to the `/learn` page now.
- Logged in pro users get redirected from `/` to `/learn`, non-logged in users stay on `/` landing page
- Logged in users once they try to naviagate to `/login` get redirected to `/learn`
- Mobile menu gets closed after user clicks on any item in it

<details>
  <summary>**Modules** menu item for non-logged in users:</summary>
  <img width="1200" src="https://github.com/skillrecordings/products/assets/1519448/604b1755-306c-48d1-8176-f28a2466f4a1">
</details>
<details>
  <summary>Mobile menu gets closed after user clicks on any item in it</summary>
  <img width="400" src="https://github.com/skillrecordings/products/assets/1519448/90abd300-d050-4049-ac78-4d13f7281fdf">
</details>


![i guess d d GIF by Hyper RPG](https://github.com/skillrecordings/products/assets/1519448/21847fed-5d9e-4dfb-8583-d74587085f89)




