### PR TITLE
fix(ER-next): ISG for /articles + sort by date

### DIFF
--- a/apps/epic-react/src/lib/articles.ts
+++ b/apps/epic-react/src/lib/articles.ts
@@ -9,7 +9,7 @@ export const ArticleSchema = z.object({
   _createdAt: z.string(),
   title: z.string(),
   slug: z.string(),
-  date: z.string().optional().nullable(),
+  date: z.string().datetime().nullable().optional(),
   description: z.nullable(z.string()).optional(),
   summary: z.nullable(z.string()).optional(),
   body: z.string(),

--- a/apps/epic-react/src/pages/articles.tsx
+++ b/apps/epic-react/src/pages/articles.tsx
@@ -109,16 +109,19 @@ export const ArticleTeaser = ({
 }
 
 export const getStaticProps: GetStaticProps = async () => {
-  const articles = await getAllArticles()
-  // const articles: Article[] = Object.values(articlesObj).sort(
-  //   (a: Article, b: Article) =>
-  //     new Date(b.date).getTime() - new Date(a.date).getTime(),
-  // )
+  const allArticles = await getAllArticles()
+
+  const articles = [...allArticles].sort((a: Article, b: Article) => {
+    const dateA = a.date ? new Date(a.date).getTime() : 0
+    const dateB = b.date ? new Date(b.date).getTime() : 0
+    return dateB - dateA
+  })
 
   return {
     props: {
       articles,
     },
+    revalidate: 10,
   }
 }
 


### PR DESCRIPTION
This adds `revalidate` to the `getStaticProps` functions on the `/articles` page so that new published articles appear without redeploy.
Also sorting articles by date applied.

![CleanShot 2024-07-12 at 00 21 25@2x](https://github.com/user-attachments/assets/1eee3fa8-2897-486a-b4d9-1aacaa7f6fd1)

![Trash Panda GIF by VonWong](https://github.com/user-attachments/assets/9491e373-6e77-495f-b8d5-c7fb0efb9ff4)

