### PR TITLE
fix(er): properly 404 on wrong lesson urls

### DIFF
--- a/apps/epic-react/src/lib/workshops.ts
+++ b/apps/epic-react/src/lib/workshops.ts
@@ -280,7 +280,7 @@ export const getWorkshop = async (slug: string) => {
     {slug: `${slug}`},
   )
 
-  return WorkshopSchema.passthrough().parse(result)
+  return WorkshopSchema.passthrough().nullable().parse(result)
 }
 
 export type Workshop = z.infer<typeof WorkshopSchema>

--- a/apps/epic-react/src/pages/modules/[module]/[lesson]/index.tsx
+++ b/apps/epic-react/src/pages/modules/[module]/[lesson]/index.tsx
@@ -61,6 +61,12 @@ export const getStaticProps: GetStaticProps = async (context) => {
     ? await getBonus(moduleSlug)
     : await getWorkshop(moduleSlug)
 
+  if (!module) {
+    return {
+      notFound: true,
+    }
+  }
+
   const moduleWithSectionsAndLessons = {
     ...module,
     useResourcesInsteadOfSections: true,

--- a/apps/epic-react/src/pages/modules/[module]/[lesson]/solution/index.tsx
+++ b/apps/epic-react/src/pages/modules/[module]/[lesson]/solution/index.tsx
@@ -29,6 +29,12 @@ export const getStaticProps: GetStaticProps = async (context) => {
       },
     }))
 
+  if (!module) {
+    return {
+      notFound: true,
+    }
+  }
+
   return {
     props: {
       lesson,


### PR DESCRIPTION
If someone mistakenly navigates to a `/modules/:module-slug/:lesson-slug` url where the `lesson-slug` is correct but the module the `module-slug` is non-existent (e.g. url should have been `/tutorials/` and not `/modules/`), the lesson page will through a `500` instead of a `404` because we try to fetch the module with `getWorkshop` and zod errors out. This returns a `404` instead 


![gif](https://media0.giphy.com/media/TfpmFFapwKwgGU8CQV/giphy.gif?cid=1927fc1byig0nilh4x5o7z415loq22fwkh7i32upxwc7v5k6&ep=v1_gifs_search&rid=giphy.gif&ct=g)