### PR TITLE
fix(er): fix nextLesson and addModuleWithResources for stand alone  lessons 

### DIFF
--- a/apps/epic-react/src/components/exercise-overlay.tsx
+++ b/apps/epic-react/src/components/exercise-overlay.tsx
@@ -22,7 +22,10 @@ const ExerciseOverlay = () => {
   const workshopAppDetailsPath = lessonResources?.workshopApp?.path
 
   const {data: moduleResources, status: moduleResourcesStatus} =
-    trpc.moduleResources.byModuleSlug.useQuery({slug: module.slug.current})
+    trpc.moduleResources.byModuleSlug.useQuery({
+      slug: module.slug.current,
+      moduleType: module.moduleType as 'tutorial' | 'workshop',
+    })
   const workshopApp = moduleResources && moduleResources.workshopApp
 
   return (

--- a/apps/epic-react/src/pages/workshops/[module]/[lesson]/index.tsx
+++ b/apps/epic-react/src/pages/workshops/[module]/[lesson]/index.tsx
@@ -16,46 +16,6 @@ import {
 import {remarkCodeBlocksShiki} from '@kentcdodds/md-temp'
 import {getSection} from '@/lib/sections'
 
-type ModuleWithResources = {
-  slug: {current: string}
-  resources: {
-    _type: 'lesson' | 'exercise' | 'explainer' | 'interview' | 'section'
-    slug: string
-    lessons?: {_type: string; slug: string}[]
-  }[]
-}
-
-const getSectionForLesson = (
-  module: ModuleWithResources,
-  lessonSlug: string,
-) => {
-  const lessonIsTopLevel = Boolean(
-    module.resources.find((resource) => {
-      return resource._type !== 'section' && resource.slug === lessonSlug
-    }),
-  )
-
-  if (lessonIsTopLevel) {
-    return null
-  } else {
-    const section = module.resources.find((resource) => {
-      if (
-        resource._type === 'section' &&
-        'lessons' in resource &&
-        resource.lessons
-      ) {
-        return resource.lessons.some((lesson) => {
-          return lesson.slug === lessonSlug
-        })
-      }
-
-      return false
-    })
-
-    return section || null
-  }
-}
-
 export const getStaticProps: GetStaticProps = async (context) => {
   const {params} = context
   const lessonSlug = params?.lesson as string
@@ -63,8 +23,11 @@ export const getStaticProps: GetStaticProps = async (context) => {
 
   const module = await getWorkshop(params?.module as string)
 
-  const _section = getSectionForLesson(module, lessonSlug)
-  const section = _section ? await getSection(_section?.slug) : null
+  // if sectionSlug does not exist in url but is still present in data structure, we need to get current lesson by filtering through all sections
+  const currentLessonSection = module.sections.find((section: any) => {
+    return section.lessons.find((lesson: any) => lesson.slug === lessonSlug)
+  })
+  const section = await getSection(sectionSlug || currentLessonSection?.slug)
   const lesson = await getExercise(lessonSlug, false)
   const moduleWithSectionsAndLessons = {
     ...module,

--- a/apps/epic-react/src/pages/workshops/[module]/[lesson]/solution/index.tsx
+++ b/apps/epic-react/src/pages/workshops/[module]/[lesson]/solution/index.tsx
@@ -17,20 +17,59 @@ import {
 } from '@/lib/workshops'
 import {getSection} from '@/lib/sections'
 
+type ModuleWithResources = {
+  slug: {current: string}
+  resources: {
+    _type: 'lesson' | 'exercise' | 'explainer' | 'interview' | 'section'
+    slug: string
+    lessons?: {_type: string; slug: string}[]
+  }[]
+}
+
+const getSectionForLesson = (
+  module: ModuleWithResources,
+  lessonSlug: string,
+) => {
+  const lessonIsTopLevel = Boolean(
+    module.resources.find((resource) => {
+      return resource._type !== 'section' && resource.slug === lessonSlug
+    }),
+  )
+
+  if (lessonIsTopLevel) {
+    return null
+  } else {
+    const section = module.resources.find((resource) => {
+      if (
+        resource._type === 'section' &&
+        'lessons' in resource &&
+        resource.lessons
+      ) {
+        return resource.lessons.some((lesson) => {
+          return lesson.slug === lessonSlug
+        })
+      }
+
+      return false
+    })
+
+    return section || null
+  }
+}
+
 export const getStaticProps: GetStaticProps = async (context) => {
   const {params} = context
   const exerciseSlug = params?.lesson as string
   const sectionSlug = params?.section as string
 
   const module = await getWorkshop(params?.module as string)
-  // if sectionSlug does not exist in url but is still present in data structure, we need to get current lesson by filtering through all sections
-  const currentLessonSection = module.sections.find((section: any) => {
-    return section.lessons.find((lesson: any) => lesson.slug === exerciseSlug)
-  })
-
-  const section = await getSection(sectionSlug || currentLessonSection?.slug)
+  const _section = getSectionForLesson(module, exerciseSlug)
+  const section = _section ? await getSection(_section?.slug) : null
   const exercise = await getExercise(exerciseSlug)
-
+  const moduleWithSectionsAndLessons = {
+    ...module,
+    useResourcesInsteadOfSections: true,
+  }
   if (!exercise) {
     const msg = `Unable to find Exercise for slug (${exerciseSlug}). Context: module (${params?.module}))`
     Sentry.captureMessage(msg)
@@ -61,7 +100,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
       solution,
       solutionBodySerialized,
       solutionBodyPreviewSerialized: solutionBodySerialized,
-      module,
+      module: moduleWithSectionsAndLessons,
       section,
       transcript: solution?.transcript,
       videoResourceId: solution?.videoResourceId,

--- a/apps/epic-react/src/pages/workshops/[module]/index.tsx
+++ b/apps/epic-react/src/pages/workshops/[module]/index.tsx
@@ -12,12 +12,16 @@ export const USER_ID_QUERY_PARAM_KEY = 'learner'
 export const getStaticProps: GetStaticProps = async ({params}) => {
   const workshop = await getWorkshop(params?.module as string)
 
+  const moduleWithSectionsAndLessons = {
+    ...workshop,
+    useResourcesInsteadOfSections: true,
+  }
   const workshopBodySerialized = workshop.body
     ? await serializeMDX(workshop.body)
     : null
 
   return {
-    props: {workshop, workshopBodySerialized},
+    props: {workshop: moduleWithSectionsAndLessons, workshopBodySerialized},
     revalidate: 10,
   }
 }

--- a/apps/epic-react/src/pages/workshops/[module]/index.tsx
+++ b/apps/epic-react/src/pages/workshops/[module]/index.tsx
@@ -34,7 +34,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   return {paths, fallback: 'blocking'}
 }
 
-const TutorialPage: React.FC<{
+const WorkshopPage: React.FC<{
   workshop: Workshop
   workshopBodySerialized: MDXRemoteSerializeResult
 }> = ({workshop, workshopBodySerialized}) => {
@@ -48,4 +48,4 @@ const TutorialPage: React.FC<{
   )
 }
 
-export default TutorialPage
+export default WorkshopPage

--- a/apps/epic-react/src/styles/globals.css
+++ b/apps/epic-react/src/styles/globals.css
@@ -80,8 +80,8 @@
     --popover-foreground: 215 20.2% 65.1%;
     --border: 216 34% 17%;
     --input: 216 34% 17%;
-    --card: 224 71% 4%;
-    --card-foreground: 213 31% 91%;
+    --card: 217 47% 14%;
+    --card-foreground: 220 13 % 91 %;
     --primary: 217 91% 60%;
     --primary-foreground: 222.2 47.4% 1.2%;
     --secondary: 222.2 47.4% 11.2%;

--- a/apps/epic-react/src/templates/exercise-template.tsx
+++ b/apps/epic-react/src/templates/exercise-template.tsx
@@ -116,6 +116,14 @@ const ExerciseTemplate: React.FC<{
     }
   }
 
+  const workshopSpecificProps =
+    module.moduleType === 'workshop'
+      ? {
+          nextPathBuilder: nextLessonPath,
+          isModuleWithResources: true,
+        }
+      : {}
+
   return (
     <VideoProvider
       muxPlayerRef={muxPlayerRef}
@@ -124,8 +132,7 @@ const ExerciseTemplate: React.FC<{
       onModuleEnded={async () => {
         addProgressMutation.mutate({lessonSlug: router.query.lesson as string})
       }}
-      nextPathBuilder={nextLessonPath}
-      isModuleWithResources={true}
+      // {...workshopSpecificProps}
       // @ts-expect-error
       inviteTeamPagePath={`/products/${module.product?.slug}`}
     >
@@ -299,11 +306,6 @@ const LessonList: React.FC<{
 
   const [ref, {height}] = useMeasure<HTMLDivElement>()
 
-  const moduleWithSectionsAndLessons = {
-    ...module,
-    useResourcesInsteadOfSections: true,
-  }
-
   return (
     <div className="sticky top-0 border-r">
       <div ref={ref}>
@@ -354,12 +356,8 @@ const LessonList: React.FC<{
           ref={scrollContainerRef}
         >
           <Collection.Root
-            ignoreSections={true}
-            module={
-              module._type === 'workshop'
-                ? moduleWithSectionsAndLessons
-                : module
-            }
+            ignoreSections={module.moduleType === 'workshop' ? true : false}
+            module={module}
             lessonPathBuilder={lessonPathBuilder}
             resourcesRenderer={(type) => {
               return (

--- a/apps/epic-react/src/templates/exercise-template.tsx
+++ b/apps/epic-react/src/templates/exercise-template.tsx
@@ -125,6 +125,7 @@ const ExerciseTemplate: React.FC<{
         addProgressMutation.mutate({lessonSlug: router.query.lesson as string})
       }}
       nextPathBuilder={nextLessonPath}
+      isModuleWithResources={true}
       // @ts-expect-error
       inviteTeamPagePath={`/products/${module.product?.slug}`}
     >

--- a/apps/epic-react/src/templates/exercise-template.tsx
+++ b/apps/epic-react/src/templates/exercise-template.tsx
@@ -132,7 +132,7 @@ const ExerciseTemplate: React.FC<{
       onModuleEnded={async () => {
         addProgressMutation.mutate({lessonSlug: router.query.lesson as string})
       }}
-      // {...workshopSpecificProps}
+      {...workshopSpecificProps}
       // @ts-expect-error
       inviteTeamPagePath={`/products/${module.product?.slug}`}
     >

--- a/apps/epic-react/src/trpc/routers/module-resources.ts
+++ b/apps/epic-react/src/trpc/routers/module-resources.ts
@@ -1,16 +1,26 @@
 import {publicProcedure, router} from '@skillrecordings/skill-lesson'
 import {z} from 'zod'
 import {getTutorial} from '@/lib/tutorials'
+import {getWorkshop} from '@/lib/workshops'
 
 export const moduleResourcesRouter = router({
   byModuleSlug: publicProcedure
     .input(
       z.object({
         slug: z.string(),
+        moduleType: z.enum(['tutorial', 'workshop']),
       }),
     )
     .query(async ({ctx, input}) => {
-      const module = await getTutorial(input.slug)
+      let module
+
+      if (input.moduleType === 'tutorial') {
+        module = await getTutorial(input.slug)
+      } else if (input.moduleType === 'workshop') {
+        module = await getWorkshop(input.slug)
+      } else {
+        throw new Error('Invalid module type')
+      }
 
       const github = module.github
       const workshopApp = module.workshopApp

--- a/packages/skill-lesson/hooks/use-mux-player.tsx
+++ b/packages/skill-lesson/hooks/use-mux-player.tsx
@@ -69,6 +69,7 @@ type VideoContextType = {
     path: string
     handlePlay: () => void
   }) => Promise<any>
+  isModuleWithResources: boolean
 }
 
 export const VideoContext = React.createContext({} as VideoContextType)
@@ -102,6 +103,7 @@ type VideoProviderProps = {
     path: string
     handlePlay: () => void
   }) => Promise<any>
+  isModuleWithResources?: boolean
 }
 
 export const VideoProvider: React.FC<
@@ -121,6 +123,7 @@ export const VideoProvider: React.FC<
   handlePlayFromBeginning = defaultHandlePlayFromBeginning,
   exerciseSlug,
   inviteTeamPagePath,
+  isModuleWithResources = false,
 }) => {
   const router = useRouter()
 
@@ -136,6 +139,7 @@ export const VideoProvider: React.FC<
     lesson,
     module,
     section,
+    isModuleWithResources,
   )
 
   const nextSection = section
@@ -306,6 +310,7 @@ export const VideoProvider: React.FC<
     handleContinue,
     handlePlayFromBeginning,
     inviteTeamPagePath,
+    isModuleWithResources,
   }
   return (
     <VideoContext.Provider value={context}>{children}</VideoContext.Provider>

--- a/packages/skill-lesson/hooks/use-next-lesson.ts
+++ b/packages/skill-lesson/hooks/use-next-lesson.ts
@@ -10,6 +10,7 @@ export const useNextLesson = (
   lesson: Lesson,
   module: Module,
   section?: Section,
+  isModuleWithResources?: boolean,
 ) => {
   const router = useRouter()
 
@@ -25,6 +26,7 @@ export const useNextLesson = (
       slug,
       module: module.slug.current,
       section: section?.slug,
+      isModuleWithResources,
     })
 
   return {nextExercise, nextExerciseStatus}

--- a/packages/skill-lesson/trpc/routers/lessons.ts
+++ b/packages/skill-lesson/trpc/routers/lessons.ts
@@ -3,13 +3,14 @@ import {type SanityDocument} from '@sanity/client'
 import find from 'lodash/find'
 import indexOf from 'lodash/indexOf'
 import {publicProcedure, router} from '../trpc.server'
-import {getModule} from '../../lib/modules'
+import {getModule, getModuleWithResources} from '../../lib/modules'
 import {getSection} from '../../lib/sections'
 import {getLesson} from '../../lib/lesson-resource'
 import {
   SolutionResourceSchema,
   LessonResourceSchema,
 } from '../../schemas/lesson'
+import flatMap from 'lodash/flatMap'
 
 export const lessonsRouter = router({
   getNextLesson: publicProcedure
@@ -19,6 +20,7 @@ export const lessonsRouter = router({
         slug: z.string().optional(),
         section: z.string().optional(),
         module: z.string().nullish(),
+        isModuleWithResources: z.boolean().optional(),
       }),
     )
     .query(async ({input}) => {
@@ -27,16 +29,32 @@ export const lessonsRouter = router({
       const lesson = await getLesson(input.slug)
       const section = input.section && (await getSection(input.section))
       const module = input.module && (await getModule(input.module))
+      const moduleWithResources =
+        input.module && (await getModuleWithResources(input.module))
 
-      // it seems like this conditional and return are going result in the
-      // case statement for `exercise` below never getting triggered.
+      // lessons when we use resources
+      const allLessons = flatMap(moduleWithResources?.resources, (resource) => {
+        if (resource._type === 'lesson') {
+          return resource
+        } else if (
+          resource._type === 'section' &&
+          Array.isArray(resource.lessons)
+        ) {
+          return resource.lessons
+        }
+        return []
+      })
+
       if (input.type === 'exercise') {
         return SolutionResourceSchema.parse(lesson.solution)
       }
 
-      const lessons = section
-        ? section?.lessons
-        : module?.lessons || module?.resources
+      const lessons =
+        input.isModuleWithResources === true
+          ? allLessons
+          : section
+          ? section?.lessons
+          : module?.lessons || module?.resources
 
       if (!lessons) return null
 

--- a/packages/skill-lesson/video/collection/index.tsx
+++ b/packages/skill-lesson/video/collection/index.tsx
@@ -620,7 +620,7 @@ const Lesson = React.forwardRef<LessonElement, LessonProps>(
             'before:content-["continue"] before:mt-2 before:-mb-1 before:text-xs before:font-semibold before:pl-10 before:text-primary before:uppercase before:block':
               showContinue,
             '[&_[data-item]:px-2': section,
-            'bg-card [&>div]:px-2.5': !section,
+            'bg-card [&>div]:px-2.5 border-b py-1.5 font-semibold': !section,
           },
           lessonProps.className,
         )}


### PR DESCRIPTION
![fix](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdXlvcmVnOG5oeG42Y21rZWdjbmdoeWhndXg4MHZhMHRmaTFvZmdwNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Af4oCYIkwN3dzu7LxH/giphy.gif)

With the changes made in this PR https://github.com/skillrecordings/products/pull/1691 we broke the tutorials since the also use `exercise-template` 

- this fixes the tutorials 404 
- includes the stand alone lessons in the `LessonList` component and style them 
- fixes the `nextLesson` query 

