### PR TITLE
fix(er): apply styles for complete and continue button in light mode

### DIFF
--- a/apps/epic-react/src/components/lesson-completion-toggle.tsx
+++ b/apps/epic-react/src/components/lesson-completion-toggle.tsx
@@ -135,7 +135,7 @@ const LessonCompleteToggle = ({className}: {className?: string}) => {
           onClick={handleToggleLessonProgress}
           disabled={isProgressSaving}
         >
-          <div className="mt-0 flex w-full cursor-pointer items-center justify-center font-semibold text-white">
+          <div className="mt-0 flex w-full cursor-pointer items-center justify-center font-semibold">
             {isLessonCompleted && isProgressSaving ? (
               <Spinner className="absolute h-5 w-5 text-white" />
             ) : (

--- a/apps/epic-react/src/components/video-overlays/lesson-complete-overlay.tsx
+++ b/apps/epic-react/src/components/video-overlays/lesson-complete-overlay.tsx
@@ -63,7 +63,7 @@ export const DefaultOverlay: React.FC = () => {
           </div>
         )}
         <div>
-          <LessonCompleteToggle className="text-md my-4 bg-white text-white hover:bg-er-gray-300 disabled:pointer-events-none disabled:opacity-50 dark:bg-er-gray-200 dark:hover:bg-er-gray-300" />
+          <LessonCompleteToggle className="text-md my-4 bg-er-gray-200 text-er-gray-800 hover:bg-er-gray-300 disabled:pointer-events-none disabled:opacity-50" />
           <div className="space-y-2">
             <Button
               data-action="replay"


### PR DESCRIPTION

![light mode](https://github.com/user-attachments/assets/1ec633a4-aac6-4bee-8829-e6e0c5ce5e67)
![dark mode](https://github.com/user-attachments/assets/f6315020-2d6d-4382-ad33-8ec51dec8d6d)

![gif](https://media3.giphy.com/media/nmv4MHdsUvz76BYnOw/giphy.gif?cid=1927fc1be4g11ju1r8kwg7m8c3w1vy98n3k5r3apa2usa2y9&ep=v1_gifs_search&rid=giphy.gif&ct=g)