### PR TITLE
Fixed Stackblitz in pro essentials workshop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: PNPM Setup
-        uses: pnpm/action-setup@v2.2.4
-        with:
-          version: 8.7.0
-          run_install: false
+        uses: pnpm/action-setup@v4
 
       - name: Node Setup
         uses: actions/setup-node@v3

--- a/apps/total-typescript/src/exercise/stackblitz-iframe.test.ts
+++ b/apps/total-typescript/src/exercise/stackblitz-iframe.test.ts
@@ -1,4 +1,8 @@
-import {getStartCommand} from './stackblitz-iframe'
+import {
+  SECTION_NOT_DETECTED,
+  getSectionNumFromPath,
+  getStartCommand,
+} from './stackblitz-iframe'
 
 describe('getStartCommand', () => {
   it.each([
@@ -40,4 +44,19 @@ describe('getStartCommand', () => {
       expect(getStartCommand({_type}, stackblitz)).toEqual(result)
     },
   )
+})
+
+describe('getSectionNumFromPath', () => {
+  it.each([
+    ['src/02-unions-and-indexing/05-terminology.problem.ts', '02'],
+    ['src/05-terminology.problem.ts', SECTION_NOT_DETECTED],
+    ['src/something.ts', SECTION_NOT_DETECTED],
+    ['src/05-terminology', SECTION_NOT_DETECTED],
+    ['src/02-wonderful/05-terminology', '02'],
+    ['src/010-something-else/02-wonderful/05-terminology', '02'],
+    ['src/010-something-else/040-wonderful/05-terminology', '040'],
+    ['src/040-wonderful-520/05-terminology', '040'],
+  ])(`Should calculate the right section number`, (type, result) => {
+    expect(getSectionNumFromPath(type)).toEqual(result)
+  })
 })

--- a/apps/total-typescript/src/exercise/stackblitz-iframe.tsx
+++ b/apps/total-typescript/src/exercise/stackblitz-iframe.tsx
@@ -115,12 +115,8 @@ export const getStackblitzUrl = ({
   stackblitz,
   isEmbed = Number(true),
 }: {
-  module: {
-    github?: {
-      repo?: string | null
-    }
-  }
-  exercise: {_type: string}
+  module: Module
+  exercise: Lesson
   stackblitz: string | null | undefined
   isEmbed?: number
 }) => {


### PR DESCRIPTION
[Decision Doc](https://gist.github.com/mattpocock/106e31b6c462344219d484bfc29fc38e)

Ended up going with solution 3. Working nicely.

To test, visit the [branch's version](https://total-typescript-turbo-a250xm5ym-skillrecordings.vercel.app/workshops/typescript-pro-essentials/mutability/fixing-a-type-assignment-inference-error/exercise) of Pro Essentials, then [our live one](https://www.totaltypescript.com/workshops/typescript-pro-essentials/mutability/fixing-a-type-assignment-inference-error/exercise) to see the difference.