### PR TITLE
feat: add automation to create a purchased tag in ck when a product is created

### DIFF
--- a/apps/epic-web/package.json
+++ b/apps/epic-web/package.json
@@ -76,6 +76,7 @@
     "@skillrecordings/commerce-server": "workspace:*",
     "@skillrecordings/convertkit-react-ui": "workspace:*",
     "@skillrecordings/database": "workspace:*",
+    "@skillrecordings/convertkit-sdk": "workspace:*",
     "@skillrecordings/feedback-widget": "workspace:*",
     "@skillrecordings/inngest": "workspace:*",
     "@skillrecordings/next-seo": "workspace:*",

--- a/apps/epic-web/schemas/documents/product.tsx
+++ b/apps/epic-web/schemas/documents/product.tsx
@@ -33,6 +33,12 @@ export default defineType({
       readOnly: true,
     }),
     defineField({
+      name: 'convertkitPurchasedTagId',
+      title: 'Convertkit Purchase Tag ID',
+      type: 'string',
+      readOnly: true,
+    }),
+    defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',

--- a/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-created.ts
+++ b/apps/epic-web/src/inngest/functions/sanity/product/sanity-product-created.ts
@@ -6,7 +6,7 @@ import {sanityWriteClient} from 'utils/sanity-server'
 import {SANITY_WEBHOOK_EVENT} from '../sanity-inngest-events'
 import {paymentOptions} from 'pages/api/skill/[...skillRecordings]'
 import {NonRetriableError} from 'inngest'
-import {createPurchasedTag} from '@skillrecordings/convertkit-sdk'
+import {createConvertkitTag} from '@skillrecordings/convertkit-sdk'
 
 const stripe = paymentOptions.providers.stripe?.paymentClient
 
@@ -42,7 +42,7 @@ export const sanityProductCreated = inngest.createFunction(
     const purchasedTag = await step.run(
       'create tag in ConvertKit',
       async () => {
-        return await createPurchasedTag(`purchased: ${title}`)
+        return await createConvertkitTag(`purchased: ${title}`)
       },
     )
 

--- a/apps/total-typescript/schemas/documents/product.tsx
+++ b/apps/total-typescript/schemas/documents/product.tsx
@@ -47,6 +47,7 @@ export default {
       name: 'convertkitPurchasedTagId',
       title: 'Convertkit Purchase Tag ID',
       type: 'string',
+      readOnly: true,
     },
     {
       name: 'slug',

--- a/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-created.ts
+++ b/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-created.ts
@@ -6,6 +6,7 @@ import {sanityWriteClient} from '@/utils/sanity-server'
 import {SANITY_WEBHOOK_EVENT} from '../sanity-inngest-events'
 import {paymentOptions} from '@/pages/api/skill/[...skillRecordings]'
 import {NonRetriableError} from 'inngest'
+import {createPurchasedTag} from '@skillrecordings/convertkit-sdk'
 
 const stripe = paymentOptions.providers.stripe?.paymentClient
 
@@ -38,6 +39,13 @@ export const sanityProductCreated = inngest.createFunction(
 
     const productStatus = state === 'active' ? 1 : 0
 
+    const purchasedTag = await step.run(
+      'create tag in ConvertKit',
+      async () => {
+        return await createPurchasedTag(`purchased: ${title}`)
+      },
+    )
+
     const product = await step.run('create product in database', async () => {
       const newProductId = v4()
       return await prisma.product.create({
@@ -56,6 +64,7 @@ export const sanityProductCreated = inngest.createFunction(
         .patch(event.data._id)
         .set({
           productId: product.id,
+          convertkitPurchasedTagId: String(purchasedTag.id),
           ...(!features && {features: getDefaultProductFeatures()}),
         })
         .commit()

--- a/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-created.ts
+++ b/apps/total-typescript/src/inngest/functions/sanity/product/sanity-product-created.ts
@@ -6,7 +6,7 @@ import {sanityWriteClient} from '@/utils/sanity-server'
 import {SANITY_WEBHOOK_EVENT} from '../sanity-inngest-events'
 import {paymentOptions} from '@/pages/api/skill/[...skillRecordings]'
 import {NonRetriableError} from 'inngest'
-import {createPurchasedTag} from '@skillrecordings/convertkit-sdk'
+import {createConvertkitTag} from '@skillrecordings/convertkit-sdk'
 
 const stripe = paymentOptions.providers.stripe?.paymentClient
 
@@ -42,7 +42,7 @@ export const sanityProductCreated = inngest.createFunction(
     const purchasedTag = await step.run(
       'create tag in ConvertKit',
       async () => {
-        return await createPurchasedTag(`purchased: ${title}`)
+        return await createConvertkitTag(`purchased: ${title}`)
       },
     )
 

--- a/packages/convertkit-sdk/src/convertkit.ts
+++ b/packages/convertkit-sdk/src/convertkit.ts
@@ -200,7 +200,7 @@ export async function subscribeToTag(email: string, tagId: string) {
   })
 }
 
-export async function createPurchasedTag(name: string) {
+export async function createConvertkitTag(name: string) {
   if (!process.env.CONVERTKIT_API_SECRET) {
     console.warn('set CONVERTKIT_API_SECRET')
     return null

--- a/packages/convertkit-sdk/src/convertkit.ts
+++ b/packages/convertkit-sdk/src/convertkit.ts
@@ -200,6 +200,38 @@ export async function subscribeToTag(email: string, tagId: string) {
   })
 }
 
+export async function createPurchasedTag(name: string) {
+  if (!process.env.CONVERTKIT_API_SECRET) {
+    console.warn('set CONVERTKIT_API_SECRET')
+    return null
+  }
+
+  try {
+    const response = await fetch(`${convertkitBaseUrl}/tags`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        api_secret: process.env.CONVERTKIT_API_SECRET,
+        name,
+      }),
+    })
+
+    if (!response.ok) {
+      console.error(`Failed to create tag: ${response.statusText}`)
+      return null
+    }
+
+    const data = await response.json()
+    console.log('Tag created successfully')
+    return data
+  } catch (error) {
+    console.error('Error creating tag:', error)
+    return null
+  }
+}
+
 export async function subscribeToForm(options: {
   email: string
   first_name?: string

--- a/packages/skill-api/src/core/services/convertkit/convertkit-tag-purchase.ts
+++ b/packages/skill-api/src/core/services/convertkit/convertkit-tag-purchase.ts
@@ -79,7 +79,7 @@ export async function convertkitTagPurchase(email: string, purchase: Purchase) {
         : process.env.CONVERTKIT_PURCHASED_ON_FIELD_NAME || 'purchased_on'
 
       await setConvertkitSubscriberFields(subscriber, {
-        [purchasedOnFieldName]: format(new Date(), 'yyyy-mm-dd HH:MM'),
+        [purchasedOnFieldName]: format(new Date(), 'yyyy-MM-dd HH:mm:ss z'),
       })
 
       return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1836,6 +1836,9 @@ importers:
       '@skillrecordings/convertkit-react-ui':
         specifier: workspace:*
         version: link:../../packages/convertkit-react-ui
+      '@skillrecordings/convertkit-sdk':
+        specifier: workspace:*
+        version: link:../../packages/convertkit-sdk
       '@skillrecordings/database':
         specifier: workspace:*
         version: link:../../packages/database


### PR DESCRIPTION
- the reason why the property of "purchase on" wasn't being set in CK was an issue with the format
- CK wasn't tagging users properly because the tag_id wasn't being pass in sanity
- added the creation of the tag in the automation once we create a product ins sanity 
![puzzle](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTQzZHdpNmJxd2doN3MycnJscmdkc2wyZDV3c283dWl5Y296b3U1YiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2Je6sbvJEn1W9OWQ/giphy.gif)