### PR TITLE
feat(er): render Completion button for purchasers

### DIFF
--- a/apps/epic-react/src/templates/lesson-template.tsx
+++ b/apps/epic-react/src/templates/lesson-template.tsx
@@ -10,7 +10,10 @@ import pluralize from 'pluralize'
 
 import {cn} from '@skillrecordings/ui/utils/cn'
 import MDX from '@skillrecordings/skill-lesson/markdown/mdx'
-import {VideoProvider} from '@skillrecordings/skill-lesson/hooks/use-mux-player'
+import {
+  VideoProvider,
+  useMuxPlayer,
+} from '@skillrecordings/skill-lesson/hooks/use-mux-player'
 import {ArticleJsonLd, CourseJsonLd} from '@skillrecordings/next-seo'
 import {Video} from '@skillrecordings/skill-lesson/video/video'
 import {getBaseUrl} from '@skillrecordings/skill-lesson/utils/get-base-url'
@@ -84,6 +87,33 @@ const NavigationProgressModule: React.FC<{
   ) : null
 }
 
+const ConditionallyDisplayLessonCompletionToggle: React.FC<{
+  lesson: {_type: string}
+}> = ({lesson}) => {
+  const {data: session, status: sessionStatus} = useSession()
+
+  const loggedIn = sessionStatus === 'authenticated' && session
+
+  const {canShowVideo} = useMuxPlayer()
+
+  const displayLessonCompletionToggle =
+    lesson._type === 'solution' ||
+    lesson._type === 'explainer' ||
+    lesson._type === 'exercise' ||
+    lesson._type === 'lesson' ||
+    lesson._type === 'interview'
+
+  if (loggedIn && canShowVideo && displayLessonCompletionToggle) {
+    return (
+      <section aria-label="track progress" className="group">
+        <LessonCompleteToggle />
+      </section>
+    )
+  } else {
+    return null
+  }
+}
+
 const ExerciseTemplate: React.FC<{
   transcript: any[]
   lessonBodySerialized: MDXRemoteSerializeResult
@@ -110,7 +140,6 @@ const ExerciseTemplate: React.FC<{
   const pageTitle = title
   const pageDescription = exerciseDescription || moduleDescription
   const path = `/${pluralize('module')}`
-  const {data: session, status: sessionStatus} = useSession()
 
   const {data: moduleProgress, status: moduleProgressStatus} =
     trpc.moduleProgress.bySlug.useQuery({
@@ -124,14 +153,6 @@ const ExerciseTemplate: React.FC<{
   const exerciseCount = section
     ? section.lessons && section.lessons.length
     : module.lessons && module.lessons.length
-
-  const displayLessonCompletionToggle =
-    (lesson._type === 'solution' ||
-      lesson._type === 'explainer' ||
-      lesson._type === 'exercise' ||
-      lesson._type === 'lesson' ||
-      lesson._type === 'interview') &&
-    session
 
   const epicReactModule = {...module, moduleType: 'module'}
 
@@ -227,11 +248,9 @@ const ExerciseTemplate: React.FC<{
                     ) : (
                       <div />
                     )}
-                    {displayLessonCompletionToggle && (
-                      <section aria-label="track progress" className="group">
-                        <LessonCompleteToggle />
-                      </section>
-                    )}
+                    <ConditionallyDisplayLessonCompletionToggle
+                      lesson={lesson}
+                    />
                   </div>
                   <hr className="border-er-gray-300 opacity-50" />
                   <div className="md:prose-md prose mx-auto mt-8 max-w-none pb-12 sm:pb-16 md:mt-10 lg:mt-12">


### PR DESCRIPTION
**for a user who hasn't purchased yet, no button**

![CleanShot 2024-06-26 at 11 04 55@2x](https://github.com/skillrecordings/products/assets/694063/a95eb6e8-c5e4-4929-b402-50e458ddeefe)

**for a user who has purchased, show button**

![CleanShot 2024-06-26 at 11 05 22@2x](https://github.com/skillrecordings/products/assets/694063/6eb1bf55-ed59-48dd-ab76-810d0999af0e)

![completion](https://media2.giphy.com/media/KavG3AruG3gAXKkswv/giphy.gif?cid=d1fd59abzacf3hwar55w2has7c3lm8y488gspv4kcpvyrbjy&ep=v1_gifs_search&rid=giphy.gif&ct=g)