### PR TITLE
fix(epic-react-next) redirect from invoice page if not user who purchased

### DIFF
--- a/apps/epic-react/src/pages/invoices/[merchantChargeId].tsx
+++ b/apps/epic-react/src/pages/invoices/[merchantChargeId].tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps = async ({req, query}) => {
   if (!merchantCharge) {
     return {
       redirect: {
-        destination: '/',
+        destination: '/404',
         permanent: false,
       },
     }
@@ -43,7 +43,7 @@ export const getServerSideProps: GetServerSideProps = async ({req, query}) => {
   } else {
     return {
       redirect: {
-        destination: '/',
+        destination: '/404',
         permanent: false,
       },
     }


### PR DESCRIPTION
While debugging some purchase flows on epic react next I noticed I was able to visit an invoice page while logged out (or as a different user). This redirects a user off an invoice page if the purchase userId is not the same as the account id that is logged in.

![gif](https://media0.giphy.com/media/3otPoFUhO2Z9uG1Qvm/giphy.gif?cid=1927fc1bk068wjaxvtc6i07aqd7zt3t0gpg3vepeoioqarx2&ep=v1_gifs_search&rid=giphy.gif&ct=g)