### PR TITLE
feat(er): use `code` or `coupon` query param

### DIFF
--- a/packages/commerce-server/src/props-for-commerce.ts
+++ b/packages/commerce-server/src/props-for-commerce.ts
@@ -14,10 +14,10 @@ export async function propsForCommerce({
   products: SanityProduct[]
 }) {
   const productIds = products.map((product) => product.productId)
-  const couponFromCode = await getCouponForCode(
-    query.code as string,
-    productIds,
-  )
+
+  const codeFromQueryParams = (query.code as string) || (query.coupon as string)
+  const couponFromCode = await getCouponForCode(codeFromQueryParams, productIds)
+
   const allowPurchase =
     Boolean(process.env.NEXT_PUBLIC_SELLING_LIVE === 'true') ||
     Boolean(query.allowPurchase)


### PR DESCRIPTION
The legacy Epic React site accepted 'golden ticket' coupon code via the
`coupon` query param. We now use the `code` query param. Since we've
distributed a bunch of coupon URLs with the `coupon` query param, this
updates the commerce props logic to work with both.

![both](https://media1.giphy.com/media/IuaM5sUvLCYTyNKV4J/giphy.gif?cid=d1fd59ablkvzkks2ql5k4c1b92wse8ir61lz6jvsu7fi79v6&ep=v1_gifs_search&rid=giphy.gif&ct=g)