### PR TITLE
ci: add npm provenance to release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     name: Release
@@ -37,6 +42,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Send a Slack notification if a publish happens
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary
- adds least-privilege release workflow permissions
- grants OIDC `id-token: write` for npm provenance
- enables npm provenance for Changesets publish via `NPM_CONFIG_PROVENANCE=true`

## Verification
- parsed all workflow YAML locally with Ruby `YAML.load_file`

Keeps the existing token-based publish path for compatibility while adding provenance attestation support.