### PR TITLE
feat(db): add user prefs table

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -267,7 +267,7 @@ model User {
 model UserPrefs {
   id          String       @id @default(uuid())
   userId      String
-  type        String?
+  type        String
   fields      Json?        @default("{}")
   user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt   DateTime     @default(now())

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -261,6 +261,17 @@ model User {
   comments                Comment[]
   roles                   String                 @default("User")
   fields                  Json?                  @default("{}")
+  prefs                   UserPrefs[]
+}
+
+model UserPrefs {
+  id          String       @id @default(uuid())
+  userId      String
+  type        String?
+  fields      Json?        @default("{}")
+  user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime?
 }
 
 model VerificationToken {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -267,7 +267,7 @@ model User {
 model UserPrefs {
   id          String       @id @default(uuid())
   userId      String
-  type        String
+  type        String       @default("Global")
   fields      Json?        @default("{}")
   user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt   DateTime     @default(now())


### PR DESCRIPTION
Adding UserPrefs table to store user preferences.

---

Once you pull these changes down locally, you'll need to do the following:

`pnpm -w generate` to regenerate the Prisma schema with this change.
`pnpm db:push` from any app whose local DB is running to update the schema

<img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcDQ5aGFpeWh3MGFiNzllaDVvYWxyMnl5M3YzajdlN2VtMTgxNDVqZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT9C25UNTwfZuk85WP/giphy-downsized.gif" width="250" alt="gif">