### PR TITLE
fix(epic-web): crop testimonial avatars to prevent distortion

### DIFF
--- a/apps/epic-web/src/pages/testing/index.tsx
+++ b/apps/epic-web/src/pages/testing/index.tsx
@@ -222,13 +222,15 @@ const Article: React.FC<{
                 <div className="mt-5 flex w-full items-center justify-between gap-1.5 text-base">
                   <div className="flex items-center gap-2">
                     {author.image ? (
-                      <Image
-                        src={author.image}
-                        alt={author.name}
-                        width={40}
-                        height={40}
-                        className="!my-0 rounded-full"
-                      />
+                      <div className="!my-0 h-10 w-10 shrink-0 overflow-hidden rounded-full">
+                        <Image
+                          src={author.image}
+                          alt={author.name}
+                          width={40}
+                          height={40}
+                          className="!my-0 h-full w-full object-cover"
+                        />
+                      </div>
                     ) : (
                       <span className="opacity-75">—</span>
                     )}


### PR DESCRIPTION
## Problem

On the Epic Web `/testing` page, the "What Other Developers are Saying" section rendered avatars with a Next.js `<Image>` set to `width={40} height={40}` directly. Non-square source images were squished into the square box — most visibly **Matija Marohnić's** avatar (source is 40×50), which appeared distorted/shrunk.

## Fix

Wrap the avatar in a fixed-size `h-10 w-10 overflow-hidden rounded-full` container and render the image with `object-cover` so oversized images are cropped to the circle instead of distorted. Added `shrink-0` so the avatar isn't compressed by the surrounding flex row.

```jsx
<div className="!my-0 h-10 w-10 shrink-0 overflow-hidden rounded-full">
  <Image src={author.image} alt={author.name} width={40} height={40}
    className="!my-0 h-full w-full object-cover" />
</div>
```

## Verification

Loaded `http://localhost:3021/testing` locally — both Robin Rump's and Matija Marohnić's avatars now render as clean, undistorted circles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)