### PR TITLE
fix(ER): remove navigating on lesson completion

### DIFF
--- a/apps/epic-react/src/components/lesson-completion-toggle.tsx
+++ b/apps/epic-react/src/components/lesson-completion-toggle.tsx
@@ -45,9 +45,9 @@ const LessonCompleteToggle = () => {
       router.push(`/modules/${module.slug.current}/completed`)
     } else if (toggleClicked && optimisticallyToggled) {
       reward()
-      router.push(
-        `/modules/${module.slug.current}/${moduleProgress?.nextLesson?.slug}`,
-      )
+      // router.push(
+      //   `/modules/${module.slug.current}/${moduleProgress?.nextLesson?.slug}`,
+      // )
     }
   }, [toggleClicked, moduleProgress, optimisticallyToggled])
 
@@ -119,9 +119,9 @@ const LessonCompleteToggle = () => {
               }}
               initial={false}
             >
-              Complete and Continue
+              Complete
               {/* prettier-ignore */}
-              <svg className="ml-2" width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none"><path d="M17 8l4 4m0 0l-4 4m4-4H3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></g></svg>
+              {/* <svg className="ml-2" width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="none"><path d="M17 8l4 4m0 0l-4 4m4-4H3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></g></svg> */}
             </motion.div>
           </div>
         </motion.button>


### PR DESCRIPTION
removes navigation on lesson completion as we figure out busted "get next lesson" functionality.

Currently `moduleProgress` is setting the first lesson it finds in a module as the next lesson which is unexpected behavior if you skipped a couple lesson or don't want to watch a welcome video

![gif](https://media2.giphy.com/media/9V8RorZtNTN8jf27k0/giphy.gif?cid=1927fc1btf9q0sxz0d0k5mv58myygiz4hqdo1efcuulp1zt4&ep=v1_gifs_search&rid=giphy.gif&ct=g)