### PR TITLE
fix(tt): protect agains typos in sanity

### DIFF
--- a/apps/total-typescript/src/components/book/book-exercise-embed.tsx
+++ b/apps/total-typescript/src/components/book/book-exercise-embed.tsx
@@ -275,7 +275,7 @@ export const ExerciseEmbed = ({
     )
   }
 
-  return resourceId ? (
+  return resourceId && exercise ? (
     <WithVideo />
   ) : (
     <div className="not-prose relative mt-10 flex flex-col items-center gap-5 rounded-lg bg-[#1B222F] px-5 pb-8 pt-2 sm:px-6">


### PR DESCRIPTION
On the off chance there is a typo or other failure to load exercise data for a chapter exercise we don't want to show broken UI that leads to a 404.

![image](https://github.com/skillrecordings/products/assets/6188161/bc9e66d9-a439-4f28-91b1-2ab918e9c1ef)


![gif](https://media2.giphy.com/media/qjtqEScZudXnnbnbz4/giphy.gif?cid=1927fc1bis6zp93aegnte0tn3mqrhg7lnw2eo52eqioj2rkx&ep=v1_gifs_search&rid=giphy.gif&ct=g)