### PR TITLE
fix: allow a countdown to appear for an expiring query coupon

### DIFF
--- a/apps/epic-react/src/components/pricing-section.tsx
+++ b/apps/epic-react/src/components/pricing-section.tsx
@@ -5,6 +5,7 @@ import type {
   SanityProductModule,
 } from '@skillrecordings/commerce-server/dist/@types'
 import {PricingTiers} from '@skillrecordings/skill-lesson/path-to-purchase/product-tiers'
+import SaleCountdown from '@skillrecordings/skill-lesson/path-to-purchase/sale-countdown'
 
 const removeModuleBySlug = (
   products: any[],
@@ -45,7 +46,6 @@ const PricingSection: React.FC<{
   ).filter(({state}) => state !== 'unavailable')
 
   const productsWithOptions = filteredProducts.map((product) => {
-    console.log({product})
     return {
       ...product,
       options: {
@@ -53,6 +53,15 @@ const PricingSection: React.FC<{
           'allowTeamPurchase' in product
             ? Boolean(product.allowTeamPurchase)
             : true,
+        saleCountdownRenderer: (props: any) => {
+          return (
+            <SaleCountdown
+              data-pricing-product-sale-countdown=""
+              size="lg"
+              {...props}
+            />
+          )
+        },
       },
     }
   })

--- a/apps/epic-react/src/pages/buy.tsx
+++ b/apps/epic-react/src/pages/buy.tsx
@@ -32,7 +32,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     groq`*[_type == 'pricing' && active == true][0]`,
   )
 
-  const allowPurchase = pricingActive || query?.allowPurchase === 'true'
+  const allowPurchase =
+    pricingActive ||
+    query?.allowPurchase === 'true' ||
+    query?.coupon ||
+    query?.code
+
   const products = await getAllActiveProducts(!allowPurchase)
 
   const {props: commerceProps} = await propsForCommerce({

--- a/apps/epic-react/src/pages/index.tsx
+++ b/apps/epic-react/src/pages/index.tsx
@@ -35,7 +35,11 @@ export const getServerSideProps: GetServerSideProps = async ({
     groq`*[_type == 'pricing' && active == true][0]`,
   )
 
-  const allowPurchase = pricingActive || query?.allowPurchase === 'true'
+  const allowPurchase =
+    pricingActive ||
+    query?.allowPurchase === 'true' ||
+    query?.coupon ||
+    query?.code
   const products = await getAllActiveProducts(!allowPurchase)
 
   const {props: commerceProps} = await propsForCommerce({

--- a/apps/epic-react/src/trpc/routers/cta.ts
+++ b/apps/epic-react/src/trpc/routers/cta.ts
@@ -315,7 +315,7 @@ export const ctaRouter = router({
             console.error('Error parsing active promotion')
             console.error(activePromotion.error)
           } else {
-            CURRENT_ACTIVE_PROMOTION = pricing.active
+            CURRENT_ACTIVE_PROMOTION = pricing?.active
               ? activePromotion.data
               : null
           }

--- a/packages/skill-lesson/path-to-purchase/product-tiers.tsx
+++ b/packages/skill-lesson/path-to-purchase/product-tiers.tsx
@@ -63,6 +63,13 @@ export const PricingTiers: React.FC<
                 purchased={purchasedProductIds.includes(product.productId)}
                 index={i}
                 couponId={couponId}
+                couponFromCode={
+                  couponFromCode &&
+                  (!couponFromCode.restrictedToProductId ||
+                    couponFromCode.restrictedToProductId === product.productId)
+                    ? couponFromCode
+                    : undefined
+                }
                 allowPurchase={allowPurchase}
                 options={options}
               />


### PR DESCRIPTION
the query param coupon code wasn't properly being passed down and the epic react grid didn't have a countdown renderer on the buy page