### PR TITLE
feat: make skill lesson hooks configurable for ignoring [section] in url

### DIFF
--- a/apps/epic-react/src/components/exercise-overlay.tsx
+++ b/apps/epic-react/src/components/exercise-overlay.tsx
@@ -261,6 +261,7 @@ const Actions = () => {
               handlePlay,
               path,
               section,
+              ignoreSections: true,
             })
           }}
         >

--- a/apps/epic-react/src/pages/workshops/[module]/[lesson]/index.tsx
+++ b/apps/epic-react/src/pages/workshops/[module]/[lesson]/index.tsx
@@ -22,7 +22,11 @@ export const getStaticProps: GetStaticProps = async (context) => {
   const sectionSlug = params?.section as string
 
   const module = await getWorkshop(params?.module as string)
-  const section = await getSection(sectionSlug)
+  // if sectionSlug does not exist in url but is still present in data structure, we need to get current lesson by filtering through all sections
+  const currentLessonSection = module.sections.find((section) => {
+    return section.lessons.find((lesson) => lesson.slug === lessonSlug)
+  })
+  const section = await getSection(sectionSlug || currentLessonSection?.slug)
   const lesson = await getExercise(lessonSlug, false)
 
   if (!lesson) {

--- a/apps/epic-react/src/pages/workshops/[module]/[lesson]/solution/index.tsx
+++ b/apps/epic-react/src/pages/workshops/[module]/[lesson]/solution/index.tsx
@@ -23,8 +23,13 @@ export const getStaticProps: GetStaticProps = async (context) => {
   const sectionSlug = params?.section as string
 
   const module = await getWorkshop(params?.module as string)
+  // if sectionSlug does not exist in url but is still present in data structure, we need to get current lesson by filtering through all sections
+  const currentLessonSection = module.sections.find((section) => {
+    return section.lessons.find((lesson) => lesson.slug === exerciseSlug)
+  })
+  console.log({currentLessonSection})
+  const section = await getSection(sectionSlug || currentLessonSection?.slug)
   const exercise = await getExercise(exerciseSlug)
-  const section = await getSection(sectionSlug)
 
   if (!exercise) {
     const msg = `Unable to find Exercise for slug (${exerciseSlug}). Context: module (${params?.module}))`

--- a/apps/epic-react/src/pages/workshops/[module]/[lesson]/solution/index.tsx
+++ b/apps/epic-react/src/pages/workshops/[module]/[lesson]/solution/index.tsx
@@ -27,7 +27,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
   const currentLessonSection = module.sections.find((section) => {
     return section.lessons.find((lesson) => lesson.slug === exerciseSlug)
   })
-  console.log({currentLessonSection})
+
   const section = await getSection(sectionSlug || currentLessonSection?.slug)
   const exercise = await getExercise(exerciseSlug)
 

--- a/apps/epic-react/src/styles/video/video-overlays.css
+++ b/apps/epic-react/src/styles/video/video-overlays.css
@@ -66,7 +66,7 @@
       }
     }
     [data-action='continue'] {
-      @apply flex h-auto w-full items-center justify-center gap-1 rounded bg-blue-600 px-3 py-3 text-lg font-semibold transition hover:bg-blue-500 sm:px-5 sm:py-3;
+      @apply flex h-auto w-full items-center justify-center gap-1 rounded bg-blue-600 px-3 py-3 text-lg font-semibold text-white transition hover:bg-blue-500 sm:px-5 sm:py-3;
       [data-icon] {
       }
     }

--- a/apps/epic-react/src/templates/exercise-template.tsx
+++ b/apps/epic-react/src/templates/exercise-template.tsx
@@ -102,6 +102,20 @@ const ExerciseTemplate: React.FC<{
     (module.moduleType === 'legacy-module' ||
       module.moduleType === 'tutorial' ||
       module.moduleType === 'workshop')
+
+  const nextLessonPath = ({
+    lesson,
+    module,
+  }: {
+    lesson: {slug: string} | null
+    module: {slug: {current: string}}
+  }) => {
+    return {
+      query: {lesson: lesson?.slug, module: module.slug.current},
+      pathname: `/${pluralize(module.moduleType)}/[module]/[lesson]`,
+    }
+  }
+
   return (
     <VideoProvider
       muxPlayerRef={muxPlayerRef}
@@ -110,6 +124,7 @@ const ExerciseTemplate: React.FC<{
       onModuleEnded={async () => {
         addProgressMutation.mutate({lessonSlug: router.query.lesson as string})
       }}
+      nextPathBuilder={nextLessonPath}
       // @ts-expect-error
       inviteTeamPagePath={`/products/${module.product?.slug}`}
     >
@@ -338,6 +353,7 @@ const LessonList: React.FC<{
           ref={scrollContainerRef}
         >
           <Collection.Root
+            ignoreSections={true}
             module={
               module._type === 'workshop'
                 ? moduleWithSectionsAndLessons

--- a/packages/skill-lesson/hooks/use-mux-player.tsx
+++ b/packages/skill-lesson/hooks/use-mux-player.tsx
@@ -60,6 +60,7 @@ type VideoContextType = {
     handlePlay: () => void
     path: string
     nextPathBuilder?: NextPathBuilder
+    ignoreSections?: boolean
   }) => Promise<any>
   handlePlayFromBeginning: (options: {
     router: NextRouter
@@ -92,6 +93,7 @@ type VideoProviderProps = {
     handlePlay: () => void
     path: string
     nextPathBuilder?: NextPathBuilder
+    ignoreSections?: boolean
   }) => Promise<any>
   handlePlayFromBeginning?: (options: {
     router: NextRouter

--- a/packages/skill-lesson/trpc/routers/lessons.ts
+++ b/packages/skill-lesson/trpc/routers/lessons.ts
@@ -34,7 +34,9 @@ export const lessonsRouter = router({
         return SolutionResourceSchema.parse(lesson.solution)
       }
 
-      const lessons = section ? section?.lessons : module?.lessons
+      const lessons = section
+        ? section?.lessons
+        : module?.lessons || module?.resources
 
       if (!lessons) return null
 

--- a/packages/skill-lesson/video/default-handle-continue.ts
+++ b/packages/skill-lesson/video/default-handle-continue.ts
@@ -22,6 +22,7 @@ export const defaultHandleContinue = async ({
   handlePlay,
   path,
   nextPathBuilder,
+  ignoreSections = false,
 }: {
   router: NextRouter
   module: Module
@@ -30,6 +31,7 @@ export const defaultHandleContinue = async ({
   handlePlay: () => void
   path: string
   nextPathBuilder?: NextPathBuilder
+  ignoreSections?: boolean
 }) => {
   if (nextPathBuilder) {
     const routerOptions = nextPathBuilder({
@@ -42,6 +44,28 @@ export const defaultHandleContinue = async ({
   }
 
   if (nextExercise?._type === 'solution') {
+    if (ignoreSections && section) {
+      const exercise =
+        section.lessons &&
+        section.lessons.find((exercise: Exercise) => {
+          const solution = exercise.solution
+          return solution?._key === nextExercise._key
+        })
+
+      return (
+        exercise &&
+        (await router
+          .push({
+            query: {
+              module: module.slug.current,
+              lesson: exercise.slug,
+            },
+
+            pathname: `${path}/[module]/[lesson]/solution`,
+          })
+          .then(() => handlePlay()))
+      )
+    }
     if (section) {
       const exercise =
         section.lessons &&


### PR DESCRIPTION
this fixes navigating to next lesson from overlays and collection component. I added new `ignoreSections` prop for `Collection` component making it work with url structure without `[section]`. same prop is used for `handleContinue` util.

<img src="https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmw2dnJwNnJ3d2pzM2tiMDN0a2RrYThqMXEwemh5bWV2MW5uMmJuMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2Je85w1owl6TJC7K/giphy.gif" width="200" alt="gif">