### PR TITLE
fix(er) fix broken complete and continue button for tutorials

### DIFF
--- a/apps/epic-react/src/components/lesson-completion-toggle.tsx
+++ b/apps/epic-react/src/components/lesson-completion-toggle.tsx
@@ -10,7 +10,7 @@ import cx from 'classnames'
 import Spinner from '@/components/spinner'
 
 const LessonCompleteToggle = ({className}: {className?: string}) => {
-  const {module, lesson} = useLesson()
+  const {module, section, lesson} = useLesson()
   const flattenedLessons = module.sections?.flatMap(
     (section) => section.lessons,
   )
@@ -84,15 +84,19 @@ const LessonCompleteToggle = ({className}: {className?: string}) => {
             flattenedLessons &&
             flattenedLessons[currentLessonIndex + 1]
           ) {
-            reward()
-            router.push(
-              `/modules/${module.slug.current}/${
-                flattenedLessons[currentLessonIndex + 1]?.slug
-              }`,
-            )
-          } else if (!progress?.completedAt) {
-          } else {
-            reward()
+            if (moduleProgress?.moduleType === 'tutorial') {
+              router.push(
+                `/${moduleProgress?.moduleType}s/${module.slug.current}/${
+                  section?.slug
+                }/${flattenedLessons[currentLessonIndex + 1]?.slug}`,
+              )
+            } else {
+              router.push(
+                `/modules/${module.slug.current}/${
+                  flattenedLessons[currentLessonIndex + 1]?.slug
+                }`,
+              )
+            }
           }
         },
         onError: (error: any) => {

--- a/apps/epic-react/src/components/video-overlays/finished-section-overlay.tsx
+++ b/apps/epic-react/src/components/video-overlays/finished-section-overlay.tsx
@@ -90,9 +90,14 @@ export const FinishedSectionOverlay = () => {
             {lesson._type === 'solution' && (
               <Link
                 data-action="try-again"
+                className="mx-auto flex h-10 w-fit items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
                 href={router.asPath.replace('solution', 'exercise')}
               >
-                <CodeIcon data-icon="" aria-hidden="true" />
+                <CodeIcon
+                  data-icon=""
+                  aria-hidden="true"
+                  className="w-5 font-normal"
+                />
                 Back to Exercise
               </Link>
             )}

--- a/apps/epic-react/src/components/video-overlays/lesson-complete-overlay.tsx
+++ b/apps/epic-react/src/components/video-overlays/lesson-complete-overlay.tsx
@@ -64,7 +64,7 @@ export const DefaultOverlay: React.FC = () => {
         )}
         <div>
           <LessonCompleteToggle className="text-md my-4 bg-white text-white hover:bg-er-gray-300 disabled:pointer-events-none disabled:opacity-50 dark:bg-er-gray-200 dark:hover:bg-er-gray-300" />
-          <div>
+          <div className="space-y-2">
             <Button
               data-action="replay"
               variant="ghost"
@@ -88,9 +88,14 @@ export const DefaultOverlay: React.FC = () => {
             {lesson._type === 'solution' && (
               <Link
                 data-action="try-again"
+                className="mx-auto flex h-10 w-fit items-center justify-center gap-2 whitespace-nowrap rounded-md px-4 py-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
                 href={router.asPath.replace('solution', 'exercise')}
               >
-                <CodeIcon data-icon="" aria-hidden="true" />
+                <CodeIcon
+                  data-icon=""
+                  aria-hidden="true"
+                  className="w-5 font-normal"
+                />
                 Back to Exercise
               </Link>
             )}

--- a/packages/skill-lesson/lib/module-progress.ts
+++ b/packages/skill-lesson/lib/module-progress.ts
@@ -120,6 +120,7 @@ export async function getModuleProgress({
 
   return ModuleProgressSchema.parse({
     moduleId: module._id,
+    moduleType: module.moduleType,
     nextLesson:
       moduleProgressLessons.find((lesson) => !lesson.lessonCompleted) || null,
     nextSection:

--- a/packages/skill-lesson/lib/modules.ts
+++ b/packages/skill-lesson/lib/modules.ts
@@ -6,6 +6,7 @@ const CoreResourceSchema = z.object({
   _id: z.string(),
   slug: z.string(),
   title: z.string(),
+  moduleType: z.string().optional(),
 })
 const LessonSchema = CoreResourceSchema
 const SectionSchema = CoreResourceSchema.merge(
@@ -46,6 +47,7 @@ const lessonStructureSubQuery = `resources[@->._type in [${toQuotedList(
 const moduleStructureQuery = groq`*[_type == "module" && (slug.current == $slug || _id == $id)][0]{
   _id,
   title,
+  moduleType,
   "slug": slug.current,
   "sections": resources[@->._type == 'section']->{
     _id,

--- a/packages/skill-lesson/video/module-progress.tsx
+++ b/packages/skill-lesson/video/module-progress.tsx
@@ -28,6 +28,7 @@ export const ModuleProgressProvider: React.FC<React.PropsWithChildren<any>> = ({
 
 export const ModuleProgressSchema = z.object({
   moduleId: z.string(),
+  moduleType: z.string().optional(),
   moduleCompleted: z.boolean(),
   percentComplete: z.number(),
   lessonCount: z.number(),


### PR DESCRIPTION
We had hard-coded values in the `Complete and Continue` button that navigated to the next lesson when you are in a `module` lesson.

This needs to be dynamic now that we have tutorials on epic react (and in the future when we implement /workshops though I'd advocate to ditch this button in favor of how skill-stack currently handles things)

When we remove sections from url we will need to update this functionality again as `section.slug` is hardcoded in the url that is navigated to. 

https://www.loom.com/share/ec43f53ce0584854bb4e92d36483a6e9

Also fixed icon styling on the complete and continue overlay

## before
![before icon style](https://github.com/user-attachments/assets/ec4a8067-d04e-4ca3-848e-3f102b6e2738)

## after
![after icon style](https://github.com/user-attachments/assets/a7ebea72-bedb-4b71-9d67-734d0ce3ea16)


![gif](https://media1.giphy.com/media/Tes2L7WzZyEOi8et1k/giphy.gif?cid=1927fc1bn7ue5moxljcm8my6ggzuiq288vrn5jdo2y5qwqxa&ep=v1_gifs_search&rid=giphy.gif&ct=g)