### PR TITLE
Made children of 'exercises' not show up in book ToC

### DIFF
--- a/apps/total-typescript/src/components/book/primary-chapter-toc.tsx
+++ b/apps/total-typescript/src/components/book/primary-chapter-toc.tsx
@@ -174,44 +174,45 @@ export const PrimaryChapterToC = ({
                       {item.text.replace(/`/g, '')}
                     </span>
                   </Link>
-                  {item.items.length > 0 && (
-                    <ol>
-                      {item.items
-                        .filter(({level}) => level < 4)
-                        .map((subItem) => (
-                          <li
-                            key={subItem.slug}
-                            data-active={visibleHeadingId === subItem.slug}
-                          >
-                            <Link
-                              className="relative inline-flex min-h-3 items-center gap-2 py-1"
-                              href={`#${subItem.slug}`}
+                  {item.text.trim() !== 'Exercises' &&
+                    item.items.length > 0 && (
+                      <ol>
+                        {item.items
+                          .filter(({level}) => level < 4)
+                          .map((subItem) => (
+                            <li
+                              key={subItem.slug}
+                              data-active={visibleHeadingId === subItem.slug}
                             >
-                              <div
-                                className={cn(
-                                  'absolute left-1 top-0 h-full w-[2px] bg-white/10',
-                                  {
-                                    'bg-primary':
-                                      visibleHeadingId === subItem.slug,
-                                  },
-                                )}
-                              />
-                              <span
-                                className={cn(
-                                  'relative pl-5 transition hover:text-primary',
-                                  {
-                                    'text-[#ADF2F2] group-hover:opacity-100':
-                                      visibleHeadingId === subItem.slug,
-                                  },
-                                )}
+                              <Link
+                                className="relative inline-flex min-h-3 items-center gap-2 py-1"
+                                href={`#${subItem.slug}`}
                               >
-                                {subItem.text.replace(/`/g, '')}
-                              </span>
-                            </Link>
-                          </li>
-                        ))}
-                    </ol>
-                  )}
+                                <div
+                                  className={cn(
+                                    'absolute left-1 top-0 h-full w-[2px] bg-white/10',
+                                    {
+                                      'bg-primary':
+                                        visibleHeadingId === subItem.slug,
+                                    },
+                                  )}
+                                />
+                                <span
+                                  className={cn(
+                                    'relative pl-5 transition hover:text-primary',
+                                    {
+                                      'text-[#ADF2F2] group-hover:opacity-100':
+                                        visibleHeadingId === subItem.slug,
+                                    },
+                                  )}
+                                >
+                                  {subItem.text.replace(/`/g, '')}
+                                </span>
+                              </Link>
+                            </li>
+                          ))}
+                      </ol>
+                    )}
                 </li>
               ))}
             </ol>

--- a/apps/total-typescript/src/components/book/secondary-chapter-toc.tsx
+++ b/apps/total-typescript/src/components/book/secondary-chapter-toc.tsx
@@ -50,7 +50,7 @@ export const SecondaryChapterToC: React.FC<{
                   {item.text.replace(/`/g, '')}
                 </span>
               </Link>
-              {item.items.length > 0 && (
+              {item.text.trim() !== 'Exercises' && item.items.length > 0 && (
                 <ol>
                   {item.items
                     .filter(({level}) => level < 4)


### PR DESCRIPTION
Before:

![image](https://github.com/skillrecordings/products/assets/28293365/f2d8d3fc-0e56-4d77-a3e4-b4f7bfc0501d)

After:

![image](https://github.com/skillrecordings/products/assets/28293365/5b4eac93-6859-4340-acdf-969e07881a10)


URL:

/books/total-typescript-essentials/deriving-types