### PR TITLE
jbranchaud/er 90 basic price tier can be purchased if higher bundle is

### DIFF
--- a/packages/skill-lesson/path-to-purchase/pricing-check-context.tsx
+++ b/packages/skill-lesson/path-to-purchase/pricing-check-context.tsx
@@ -61,16 +61,19 @@ export const PriceCheckProvider: React.FC<React.PropsWithChildren<any>> = ({
         return false
       }
 
+      const unitPriceOfPurchasedProducts = []
       for (const productId of purchasedProductIds) {
-        for (const key in prices) {
-          if (key === productId) {
-            if (prices[key].unitPrice > price.unitPrice) {
-              return true
-            }
-          }
+        const purchasedPrice = prices[productId]
+        if (purchasedPrice) {
+          unitPriceOfPurchasedProducts.push(purchasedPrice.unitPrice)
         }
       }
-      return false
+
+      // if any purchased product has a unit price greater than the price
+      // we are checking, then it is a downgrade
+      return unitPriceOfPurchasedProducts.some(
+        (unitPrice) => unitPrice > price.unitPrice,
+      )
     },
     [prices],
   )

--- a/packages/skill-lesson/path-to-purchase/product-tiers.tsx
+++ b/packages/skill-lesson/path-to-purchase/product-tiers.tsx
@@ -28,17 +28,15 @@ export const PricingTiers: React.FC<
     couponIdFromCoupon || (validCoupon ? couponFromCode?.id : undefined)
 
   const purchasedProductIds = purchases.map((purchase) => purchase.productId)
+
   return (
     <>
       {redeemableCoupon ? <RedeemDialogForCoupon /> : null}
       <div data-pricing-container="">
-        {products?.map((productWithOptions, i) => {
-          const {options, ...product} = productWithOptions
-          return (
-            <PriceCheckProvider
-              key={productWithOptions.slug}
-              purchasedProductIds={purchasedProductIds}
-            >
+        <PriceCheckProvider purchasedProductIds={purchasedProductIds}>
+          {products?.map((productWithOptions, i) => {
+            const {options, ...product} = productWithOptions
+            return (
               <Pricing
                 key={product.name}
                 userId={userId}
@@ -49,9 +47,9 @@ export const PricingTiers: React.FC<
                 allowPurchase={allowPurchase}
                 options={options}
               />
-            </PriceCheckProvider>
-          )
-        })}
+            )
+          })}
+        </PriceCheckProvider>
       </div>
     </>
   )


### PR DESCRIPTION
- **fix(er): wrap all prices with Price Check Provider**
- **cleanup: made isDowngrade logic clearer**

The main thing this PR does is to make lower-tier options show up as _Unavailable_ if you have already purchased one of the higher tiers.

![CleanShot 2024-06-24 at 11 16 43@2x](https://github.com/skillrecordings/products/assets/694063/6040c9eb-f5e6-40f0-bbc8-0ed53640775e)

![tier](https://media1.giphy.com/media/eITfsH4wegT8WXEvAJ/giphy.gif?cid=d1fd59abrni2hwq1a9ibidgmjs4z3d0bhfhv3w04zsu2ccwf&ep=v1_gifs_search&rid=giphy.gif&ct=g)
