### PR TITLE
feat(epic-web): redesign contributor page

### DIFF
--- a/apps/epic-web/src/lib/contributors.server.ts
+++ b/apps/epic-web/src/lib/contributors.server.ts
@@ -1,7 +1,13 @@
 import {sanityClient} from '../utils/sanity-client'
 import groq from 'groq'
 import * as mysql from 'mysql2/promise'
+import getReadingTime from 'reading-time'
 import {ContributorResource, ContributorResourcesSchema} from './contributors'
+
+// Whole-minute reading estimate for an article body, or null when there's no
+// body (matches how /articles and /[article] surface "~ N minutes").
+const toReadingTime = (body?: string | null): number | null =>
+  body ? Math.max(1, Math.round(getReadingTime(body).minutes)) : null
 
 // Establish connection options for the course-builder database (same as articles)
 const access: mysql.ConnectionOptions = {
@@ -85,6 +91,7 @@ const getContributorCourseBuilderArticles = async (
           moduleType: null,
           image: null,
           muxPlaybackId,
+          readingTime: toReadingTime(fields.body),
         }
       }),
     )
@@ -106,6 +113,7 @@ export const getContributorResources = async (
             title,
             description,
             summary,
+            body,
             "slug": slug.current,
             "moduleType": moduleType,
             "image": coalesce(image.asset->url, image.secure_url),
@@ -113,6 +121,18 @@ export const getContributorResources = async (
     }`,
     {id},
   )
+
+  // Compute reading time from the article body, then drop the body so it never
+  // ships to the client (the schema parse below also strips it).
+  const sanityResourcesWithReadingTime = (
+    Array.isArray(sanityResources) ? sanityResources : []
+  ).map((resource: any) => {
+    const {body, ...rest} = resource
+    return {
+      ...rest,
+      readingTime: resource._type === 'article' ? toReadingTime(body) : null,
+    }
+  })
 
   let courseBuilderResources: ContributorResource[] = []
   if (userId) {
@@ -129,10 +149,7 @@ export const getContributorResources = async (
   // Merge both sources, drop duplicate slugs (an article may exist in both
   // after a migration), and keep the newest-to-oldest ordering of the page.
   const seen = new Set<string>()
-  const merged = [
-    ...(Array.isArray(sanityResources) ? sanityResources : []),
-    ...courseBuilderResources,
-  ]
+  const merged = [...sanityResourcesWithReadingTime, ...courseBuilderResources]
     .filter((resource: any) => {
       const slug = resource?.slug
       if (!slug) return true

--- a/apps/epic-web/src/lib/contributors.ts
+++ b/apps/epic-web/src/lib/contributors.ts
@@ -118,6 +118,9 @@ export const ContributorResourceSchema = z.object({
   moduleType: z.string().optional().nullable(),
   image: z.string().optional().nullable(),
   muxPlaybackId: z.string().optional().nullable(),
+  // Estimated reading time in whole minutes, computed from the article body on
+  // the server. Null for resources without a body (talks, modules, etc.).
+  readingTime: z.number().optional().nullable(),
 })
 
 export const ContributorResourcesSchema = z.array(ContributorResourceSchema)

--- a/apps/epic-web/src/templates/contributor-template.tsx
+++ b/apps/epic-web/src/templates/contributor-template.tsx
@@ -5,23 +5,210 @@ import Image from 'next/image'
 import ReactMarkdown from 'react-markdown'
 import pluralize from 'pluralize'
 import Link from 'next/link'
-import {getIcon} from 'pages/search'
 import {cn} from '@skillrecordings/ui/utils/cn'
-import {useTheme} from 'next-themes'
 import {ShieldCheckIcon} from '@heroicons/react/solid'
 import {getOgImage} from 'utils/get-og-image'
+
+// Build the canonical path for a resource, mirroring the route structure:
+// modules live under their pluralized moduleType (`/workshops/…`), articles at
+// the root (`/slug`), everything else under its pluralized type (`/talks/…`).
+const getResourcePath = (resource: ContributorResource): string => {
+  if (resource._type === 'module') {
+    return resource.moduleType
+      ? `/${pluralize(resource.moduleType)}/${resource.slug}`
+      : `/${resource.slug}`
+  }
+  if (resource._type === 'article') return `/${resource.slug}`
+  return `/${pluralize(resource._type)}/${resource.slug}`
+}
+
+const muxThumbnail = (id: string) =>
+  `https://image.mux.com/${id}/thumbnail.png?width=480&height=384&fit_mode=preserve&time=16`
+
+const ArrowIcon: React.FC<{className?: string}> = ({className}) => (
+  <svg
+    className={className}
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="5" y1="12" x2="19" y2="12" />
+    <polyline points="12 5 19 12 12 19" />
+  </svg>
+)
+
+const Badge: React.FC<{
+  children: React.ReactNode
+  variant?: 'muted' | 'free' | 'pro'
+}> = ({children, variant = 'muted'}) => (
+  <span
+    className={cn(
+      'inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide',
+      {
+        'bg-foreground/5 text-foreground/60': variant === 'muted',
+        'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400/90':
+          variant === 'free',
+        'border border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-400/90':
+          variant === 'pro',
+      },
+    )}
+  >
+    {children}
+  </span>
+)
+
+const SectionHeading: React.FC<{
+  title: string
+  count?: number
+  free?: boolean
+  pro?: boolean
+}> = ({title, count, free, pro}) => (
+  <div className="mb-6 flex flex-wrap items-center gap-3">
+    <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+    {typeof count === 'number' && (
+      <span className="rounded bg-foreground/5 px-2 py-0.5 text-sm font-medium text-foreground/55">
+        {count}
+      </span>
+    )}
+    {free && <Badge variant="free">Free</Badge>}
+    {pro && <Badge variant="pro">Pro</Badge>}
+  </div>
+)
+
+// A text-first card used for articles: bold title, description, then an
+// author + reading-time footer.
+const ArticleCard: React.FC<{
+  resource: ContributorResource
+  author: Pick<Contributor, 'name' | 'picture'>
+}> = ({resource, author}) => (
+  <li className="h-full">
+    <Link
+      href={getResourcePath(resource)}
+      className="group flex h-full flex-col rounded-lg border bg-card p-6 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md sm:p-7"
+    >
+      <h3 className="text-lg font-semibold leading-snug tracking-tight sm:text-xl">
+        {resource.title}
+      </h3>
+      {resource.description && (
+        <p className="mt-3 leading-relaxed text-foreground/60">
+          {resource.description}
+        </p>
+      )}
+      <div className="mt-auto flex flex-wrap items-center gap-x-8 gap-y-4 pt-8">
+        <div className="flex items-center gap-3">
+          {author.picture?.url && (
+            <Image
+              src={author.picture.url}
+              alt={author.picture.alt || author.name}
+              width={44}
+              height={44}
+              className="h-11 w-11 rounded-full bg-foreground/5 object-cover"
+            />
+          )}
+          <div className="text-sm leading-tight">
+            <div className="font-medium">Written by</div>
+            <div className="text-foreground/60">{author.name}</div>
+          </div>
+        </div>
+        {resource.readingTime ? (
+          <div className="text-sm leading-tight">
+            <div className="font-medium">Time to read</div>
+            <div className="text-foreground/60">
+              ~ {resource.readingTime}{' '}
+              {resource.readingTime === 1 ? 'minute' : 'minutes'}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Link>
+  </li>
+)
+
+// A media card used for talks, tips, and modules: thumbnail + title + CTA.
+const MediaCard: React.FC<{
+  resource: ContributorResource
+  cta: string
+}> = ({resource, cta}) => {
+  const thumbnail = resource.image
+    ? resource.image
+    : resource.muxPlaybackId
+    ? muxThumbnail(resource.muxPlaybackId)
+    : null
+  const isVideo = !resource.image && Boolean(resource.muxPlaybackId)
+
+  return (
+    <li className="h-full">
+      <Link
+        href={getResourcePath(resource)}
+        className="group flex h-full flex-col overflow-hidden rounded-lg border bg-card shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-md"
+      >
+        <div className="relative flex aspect-[16/10] items-center justify-center overflow-hidden border-b bg-foreground/5">
+          {thumbnail && (
+            <Image
+              src={thumbnail}
+              alt={resource.title}
+              fill
+              className={cn(isVideo ? 'object-cover' : 'object-contain p-6')}
+            />
+          )}
+          {isVideo && (
+            <span className="absolute grid h-11 w-11 place-items-center rounded-full bg-white/85 shadow-md">
+              <svg viewBox="0 0 24 24" className="ml-0.5 h-4 w-4 fill-black/80">
+                <polygon points="6 4 20 12 6 20 6 4" />
+              </svg>
+            </span>
+          )}
+        </div>
+        <div className="flex flex-1 flex-col p-5">
+          <h3 className="text-lg font-semibold leading-snug">
+            {resource.title}
+          </h3>
+          {resource.description && (
+            <p className="mt-2 line-clamp-2 text-sm text-foreground/60">
+              {resource.description}
+            </p>
+          )}
+          <span className="mt-auto inline-flex items-center gap-1.5 pt-4 text-sm font-medium text-foreground/80">
+            {cta}
+            <ArrowIcon className="transition-transform duration-200 group-hover:translate-x-1" />
+          </span>
+        </div>
+      </Link>
+    </li>
+  )
+}
 
 const ContributorTemplate: React.FC<{
   contributor: Contributor
   resources: ContributorResource[]
 }> = ({contributor, resources}) => {
-  const {theme} = useTheme()
   const isKent = contributor.slug === 'kent-c-dodds'
   const ogImage = getOgImage({
     title: contributor.name,
     image: contributor?.picture?.url,
     path: '/contributor',
   })
+
+  const safeResources = resources || []
+  // Free resources (articles, talks/tips, tutorials) lead the page; paid
+  // workshops get their own section at the end.
+  const articles = safeResources.filter((r) => r._type === 'article')
+  const talks = safeResources.filter((r) => r._type === 'talk')
+  const tips = safeResources.filter((r) => r._type === 'tip')
+  const freeMedia = [...talks, ...tips]
+  const tutorials = safeResources.filter(
+    (r) => r._type === 'module' && r.moduleType === 'tutorial',
+  )
+  const workshops = safeResources.filter(
+    (r) => r._type === 'module' && r.moduleType === 'workshop',
+  )
+
   return (
     <Layout
       meta={{
@@ -30,117 +217,162 @@ const ContributorTemplate: React.FC<{
         ogImage,
       }}
     >
-      <header className="mx-auto w-full max-w-screen-lg px-5 py-8"></header>
-      <main className="relative mx-auto flex w-full max-w-screen-lg grid-cols-12 flex-col gap-5 pb-0 md:grid md:px-5 md:pb-16 lg:px-0">
-        <aside className="relative col-span-3 -mt-5 px-5 md:px-0">
-          <div className="sticky top-20 flex flex-col">
-            {contributor.picture?.url && (
-              <div className="relative h-40 w-40">
-                <Image
-                  fill
-                  src={contributor.picture.url}
-                  alt={contributor.picture?.alt}
-                  className="rounded-full bg-foreground/5 object-cover"
-                  priority
-                />
-                {isKent ? (
-                  <div className="absolute bottom-0 right-0 flex items-center justify-center rounded-full border bg-background p-2">
-                    <ShieldCheckIcon className="w-5 text-indigo-500 dark:text-amber-300" />
-                  </div>
-                ) : null}
-              </div>
-            )}
-            <h1 className="pt-3 text-xl font-bold">{contributor.name}</h1>
+      {/* ——— Author hero ——— */}
+      <header className="border-b">
+        <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center gap-8 px-5 py-14 text-center md:flex-row md:items-center md:text-left">
+          {contributor.picture?.url && (
+            <div className="relative h-32 w-32 flex-shrink-0 sm:h-36 sm:w-36">
+              <Image
+                fill
+                src={contributor.picture.url}
+                alt={contributor.picture?.alt || contributor.name}
+                className="rounded-full bg-foreground/5 object-cover ring-2 ring-background"
+                priority
+              />
+              {isKent && (
+                <div className="absolute bottom-1 right-1 flex items-center justify-center rounded-full border bg-background p-1.5">
+                  <ShieldCheckIcon className="w-5 text-indigo-500 dark:text-amber-300" />
+                </div>
+              )}
+            </div>
+          )}
+          <div className="flex flex-col items-center md:items-start">
+            <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+              {contributor.name}
+            </h1>
             {contributor.bio && (
-              <ReactMarkdown className="prose prose-sm w-full overflow-y-auto pt-2 dark:prose-invert prose-p:opacity-80">
+              <ReactMarkdown className="prose prose-sm mt-3 max-w-xl dark:prose-invert prose-p:opacity-80 prose-a:text-primary">
                 {contributor.bio}
               </ReactMarkdown>
             )}
-            <hr className="mt-5 flex h-px w-full bg-border md:hidden" />
+            {contributor.links && contributor.links.length > 0 && (
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-2 md:justify-start">
+                {contributor.links.map(
+                  (link) =>
+                    link.url && (
+                      <a
+                        key={link.url}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rounded-md border bg-card px-3 py-1.5 text-sm font-medium text-foreground/70 transition hover:border-foreground/30 hover:text-foreground"
+                      >
+                        {link.label || link.url.replace(/^https?:\/\//, '')}
+                      </a>
+                    ),
+                )}
+              </div>
+            )}
           </div>
-        </aside>
-        <article className="col-span-9 md:pl-10">
-          <h2 className="px-5 text-xl font-bold md:px-0">Resources</h2>
-          <p className="px-5 pt-2 opacity-75 md:px-0">From newest to oldest.</p>
-          <ul className="mt-5 flex flex-col md:mt-8">
-            {resources &&
-              resources.map((resource, i) => {
-                const resourceType =
-                  resource._type === 'module'
-                    ? resource.moduleType || resource._type
-                    : resource._type
-                const path =
-                  resource._type === 'module'
-                    ? resource.moduleType && pluralize(resource.moduleType)
-                    : resource._type === 'article'
-                    ? null
-                    : pluralize(resource._type)
+        </div>
+      </header>
 
-                return (
-                  <li key={resource._id}>
-                    <Link
-                      className={cn(
-                        'group relative flex items-center gap-2 p-3.5 sm:p-5 md:rounded ',
-                        {
-                          'bg-card': i % 2 === 0,
-                        },
-                      )}
-                      href={
-                        path ? `/${path}/${resource.slug}` : `/${resource.slug}`
-                      }
-                    >
-                      <div className="flex flex-shrink-0">
-                        {/* <div className="absolute bottom-1 left-1 hidden items-center gap-1.5 rounded-sm border bg-background p-1 lg:flex">
-                          <div className="relative z-10 opacity-100 [&_svg]:h-4 [&_svg]:w-4">
-                            {getIcon(resourceType, true, theme)}
-                          </div>
-                          <span className="absolute -left-1 z-0 rounded-r border-y border-r bg-background px-1 py-0.5 pl-2 text-sm uppercase opacity-0 transition duration-200 group-hover:translate-x-5 group-hover:opacity-100">
-                            <span className="font-semibold opacity-0 transition duration-300 group-hover:opacity-100">
-                              {resourceType}
-                            </span>
-                          </span>
-                        </div> */}
-                        {resource.image && (
-                          <Image
-                            src={resource.image}
-                            alt={resource.title}
-                            width={200 / 1.5}
-                            height={200 / 1.5}
-                            className={cn(
-                              'mr-2 max-w-[80px] rounded-sm sm:max-w-full',
-                              {
-                                'aspect-square object-cover':
-                                  resourceType === 'article',
-                              },
-                            )}
-                          />
-                        )}
-                        {resource.muxPlaybackId && (
-                          <Image
-                            src={`https://image.mux.com/${resource.muxPlaybackId}/thumbnail.png?width=480&height=384&fit_mode=preserve&time=16`}
-                            alt={resource.title}
-                            width={200 / 1.5}
-                            height={113 / 1.5}
-                            aria-hidden="true"
-                            className="mr-2 aspect-square max-w-[80px] rounded-sm object-cover sm:max-w-full"
-                          />
-                        )}
-                      </div>
-                      <div>
-                        <h3 className="w-full text-base font-semibold md:text-lg">
-                          {resource?.title}
-                        </h3>
-                        <p className="flex text-sm capitalize opacity-75 ">
-                          {/* {getIcon(resourceType, true, theme)} */}
-                          {resourceType}
-                        </p>
-                      </div>
-                    </Link>
-                  </li>
-                )
-              })}
-          </ul>
-        </article>
+      <main className="mx-auto w-full max-w-screen-lg px-5 pb-20">
+        {/* ——— Intro / counts ——— */}
+        <div className="mt-10 flex flex-col gap-5 rounded-lg border bg-card p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+          <p className="max-w-xl text-foreground/70">
+            Start with the <strong className="text-foreground">free</strong>{' '}
+            articles, talks, and tutorials. The Pro workshops at the bottom go
+            deeper for the complete, hands-on path.
+          </p>
+          <div className="flex gap-8">
+            {[
+              {n: articles.length, l: 'Articles'},
+              {n: freeMedia.length, l: 'Talks & Tips'},
+              {n: tutorials.length, l: 'Tutorials'},
+              {n: workshops.length, l: 'Workshops'},
+            ]
+              .filter((s) => s.n > 0)
+              .map((s) => (
+                <div key={s.l} className="text-center">
+                  <div className="text-xl font-semibold tracking-tight">
+                    {s.n}
+                  </div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-foreground/40">
+                    {s.l}
+                  </div>
+                </div>
+              ))}
+          </div>
+        </div>
+
+        {/* ——— Articles (free, 3-up grid) ——— */}
+        {articles.length > 0 && (
+          <section className="pt-14">
+            <SectionHeading title="Articles" count={articles.length} free />
+            <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {articles.map((resource) => (
+                <ArticleCard
+                  key={resource._id}
+                  resource={resource}
+                  author={contributor}
+                />
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* ——— Talks & Tips (free) ——— */}
+        {freeMedia.length > 0 && (
+          <section className="pt-14">
+            <SectionHeading
+              title={
+                talks.length && tips.length
+                  ? 'Talks & Tips'
+                  : talks.length
+                  ? 'Talks'
+                  : 'Tips'
+              }
+              count={freeMedia.length}
+              free
+            />
+            <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {freeMedia.map((resource) => (
+                <MediaCard
+                  key={resource._id}
+                  resource={resource}
+                  cta={resource._type === 'talk' ? 'Watch' : 'Watch tip'}
+                />
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* ——— Tutorials (free) ——— */}
+        {tutorials.length > 0 && (
+          <section className="pt-14">
+            <SectionHeading title="Tutorials" count={tutorials.length} free />
+            <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {tutorials.map((resource) => (
+                <MediaCard
+                  key={resource._id}
+                  resource={resource}
+                  cta="Start tutorial"
+                />
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* ——— Pro workshops (paid) ——— */}
+        {workshops.length > 0 && (
+          <section className="mt-16 border-t border-dashed pt-12">
+            <SectionHeading
+              title="Pro Workshops"
+              count={workshops.length}
+              pro
+            />
+            <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {workshops.map((resource) => (
+                <MediaCard
+                  key={resource._id}
+                  resource={resource}
+                  cta="Start workshop"
+                />
+              ))}
+            </ul>
+          </section>
+        )}
       </main>
     </Layout>
   )


### PR DESCRIPTION
## Summary

Reworks the Epic Web contributor page (`/contributors/[slug]`) from a flat, newest-to-oldest list into a shareable, resource-focused index that leads with free content and groups paid workshops on their own.

### Layout
- **Author hero** at the top — avatar, name, bio, and links.
- **Articles** in a 3-up grid, each card showing the title, description, author (avatar + "Written by"), and **per-article reading time**.
- **Talks & Tips** — free media cards with video thumbnails.
- **Tutorials** — free modules, their own section.
- **Pro Workshops** — paid modules in a dedicated section at the end, separated from the free resources.

Sections derive generically from each resource's `_type` / `moduleType`, so the layout adapts per contributor (e.g. Tutorials only appear when the instructor has them — verified empty for Artem, populated for Kent).

### Reading time
Computes per-article reading time server-side from the article body (both Sanity and Course Builder sources) via the `reading-time` package — mirroring how `/articles` surfaces it — and strips the body before it ships to the client.

## Files
- `templates/contributor-template.tsx` — redesigned layout/components
- `lib/contributors.ts` — `readingTime` added to the resource schema
- `lib/contributors.server.ts` — compute reading time for both data sources

## Testing
- `tsc --noEmit` passes.
- Verified rendering on the local dev server for both a workshops-only contributor (Artem Zakharchenko) and one with tutorials (Kent C. Dodds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)