### PR TITLE
feat: add UpgradableProducts seed data for ERv1

### DIFF
--- a/apps/epic-react/seed_data/data.Products.upgrades.00001.sql
+++ b/apps/epic-react/seed_data/data.Products.upgrades.00001.sql
@@ -1,0 +1,11 @@
+-- Epic React Upgradable Products
+--   Basic:    kcd_910c9191-5a69-4019-ad1d-c55bea7e9714
+--   Standard: kcd_8acc60f1-8c3f-4093-b20d-f60fc6e0cf61
+--   Pro:      kcd_2b4f4080-4ff1-45e7-b825-7d0fff266e38
+INSERT INTO `UpgradableProducts`(`upgradableFromId`, `upgradableToId`) VALUES
+    -- Basic to Standard
+    ("kcd_910c9191-5a69-4019-ad1d-c55bea7e9714", "kcd_8acc60f1-8c3f-4093-b20d-f60fc6e0cf61"),
+    -- Basic to Pro
+    ("kcd_910c9191-5a69-4019-ad1d-c55bea7e9714", "kcd_2b4f4080-4ff1-45e7-b825-7d0fff266e38"),
+    -- Standard to Pro
+    ("kcd_8acc60f1-8c3f-4093-b20d-f60fc6e0cf61", "kcd_2b4f4080-4ff1-45e7-b825-7d0fff266e38");


### PR DESCRIPTION
Run these against your local `kcd-products` database to have Upgradable Products enabled for ERv1. We will also need to run these against production database before going live.

![seed](https://media0.giphy.com/media/OH9zWD6tKD9E5QL7Ru/giphy.gif?cid=d1fd59ab9vv583dv5x4p04yqw2jr0zq2p2dhe8337yipfj2d&ep=v1_gifs_search&rid=giphy.gif&ct=g)