### PR TITLE
Changed compilerOptions.jsx to react-jsx on twoslash examples

### DIFF
--- a/packages/skill-lesson/markdown/shiki-twoslash-plugin.ts
+++ b/packages/skill-lesson/markdown/shiki-twoslash-plugin.ts
@@ -32,7 +32,7 @@ const compilerOptions: CompilerOptions = {
   noEmit: true,
   module: 99 /* ESNext */,
   moduleResolution: 100 /* Bundler */,
-  jsx: 2 /* React */,
+  jsx: 4 /* ReactJSX */,
 }
 
 const twoslash = createTwoslashFromCDN({


### PR DESCRIPTION
When we moved to ATA in 