### PR TITLE
Fixed the default lang on shiki

### DIFF
--- a/packages/skill-lesson/markdown/shiki-twoslash-plugin.ts
+++ b/packages/skill-lesson/markdown/shiki-twoslash-plugin.ts
@@ -22,7 +22,7 @@ const storage = createStorage({
     : memoryDriver(),
 })
 
-const LANGS = ['typescript', 'ts', 'js', 'json', 'tsx', 'html', 'bash']
+const LANGS = ['typescript', 'ts', 'js', 'json', 'tsx', 'html', 'bash', 'txt']
 
 const compilerOptions: CompilerOptions = {
   target: 9 /* ES2022 */,
@@ -43,7 +43,6 @@ const twoslash = createTwoslashFromCDN({
 const transformerTwoslash = createTransformerFactory(twoslash.runSync)({
   renderer: rendererClassic(),
   throws: true,
-  langs: LANGS,
   twoslashOptions: {
     compilerOptions,
   },
@@ -124,7 +123,7 @@ export function shikiTwoslashPlugin(
         if (!node.meta?.includes('twoslash')) {
           await prepHighlighter(opts.theme)
           const html = highlighter!.codeToHtml(code, {
-            lang: node.lang ?? 'typescript',
+            lang: node.lang ?? 'txt',
             theme: opts.theme || defaultTheme,
           })
 


### PR DESCRIPTION
Before this change, shiki was too eager to interpret a code snippet as 'lang: typescript' if a lang was not found, leading to dodgy syntax highlighting on code snippets intended to be `txt`:

![image](https://github.com/skillrecordings/products/assets/28293365/36ecf76f-045a-49e4-9287-9129ef459fa5)

Now, it'll interpret snippets without a lang as `txt` instead of `typescript`.