### PR TITLE
feat(er): fix Basic->Standard->Pro upgrade chain

### DIFF
--- a/packages/commerce-server/src/format-prices-for-product.ts
+++ b/packages/commerce-server/src/format-prices-for-product.ts
@@ -115,12 +115,12 @@ export async function getFixedDiscountForIndividualUpgrade({
     ),
   )
   if (upgradeIsAvailable) {
-    const pricesToBeDiscounted = await pricesOfPurchasesTowardOneBundle({
+    const pricesTowardDiscount = await pricesOfPurchasesTowardOneBundle({
       userId,
       bundleId: productToBePurchased.id,
     })
 
-    const pricesArray = pricesToBeDiscounted.map((price) => {
+    const pricesArray = pricesTowardDiscount.map((price) => {
       return price.unitAmount.toNumber()
     })
 

--- a/packages/database/src/prisma-api.ts
+++ b/packages/database/src/prisma-api.ts
@@ -429,6 +429,7 @@ export function getSdk(
                   productType: true,
                 },
               },
+              upgradedFromId: true,
             },
           })
         : []
@@ -899,13 +900,25 @@ export function getSdk(
         },
       })
 
-      const purchasesMade = purchases.map((purchase) => {
-        return purchase.productId
-      })
+      const alreadyUpgradedPurchaseIds = purchases
+        .map((purchase) => {
+          return purchase.upgradedFromId
+        })
+        .filter((id): id is string => Boolean(id))
+
+      const purchasesNotAlreadyUpgraded = purchases.filter(
+        (purchase) => !alreadyUpgradedPurchaseIds.includes(purchase.id),
+      )
+
+      const purchasedProductIds = purchasesNotAlreadyUpgraded.map(
+        (purchase) => {
+          return purchase.productId
+        },
+      )
 
       const prices = await ctx.prisma.price.findMany({
         where: {
-          productId: {in: purchasesMade},
+          productId: {in: purchasedProductIds},
         },
       })
 


### PR DESCRIPTION
There were two issues with this flow:
1. the second upgrade (Standard->Pro) was failing because we weren't
   finding the right `UpgradableProducts` record. We now filter out the
   `Basic->Pro` one since you've already done a `Basic->*` upgrade. That
   leaves only the `Standard->Pro` upgrade path.
2. the base prices of both the Basic and Standard purchases were being
   used to determine the fixed discount of the `Standard->Pro` upgrade
   which resulted in too much money being discounted from the price. We
   now filter out the `Basic` purchase since that was upgraded to
   `Standard` and just use the base price of the `Standard` purchase.

![basic](https://media2.giphy.com/media/l1KdbHUPe27GQsJH2/giphy.gif?cid=d1fd59abuyn6r55ihz2ylj9jzb5cmsdti0k2v4c96t752sg3&ep=v1_gifs_search&rid=giphy.gif&ct=g)
