### PR TITLE
fix(er-next): sort the modules array to get proper next module link on /completed page

### DIFF
--- a/apps/epic-react/src/pages/modules/[module]/completed.tsx
+++ b/apps/epic-react/src/pages/modules/[module]/completed.tsx
@@ -14,20 +14,43 @@ import {getModuleProgress} from '@skillrecordings/skill-lesson/lib/module-progre
 import ModuleCertificate from '@/certificate/module-certificate'
 import {MODULES_WITH_NO_CERTIFICATE} from '@/pages/learn'
 
+const modulesOrderedBySlug = {
+  'welcome-to-epic-react': 0,
+  'react-fundamentals': 1,
+  'react-hooks': 2,
+  'advanced-react-hooks': 3,
+  'advanced-react-patterns': 4,
+  'react-performance': 5,
+  'testing-react-apps': 6,
+  'react-suspense': 7,
+  'build-an-epic-react-app': 8,
+}
+
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const {params, req} = context
   const token = await getToken({req})
 
   const moduleSlug = params?.module as string
   const allModules = await getAllWorkshops()
+  const allModulesOrderedBySlug = [...allModules].sort((a, b) => {
+    return (
+      (modulesOrderedBySlug[
+        a.slug.current as keyof typeof modulesOrderedBySlug
+      ] as number) -
+      (modulesOrderedBySlug[
+        b.slug.current as keyof typeof modulesOrderedBySlug
+      ] as number)
+    )
+  })
+
   const module = find(
-    allModules,
+    allModulesOrderedBySlug,
     (module) => module.slug.current === moduleSlug,
   )
-  const moduleIndex = findIndex(allModules, (module, i) => {
+  const moduleIndex = findIndex(allModulesOrderedBySlug, (module, i) => {
     return module.slug.current === moduleSlug
   })
-  const nextModule = allModules[moduleIndex + 1]
+  const nextModule = allModulesOrderedBySlug?.[moduleIndex + 1]
 
   const moduleWithSectionsAndLessons = {
     ...module,


### PR DESCRIPTION
[linear](https://linear.app/skillrecordings/issue/ER-121/incorrect-link-to-the-next-module-on-the-module-completed-page)

<details>
  <summary>Before:</summary>
  <img width="1200" src="https://github.com/user-attachments/assets/946bd299-aa64-41c6-a853-9cd4dff4faf1">
</details>
<details>
  <summary>After:</summary>
  <img width="1200" src="https://github.com/user-attachments/assets/5f7c6e20-6a53-4ee8-b712-e2c4705740ba">
</details>




![Thanks Eating GIF](https://github.com/user-attachments/assets/4e99d5a1-165e-495d-b051-de0107cc2b2d)
